### PR TITLE
Honor `CMAKE_CXX_COMPILER` as CUDA host compiler.

### DIFF
--- a/CUDA.cmake
+++ b/CUDA.cmake
@@ -37,6 +37,7 @@ endif()
 
 if(CUTLASS_NATIVE_CUDA)
 
+  set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
   enable_language(CUDA)
 
   if(NOT CUDA_VERSION)


### PR DESCRIPTION
If you run `CC=gcc-8 CXX=g++-8 cmake ../`, as of cmake 3.13.4, it will ignore these environment variables for cuda host compiler.  Setting the `CMAKE_CUDA_HOST_COMPILER` builtin variable fixes the issue.