### PR TITLE
Fix incorrect behavior of matrix::fill_random() and Hgemm

### DIFF
--- a/cutlass/gemm/thread_accumulator.h
+++ b/cutlass/gemm/thread_accumulator.h
@@ -453,12 +453,17 @@ public:
 
         // Simply traverse the accumulator tile in column-major order
         #pragma unroll
-        for (int x = 0; x < ThreadTilePairsX; ++x)
+        for (int x = 0; x < ThreadTilePairsX; x += 2)
         {
             #pragma unroll
             for (int y = 0; y < ThreadTilePairsY; ++y)
             {
                 mad_xy_even(pairs_tile_a, pairs_tile_b, x, y);
+            }
+            #pragma unroll
+            for (int y = 0; y < ThreadTilePairsY; ++y)
+            {
+                mad_xy_odd(pairs_tile_a, pairs_tile_b, x + 1, y);
             }
         }
     }

--- a/cutlass_test/util/matrix.h
+++ b/cutlass_test/util/matrix.h
@@ -97,7 +97,7 @@ public:
         _d_data(NULL),
         _device_id(0)
     {
-        _h_data.resize(_m * _n, 0);
+        _h_data.resize(_m * _n, value_t{});
         CUDA_PERROR_EXIT(cudaMalloc((void ** )&_d_data, sizeof(value_t) * _m * _n));
         CUDA_PERROR_EXIT(cudaGetDevice(&_device_id));
     }
@@ -277,7 +277,7 @@ public:
         {
             for (int i = 0; i < _m; i++)
             {
-                _h_data[i + j * _m] = (value_t) generator();
+                _h_data[i + j * _m] = (host_value_t) generator();
             }
         }
     }


### PR DESCRIPTION
1. Correct type conversion for matrix of FP16

Use `host_value_t` instead of `value_t` as conversion type in `matrix::fill_random()`. Otherwise, each element in `_h_data` will be same value and the value is unpredictable when `value_t` is `__half` type which causes verfication process of GEMM is malfunction.

2. Correct multiply and accumulation behavior of hgemm

Only data of the even rows of matrix B is read because only `thread_accumulator::mad_xy_even()` is called in `thread_accumulator::multiply_accumulate()` which causes operand of `HFMA2` is incorrect.

For example:
```
__half matrix_a[2][2] = {{3, 5},
                         {6, 2}};
__half matrix_b[2][2] = {{3, 6},
                         {7, 5}};
```
The result of hgemm_nn should be
```
__half matrix_c[2][2] = {{45, 27},
                         {51, 45}};
```
However, original cutlass' result is
```
__half matrix_c[2][2] = {{45, 27},
                         {45, 27}};
```
Therefore, also call `thread_accumulator::mad_xy_odd()` in `thread_accumulator::multiply_accumulate()` to read data of odd rows.