### PR TITLE
The kAdvance should be always 1 for column-A and Row-B

### DIFF
--- a/include/cutlass/transform/threadblock/regular_tile_iterator_pitch_linear.h
+++ b/include/cutlass/transform/threadblock/regular_tile_iterator_pitch_linear.h
@@ -276,7 +276,7 @@ public:
     layout::PitchLinearShape<Shape::kColumn, Shape::kRow>,
     Element,
     layout::PitchLinear,
-    (kAdvanceRank == 0 ? 1 : 0),
+    1,
     ThreadMap,
     kAlignment
   >;
@@ -398,7 +398,7 @@ public:
     layout::PitchLinearShape<Shape::kRow, Shape::kColumn>,
     Element,
     layout::PitchLinear,
-    (kAdvanceRank == 0 ? 0 : 1),
+    1,
     ThreadMap
   >;
 


### PR DESCRIPTION
Whether A/B is col-major or row-major, the expected layout in shared mem is A:col-major, B: row-major. Both te advanceRank should be 1.
Signed-off-by: Jie Han <15202116112@163.com>