### PR TITLE
Fix for issue #211

### DIFF
--- a/include/cutlass/conv/device/implicit_gemm_convolution.h
+++ b/include/cutlass/conv/device/implicit_gemm_convolution.h
@@ -74,7 +74,8 @@ public:
 
   static int const kWarpCount = 
     (ThreadblockShape::kM / WarpShape::kM) * 
-    (ThreadblockShape::kN / WarpShape::kN);
+    (ThreadblockShape::kN / WarpShape::kN) *
+    (ThreadblockShape::kK / WarpShape::kK);
 
   /// Argument structure
   using Arguments = typename ImplicitGemmKernel::Arguments;

--- a/tools/library/scripts/generator.py
+++ b/tools/library/scripts/generator.py
@@ -701,6 +701,7 @@ def GenerateSM75_TensorOp_1688(manifest, args):
       TileDescription([ 64, 128, 32], 2, [2, 2, 1], math_inst, min_cc, max_cc),
       TileDescription([128,  64, 32], 2, [2, 2, 1], math_inst, min_cc, max_cc),
       TileDescription([ 64,  64, 32], 2, [2, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([ 64, 128, 64], 2, [1, 2, 2], math_inst, min_cc, max_cc),
     ]
 
     data_type = [


### PR DESCRIPTION
- Add a sliced-K tile size kernel instance to the library for Turing 1688 TensorOp
- Fix num warps calculations in implicit gemm header to account for slice-K