### PR TITLE
update tools/library/CMakeLists to require python 3.6 according to #70

### DIFF
--- a/tools/library/CMakeLists.txt
+++ b/tools/library/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 include(GNUInstallDirs)
 
-find_package(Python3 3.5 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 3.6 COMPONENTS Interpreter REQUIRED)
 
 add_library(cutlass_library_includes INTERFACE)
 add_library(nvidia::cutlass::library::includes ALIAS cutlass_library_includes)


### PR DESCRIPTION
#70 only updates the documentation. This commit reflects this bump in python version to the CMake configuration as well.