### PR TITLE
Allow mma instructions with clang.

### DIFF
--- a/include/cutlass/arch/mma_sm70.h
+++ b/include/cutlass/arch/mma_sm70.h
@@ -37,13 +37,13 @@
 #include "cutlass/layout/matrix.h"
 #include "cutlass/numeric_types.h"
 
-#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 1)))
+#if ((defined(__clang__) && defined(__CUDA__) && CUDA_VERSION >= 10011) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 1)))
 #define CUTLASS_ARCH_MMA_SM70_SUPPORTED
 #endif
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700))
 
-#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 &&__CUDACC_VER_MINOR__ >= 1)))
+#if ((defined(__clang__) && defined(__CUDA__) && CUDA_VERSION >= 10011) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 &&__CUDACC_VER_MINOR__ >= 1)))
 #define CUTLASS_ARCH_MMA_SM70_ENABLED
 #endif
 

--- a/include/cutlass/arch/mma_sm70.h
+++ b/include/cutlass/arch/mma_sm70.h
@@ -37,13 +37,13 @@
 #include "cutlass/layout/matrix.h"
 #include "cutlass/numeric_types.h"
 
-#if ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 1))
+#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 1)))
 #define CUTLASS_ARCH_MMA_SM70_SUPPORTED
 #endif
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700))
 
-#if ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 &&__CUDACC_VER_MINOR__ >= 1))
+#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 &&__CUDACC_VER_MINOR__ >= 1)))
 #define CUTLASS_ARCH_MMA_SM70_ENABLED
 #endif
 

--- a/include/cutlass/arch/mma_sm75.h
+++ b/include/cutlass/arch/mma_sm75.h
@@ -49,7 +49,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2)))
+#if ((defined(__clang__) && defined(__CUDA__) && CUDA_VERSION >= 10011) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2)))
 
 #define CUTLASS_ARCH_MMA_SM75_SUPPORTED 1
 

--- a/include/cutlass/arch/mma_sm75.h
+++ b/include/cutlass/arch/mma_sm75.h
@@ -49,7 +49,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2))
+#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2)))
 
 #define CUTLASS_ARCH_MMA_SM75_SUPPORTED 1
 

--- a/include/cutlass/arch/mma_sm80.h
+++ b/include/cutlass/arch/mma_sm80.h
@@ -40,7 +40,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0)))
+#if ((defined(__clang__) && defined(__CUDA__) && CUDA_VERSION >= 10011) || ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0)))
 
 #define CUTLASS_ARCH_MMA_SM80_SUPPORTED 1
 

--- a/include/cutlass/arch/mma_sm80.h
+++ b/include/cutlass/arch/mma_sm80.h
@@ -40,7 +40,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0))
+#if (defined(__clang__) || ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0)))
 
 #define CUTLASS_ARCH_MMA_SM80_SUPPORTED 1
 


### PR DESCRIPTION
Enable the inline PTX when using clang.