### PR TITLE
Clean up C++ warnings

### DIFF
--- a/include/cutlass/layout/matrix.h
+++ b/include/cutlass/layout/matrix.h
@@ -529,7 +529,7 @@ public:
 
   /// Inverse of layout function, mapping linear offset to logical coordinate
   CUTLASS_HOST_DEVICE
-  MatrixCoord inverse(LongIndex offset) const {
+  MatrixCoord inverse(LongIndex /*offset*/) const {
     // TODO
     return MatrixCoord(0, 0);
   }

--- a/include/cutlass/layout/vector.h
+++ b/include/cutlass/layout/vector.h
@@ -71,7 +71,7 @@ public:
 
   /// Helper returns a layout to a tightly packed tensor
   CUTLASS_HOST_DEVICE
-  static PackedVectorLayout packed(TensorCoord const &size) {
+  static PackedVectorLayout packed(TensorCoord const &/*size*/) {
     return PackedVectorLayout();
   }
 

--- a/include/cutlass/reduction/device/reduce_split_k.h
+++ b/include/cutlass/reduction/device/reduce_split_k.h
@@ -123,13 +123,13 @@ public:
   ReduceSplitK() { }
 
   /// Determines whether the ReduceSplitK can execute the given problem.
-  static Status can_implement(Arguments const &args) {
+  static Status can_implement(Arguments const & /*args*/) {
 
     return Status::kSuccess;
   }
 
   /// Gets the workspace size
-  static size_t get_workspace_size(Arguments const &args) {
+  static size_t get_workspace_size(Arguments const & /*args*/) {
     // needs no additional workspace
     return 0;
   }
@@ -137,8 +137,8 @@ public:
   /// Initializes Reduction state from arguments.
   Status initialize(
     Arguments const &args, 
-    void *workspace = nullptr, 
-    cudaStream_t stream = nullptr) {
+    void */*workspace*/ = nullptr, 
+    cudaStream_t /*stream*/ = nullptr) {
     
     // initialize the params structure from the arguments
     params_ = typename ReductionKernel::Params(
@@ -157,7 +157,7 @@ public:
    }
 
   /// Initializes Reduction kernel state from arguments.
-  Status update(Arguments const &args, void *workspace = nullptr) {
+  Status update(Arguments const &args, void */*workspace*/ = nullptr) {
 
     // update the params structure from the arguments
     params_.workspace.reset(args.workspace.non_const_ref().data());

--- a/tools/library/include/cutlass/library/library.h
+++ b/tools/library/include/cutlass/library/library.h
@@ -378,7 +378,6 @@ struct OperationDescription {
   //
   OperationDescription(
     char const * name = "unknown",
-    Provider Provider = Provider::kInvalid,
     OperationKind kind = OperationKind::kInvalid, 
     TileDescription const & tile_description = TileDescription()
   ):

--- a/tools/library/src/gemm_operation.h
+++ b/tools/library/src/gemm_operation.h
@@ -639,7 +639,7 @@ public:
   
   /// Gets the host-side workspace
   virtual uint64_t get_host_workspace_size(
-    void const *configuration) const {
+    void const */*configuration*/) const {
 
     return sizeof(Operator);
   }

--- a/tools/library/src/reduction/reduction_operation.h
+++ b/tools/library/src/reduction/reduction_operation.h
@@ -173,7 +173,7 @@ public:
 
   /// Gets the host-side workspace
   virtual uint64_t get_host_workspace_size(
-    void const *configuration) const {
+    void const */*configuration*/) const {
 
     return sizeof(Operator);
   }

--- a/tools/profiler/src/gemm_operation_profiler.cu
+++ b/tools/profiler/src/gemm_operation_profiler.cu
@@ -303,8 +303,8 @@ void GemmOperationProfiler::GemmProblem::initialize_result(
 /// Extracts the problem dimensions
 Status GemmOperationProfiler::initialize_configuration(
   Options const &options,  
-  PerformanceReport &report,
-  DeviceContext &device_context,
+  PerformanceReport &/*report*/,
+  DeviceContext &/*device_context*/,
   library::Operation const *operation,
   ProblemSpace const &problem_space,
   ProblemSpace::Problem const &problem) {
@@ -354,7 +354,7 @@ Status GemmOperationProfiler::initialize_configuration(
 /// Initializes the performance result
 void GemmOperationProfiler::initialize_result_(
   PerformanceResult &result,
-  Options const &options,  
+  Options const &/*options*/,  
   library::GemmDescription const &operation_desc,
   ProblemSpace const &problem_space) {
 
@@ -376,11 +376,11 @@ void GemmOperationProfiler::initialize_result_(
 /// Initializes workspace
 Status GemmOperationProfiler::initialize_workspace(
   Options const &options,  
-  PerformanceReport &report,
+  PerformanceReport &/*report*/,
   DeviceContext &device_context,
   library::Operation const *operation,
-  ProblemSpace const &problem_space,
-  ProblemSpace::Problem const &problem) {
+  ProblemSpace const &/*problem_space*/,
+  ProblemSpace::Problem const &/*problem*/) {
   
   library::GemmDescription const &operation_desc = 
     static_cast<library::GemmDescription const &>(operation->description());
@@ -606,11 +606,11 @@ bool GemmOperationProfiler::verify_cutlass(
 /// Verifies CUTLASS against references
 bool GemmOperationProfiler::verify_with_cublas_(
   Options const &options,  
-  PerformanceReport &report,
+  PerformanceReport &/*report*/,
   DeviceContext &device_context,
   library::Operation const *operation,
-  ProblemSpace const &problem_space,
-  ProblemSpace::Problem const &problem) {
+  ProblemSpace const &/*problem_space*/,
+  ProblemSpace::Problem const &/*problem*/) {
 
 
 #if CUTLASS_ENABLE_CUBLAS
@@ -727,11 +727,11 @@ bool GemmOperationProfiler::verify_with_cublas_(
 /// Verifies CUTLASS against host and device references
 bool GemmOperationProfiler::verify_with_reference_(
   Options const &options,  
-  PerformanceReport &report,
+  PerformanceReport &/*report*/,
   DeviceContext &device_context,
   library::Operation const *operation,
-  ProblemSpace const &problem_space,
-  ProblemSpace::Problem const &problem) {
+  ProblemSpace const &/*problem_space*/,
+  ProblemSpace::Problem const &/*problem*/) {
 
   library::GemmDescription const &gemm_desc = 
     static_cast<library::GemmDescription const &>(operation->description());
@@ -871,11 +871,11 @@ bool GemmOperationProfiler::verify_with_reference_(
 /// Measures performance results
 bool GemmOperationProfiler::profile(
   Options const &options,  
-  PerformanceReport &report,
-  DeviceContext &device_context,
+  PerformanceReport &/*report*/,
+  DeviceContext &/*device_context*/,
   library::Operation const *operation,
-  ProblemSpace const &problem_space,
-  ProblemSpace::Problem const &problem) {
+  ProblemSpace const &/*problem_space*/,
+  ProblemSpace::Problem const &/*problem*/) {
 
   if (options.profiling.provider_enabled(library::Provider::kCUTLASS)) {
 

--- a/tools/profiler/src/problem_space.cpp
+++ b/tools/profiler/src/problem_space.cpp
@@ -1048,7 +1048,8 @@ bool arg_as_scalar(
 
   if (value_ptr->not_null) {
     if (value_ptr->argument->description->type == ArgumentTypeID::kInteger) {
-      int64_t int_value = static_cast<IntegerArgument::IntegerValue const *>(value_ptr)->value;
+      // Unused for now
+      // int64_t int_value = static_cast<IntegerArgument::IntegerValue const *>(value_ptr)->value;
       
       // TODO - convert int64_t => destination type
     }


### PR DESCRIPTION
Happy new year!

As per the discussions on #157, this PR is meant to clean some warnings before effectively enforcing `-Wall -Werror` again.

Most of the unused parameters I've left as unnamed parameters since I'm not sure if I should mess with the current API in other places (and some of those are just virtuals).

I'm also not sure if I should make a single, huge PR with all the fixes, or break it up in some way.


As a side note, there are tons of warnings related to SM-specific code, such as:
```
../include/cutlass/arch/mma_sparse_sm80.h:1411:1: warning: unused parameter ‘d’ [-Wunused-parameter]
 1410 |   void operator()(
      |            ~~~~~~~
 1411 |     FragmentC &d,
      | ^
../include/cutlass/arch/mma_sparse_sm80.h:1412:1: warning: unused parameter ‘a’ [-Wunused-parameter]
 1411 |     FragmentC &d,
      |     ~~~~~~~~~~~~~
 1412 |     FragmentA const &a,
      | ^
../include/cutlass/arch/mma_sparse_sm80.h:1413:1: warning: unused parameter ‘b’ [-Wunused-parameter]
 1412 |     FragmentA const &a,
      |     ~~~~~~~~~~~~~~~~~~~
 1413 |     FragmentB const &b,
      | ^
../include/cutlass/arch/mma_sparse_sm80.h:1414:1: warning: unused parameter ‘c’ [-Wunused-parameter]
 1413 |     FragmentB const &b,
      |     ~~~~~~~~~~~~~~~~~~~
 1414 |     FragmentC const &c,
      | ^
../include/cutlass/arch/mma_sparse_sm80.h:1415:1: warning: unused parameter ‘E’ [-Wunused-parameter]
 1414 |     FragmentC const &c,
      |     ~~~~~~~~~~~~~~~~~~~
 1415 |     uint32_t const &E,
      | ^
../include/cutlass/arch/mma_sparse_sm80.h:1416:1: warning: unused parameter ‘id2’ [-Wunused-parameter]
 1415 |     uint32_t const &E,
      |     ~~~~~~~~~~~~~~~~~~
 1416 |     int const id2
      | ^  
```

and
```
../include/cutlass/arch/mma_sm75.h:104:1: warning: unused parameter ‘d’ [-Wunused-parameter]
  103 |   void operator()(
      |            ~~~~~~~
  104 |     FragmentC &d,
      | ^
../include/cutlass/arch/mma_sm75.h:105:1: warning: unused parameter ‘a’ [-Wunused-parameter]
  104 |     FragmentC &d,
      |     ~~~~~~~~~~~~~
  105 |     FragmentA const &a,
      | ^
../include/cutlass/arch/mma_sm75.h:106:1: warning: unused parameter ‘b’ [-Wunused-parameter]
  105 |     FragmentA const &a,
      |     ~~~~~~~~~~~~~~~~~~~
  106 |     FragmentB const &b,
      | ^
../include/cutlass/arch/mma_sm75.h:107:1: warning: unused parameter ‘c’ [-Wunused-parameter]
  106 |     FragmentB const &b,
      |     ~~~~~~~~~~~~~~~~~~~
  107 |     FragmentC const &c
      | ^
```

I'm not really sure how I should tackle those, any opinions are welcome.

I'll leave this PR as a draft for now while we discuss any changes and add more clean-up commits.