### PR TITLE
Fixed FLOPS count for CGEMM

### DIFF
--- a/examples/10_planar_complex/planar_complex.cu
+++ b/examples/10_planar_complex/planar_complex.cu
@@ -186,12 +186,10 @@ struct Options {
 
   /// Compute performance in GFLOP/s
   double gflops(double runtime_s) const {
+    // Number of real-valued multiply-adds. Each complex multiply has 4 real multiplies and 2 real adds.
+    int64_t ops = (8 * (problem_size.m() * problem_size.n() * problem_size.k()) - 2.0 * (problem_size.m() * problem_size.n())) * batch_count;
 
-    // Number of real-valued multiply-adds 
-    int64_t fmas = problem_size.product() * batch_count * 4;
-    
-    // Two flops per multiply-add
-    return 2.0 * double(fmas) / double(1.0e9) / runtime_s;
+    return double(ops) / double(1.0e9) / runtime_s;
   }
 };
 


### PR DESCRIPTION
Complex matrix multiplies require 8mnk - 2mn operations, which is slightly different from the amount in this file. The 8mnk is from the element-wise multiplies, and the 2mn is from summing the products. The formula can be derived by:

6mnk+ 2mn(k-1) = 8mnk - 2mn
