### PR TITLE
Bugfix: typo, make reduction device cases passed

### DIFF
--- a/include/cutlass/reduction/device/tensor_reduce.h
+++ b/include/cutlass/reduction/device/tensor_reduce.h
@@ -170,7 +170,7 @@ struct TensorReduction {
     cudaStream_t stream = nullptr) {
 
     int64_t src_stride[3];
-    int64_t dst_stride[2];
+    int64_t dst_stride[3];
 
     switch (reduction_index) {
     case 0:


### PR DESCRIPTION
With this patch, reduction/device level cases could all pass on environment of V100 w/ CUDA-10.0.
Below shows the reduction/device test cases status comparison w/o and w/ this patch.
Before:  
```
Note: Google Test filter = -SM75*:SM80*
[==========] Running 26 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 26 tests from Reduction_TensorReduce
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_f32x8_f16x8
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_f32x8_f16x8 (84738 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_f32x2_f16x2
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_f32x2_f16x2 (20963 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_f32x1_f16x1
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_f32x1_f16x1 (10443 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_s32x4
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_s32x4 (32269 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_cf32
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_cf32 (12417 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_maximum_w_cf32
[       OK ] Reduction_TensorReduce.nhwc_maximum_w_cf32 (7817 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_minimum_w_cf32
[       OK ] Reduction_TensorReduce.nhwc_minimum_w_cf32 (7819 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_XOR_w_u32
[       OK ] Reduction_TensorReduce.nhwc_XOR_w_u32 (7823 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_AND_w_s32
[       OK ] Reduction_TensorReduce.nhwc_AND_w_s32 (7816 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_OR_w_u32
[       OK ] Reduction_TensorReduce.nhwc_OR_w_u32 (7816 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_w_s32
[       OK ] Reduction_TensorReduce.nhwc_ANY_w_s32 (7983 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_w_s32
[       OK ] Reduction_TensorReduce.nhwc_ALL_w_s32 (7724 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_w_f32
[       OK ] Reduction_TensorReduce.nhwc_ANY_w_f32 (7789 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_w_f32
[       OK ] Reduction_TensorReduce.nhwc_ALL_w_f32 (8077 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x1
/home/jsshi/peter_workspace/cutlass/test/unit/reduction/device/tensor_reduce_contiguous.cu:119: Failure
Value of: equal
  Actual: false
Expected: true
Error at location (1, 0, 0, 0)
  expected: 264
       got: 25
Problem: 3, 5, 7, 2049 -> 3, 5, 7, 1
   Grid: 0, 0, 0
   Block: 0, 0, 0
  FInal: 1, 1, 1
   Block: 1, 1, 1
/home/jsshi/peter_workspace/cutlass/test/unit/reduction/device/tensor_reduce_contiguous.cu:181: Failure
Value of: TestAllReduction_NHWC_reduce_c<TensorReduction>()
  Actual: false
Expected: true
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x1 (16 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x1_f16x1
/home/jsshi/peter_workspace/cutlass/test/unit/reduction/device/tensor_reduce_contiguous.cu:119: Failure
Value of: equal
  Actual: false
Expected: true
Error at location (1, 0, 0, 0)
  expected: 264
       got: 25
Problem: 3, 5, 7, 2049 -> 3, 5, 7, 1
   Grid: 0, 0, 0
   Block: 0, 0, 0
  FInal: 1, 1, 1
   Block: 1, 1, 1
/home/jsshi/peter_workspace/cutlass/test/unit/reduction/device/tensor_reduce_contiguous.cu:207: Failure
Value of: TestAllReduction_NHWC_reduce_c<TensorReduction>()
  Actual: false
Expected: true
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x1_f16x1 (22 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x2
/home/jsshi/peter_workspace/cutlass/test/unit/reduction/device/tensor_reduce_contiguous.cu:96: Failure
Expected equality of these values:
  cudaDeviceSynchronize()
    Which is: misaligned address
  cudaSuccess
    Which is: no error
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x2 (44 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x2_f16x2
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x2_f16x2 (3 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x4
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x4 (2 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x4_f16x4
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x4_f16x4 (7 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_maximum_c_f32x4
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_maximum_c_f32x4 (2 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_minimum_c_f32x4
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_minimum_c_f32x4 (2 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_c_s32
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_ANY_c_s32 (1 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_c_s32
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_ALL_c_s32 (0 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_c_f32
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_ANY_c_f32 (1 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_c_f32
unknown file: Failure
C++ exception with description "std::exception" thrown in the test body.
[  FAILED  ] Reduction_TensorReduce.nhwc_ALL_c_f32 (0 ms)
[----------] 26 tests from Reduction_TensorReduce (231595 ms total)

[----------] Global test environment tear-down
[==========] 26 tests from 1 test case ran. (231595 ms total)
[  PASSED  ] 14 tests.
[  FAILED  ] 12 tests, listed below:
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x1
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x1_f16x1
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x2
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x2_f16x2
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x4
[  FAILED  ] Reduction_TensorReduce.nhwc_reduce_c_f32x4_f16x4
[  FAILED  ] Reduction_TensorReduce.nhwc_maximum_c_f32x4
[  FAILED  ] Reduction_TensorReduce.nhwc_minimum_c_f32x4
[  FAILED  ] Reduction_TensorReduce.nhwc_ANY_c_s32
[  FAILED  ] Reduction_TensorReduce.nhwc_ALL_c_s32
[  FAILED  ] Reduction_TensorReduce.nhwc_ANY_c_f32
[  FAILED  ] Reduction_TensorReduce.nhwc_ALL_c_f32

12 FAILED TESTS

```
After:  
```
Note: Google Test filter = -SM75*:SM80*
[==========] Running 26 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 26 tests from Reduction_TensorReduce
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_f32x8_f16x8
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_f32x8_f16x8 (84532 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_f32x2_f16x2
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_f32x2_f16x2 (20888 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_f32x1_f16x1
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_f32x1_f16x1 (10418 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_s32x4
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_s32x4 (32108 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_w_cf32
[       OK ] Reduction_TensorReduce.nhwc_reduce_w_cf32 (12395 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_maximum_w_cf32
[       OK ] Reduction_TensorReduce.nhwc_maximum_w_cf32 (7794 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_minimum_w_cf32
[       OK ] Reduction_TensorReduce.nhwc_minimum_w_cf32 (7785 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_XOR_w_u32
[       OK ] Reduction_TensorReduce.nhwc_XOR_w_u32 (7773 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_AND_w_s32
[       OK ] Reduction_TensorReduce.nhwc_AND_w_s32 (7785 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_OR_w_u32
[       OK ] Reduction_TensorReduce.nhwc_OR_w_u32 (7765 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_w_s32
[       OK ] Reduction_TensorReduce.nhwc_ANY_w_s32 (7949 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_w_s32
[       OK ] Reduction_TensorReduce.nhwc_ALL_w_s32 (7691 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_w_f32
[       OK ] Reduction_TensorReduce.nhwc_ANY_w_f32 (7777 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_w_f32
[       OK ] Reduction_TensorReduce.nhwc_ALL_w_f32 (8047 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x1
[       OK ] Reduction_TensorReduce.nhwc_reduce_c_f32x1 (6355 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x1_f16x1
[       OK ] Reduction_TensorReduce.nhwc_reduce_c_f32x1_f16x1 (8602 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x2
[       OK ] Reduction_TensorReduce.nhwc_reduce_c_f32x2 (12679 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x2_f16x2
[       OK ] Reduction_TensorReduce.nhwc_reduce_c_f32x2_f16x2 (17025 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x4
[       OK ] Reduction_TensorReduce.nhwc_reduce_c_f32x4 (25539 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_reduce_c_f32x4_f16x4
[       OK ] Reduction_TensorReduce.nhwc_reduce_c_f32x4_f16x4 (34022 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_maximum_c_f32x4
[       OK ] Reduction_TensorReduce.nhwc_maximum_c_f32x4 (25465 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_minimum_c_f32x4
[       OK ] Reduction_TensorReduce.nhwc_minimum_c_f32x4 (25474 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_c_s32
[       OK ] Reduction_TensorReduce.nhwc_ANY_c_s32 (6422 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_c_s32
[       OK ] Reduction_TensorReduce.nhwc_ALL_c_s32 (6227 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ANY_c_f32
[       OK ] Reduction_TensorReduce.nhwc_ANY_c_f32 (6306 ms)
[ RUN      ] Reduction_TensorReduce.nhwc_ALL_c_f32
[       OK ] Reduction_TensorReduce.nhwc_ALL_c_f32 (6530 ms)
[----------] 26 tests from Reduction_TensorReduce (411353 ms total)

[----------] Global test environment tear-down
[==========] 26 tests from 1 test case ran. (411353 ms total)
[  PASSED  ] 26 tests.

```
Signed-off-by: Peter Han <fujun.han@iluvatar.ai>