### PR TITLE
Make cutlass::gemm::device::GemmArray usable

### DIFF
--- a/include/cutlass/gemm/device/gemm_array.h
+++ b/include/cutlass/gemm/device/gemm_array.h
@@ -376,8 +376,8 @@ public:
 
     cutlass::gemm::GemmCoord grid_shape = threadblock_swizzle.get_tiled_shape(
       args.problem_size,
-      args.batch_count,
-      {ThreadblockShape::kM, ThreadblockShape::kN, ThreadblockShape::kK});
+      {ThreadblockShape::kM, ThreadblockShape::kN, ThreadblockShape::kK},
+      args.batch_count);
 
     // Initialize the Params structure
     params_ = typename GemmKernel::Params{

--- a/media/docs/gemm_api.md
+++ b/media/docs/gemm_api.md
@@ -81,6 +81,7 @@ has semantics similar to cuBLAS.
 
 The device-wide GEMM API is embodied by the following operators:
 - [cutlass::gemm::device::Gemm](/include/cutlass/gemm/device/gemm.h) - basic GEMM operation
+- [cutlass::gemm::device::GemmArray](/include/cutlass/gemm/device/gemm_array.h) - batched GEMM operation in which input matrices are read from arrays of pointers
 - [cutlass::gemm::device::GemmBatched](/include/cutlass/gemm/device/gemm_batched.h) - batched GEMM operation in which input matrices are separated by a constant stride
 - [cutlass::gemm::device::GemmSplitKParallel](/include/cutlass/gemm/device/gemm_splitk_parallel.h) - GEMM operation that partitions the GEMM K dimension then launches a separate reduction kernel
 


### PR DESCRIPTION
For my application, I want a batched GEMM with no fixed stride between matrices (in cuBLAS terms, `cublas*gemmBatched()` instead of `cublas*gemmStridedBatched()`). There's apparently a class that does exactly this (`cutlass::gemm::device::GemmArray`), however, it uses the wrong argument order for `GemmBatchedIdentityThreadblockSwizzle::get_tiled_block()` and therefore doesn't compile.

In this PR, I swap the order of the arguments and add a demo for `GemmArray` to show that it works, at least for the toy SGEMM in `examples/05_batched_gemm`.

I also tested it on my application (using FP16), and it appears to work perfectly. There might be more to it, but to me it looks like `GemmArray` is identical to `GemmBatched` in every way except actually fetching pointers to the element of the batch, so I hope my patch is not subtly broken.