### PR TITLE
Removed trivial copy constructors on parameter classes to enable devi…

### DIFF
--- a/examples/18_ampere_fp64_tensorop_affine2_gemm/ampere_fp64_tensorop_affine2_gemm.cu
+++ b/examples/18_ampere_fp64_tensorop_affine2_gemm/ampere_fp64_tensorop_affine2_gemm.cu
@@ -94,7 +94,7 @@ using SmArch = cutlass::arch::Sm80;
 using ThreadblockShape = cutlass::gemm::GemmShape<128, 128, 16>;  // Threadblock tile shape
 
 // This code section describes tile size a warp will compute
-using WarpShape = cutlass::gemm::GemmShape<64, 32, 16>;         // Warp tile shape
+using WarpShape = cutlass::gemm::GemmShape<32, 64, 16>;         // Warp tile shape
 
 // This code section describes the size of MMA op
 using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;    // TensorCore instruction shape
@@ -110,7 +110,8 @@ using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
     ElementOutput,                                        // Data type of output matrix.
     1,                                                    // The number of elements per memory
                                                           // access has.  It has to be 1 for
-                                                          // affine2. 
+                                                          // affine2.
+    ElementAccumulator,
     ElementComputeEpilogue>;
 
 using GemmKernel = typename cutlass::gemm::kernel::DefaultGemmUniversal<
@@ -226,7 +227,7 @@ int run() {
     tensor_b.device_ref().data(),              // <- reference to matrix B on device
     tensor_c.device_ref().data(),              // <- reference to matrix C on device
     tensor_d.device_ref().data(),              // <- reference to matrix D on device
-    tensor_a.layout().capacity(problem_size.mn()),
+    tensor_a.layout().capacity(problem_size.mk()),
     tensor_b.layout().capacity(problem_size.kn()),
     tensor_c.layout().capacity(problem_size.mn()),
     tensor_d.layout().capacity(problem_size.mn()),
@@ -302,7 +303,7 @@ int run() {
 
   CUTLASS_CHECK(status);
 
-  return 0;
+  return (pass ? 0 : -1);
 }
 
 int main(int argc, char const **args) {

--- a/include/cutlass/coord.h
+++ b/include/cutlass/coord.h
@@ -94,14 +94,6 @@ public:
     }
   }
 
-  /// Copy constructor
-  CUTLASS_HOST_DEVICE
-  Coord(Coord<kRank, Index, LongIndex> const &coord) {
-    for (int i = 0; i < kRank; ++i) {
-      idx[i] = coord[i];
-    }
-  }
-
   /// Returns a slice of the Coord which may be larger or smaller in rank
   /// than this.
   template <int Slice>

--- a/include/cutlass/gemm/kernel/gemm_universal.h
+++ b/include/cutlass/gemm/kernel/gemm_universal.h
@@ -162,6 +162,10 @@ public:
       ptr_A(ptr_A), ptr_B(ptr_B), ptr_C(ptr_C), ptr_D(ptr_D), 
       batch_stride_A(batch_stride_A), batch_stride_B(batch_stride_B), batch_stride_C(batch_stride_C), batch_stride_D(batch_stride_D), 
       stride_a(stride_a), stride_b(stride_b), stride_c(stride_c), stride_d(stride_d) {
+      lda = 0;
+      ldb = 0;
+      ldc = 0;
+      ldd = 0;
 
       CUTLASS_TRACE_HOST("GemmUniversal::Arguments::Arguments() - problem_size: " << problem_size);
       }

--- a/include/cutlass/tensor_ref.h
+++ b/include/cutlass/tensor_ref.h
@@ -218,6 +218,16 @@ class TensorRef {
   
   }
 
+  /// Converting constructor from TensorRef to non-constant data.
+  template<typename _Magic = int>
+  CUTLASS_HOST_DEVICE
+  TensorRef(
+    NonConstTensorRef const &ref,             ///< TensorRef to non-const data
+    ///SFINAE trick to avoid creating a copy-constructor when Element_ is already non-const
+    _Magic magic = (typename std::enable_if< ! std::is_same<NonConstTensorRef, TensorRef<Element_, Layout_> >::value, _Magic>::type)0
+  ):
+    ptr_(ref.data()), layout_(ref.layout()) { }
+
   /// Returns a reference to constant-valued tensor.
   CUTLASS_HOST_DEVICE
   ConstTensorRef const_ref() const {

--- a/include/cutlass/tensor_ref.h
+++ b/include/cutlass/tensor_ref.h
@@ -218,13 +218,6 @@ class TensorRef {
   
   }
 
-  /// Converting constructor from TensorRef to non-constant data.
-  CUTLASS_HOST_DEVICE
-  TensorRef(
-    NonConstTensorRef const &ref              ///< TensorRef to non-const data
-  ):
-    ptr_(ref.data()), layout_(ref.layout()) { }
-
   /// Returns a reference to constant-valued tensor.
   CUTLASS_HOST_DEVICE
   ConstTensorRef const_ref() const {

--- a/include/cutlass/tensor_ref.h
+++ b/include/cutlass/tensor_ref.h
@@ -224,7 +224,7 @@ class TensorRef {
   TensorRef(
     NonConstTensorRef const &ref,             ///< TensorRef to non-const data
     ///SFINAE trick to avoid creating a copy-constructor when Element_ is already non-const
-    _Magic magic = (typename std::enable_if< ! std::is_same<NonConstTensorRef, TensorRef<Element_, Layout_> >::value, _Magic>::type)0
+    _Magic magic = (typename platform::enable_if< ! platform::is_same<NonConstTensorRef, TensorRef<Element_, Layout_> >::value, _Magic>::type)0
   ):
     ptr_(ref.data()), layout_(ref.layout()) { }
 


### PR DESCRIPTION
Currently `cutlass::gemm::kernel::DefaultGemm<...>::GemmKernel` cannot be launched from device (CUDA Dynamic Parallelism) because its `Params` class indirectly contains two classes with user-defined constructors: `Coord` (base class of `GemmCoord`) and `TensorRef`.

This patch removes such copy constructors, enabling the kernels to be launched from device-side. These copy constructors are trivial anyway so removing them shouldn't affect functionality.

Test code that fails to build without patch and works with patch:

```C++
#include "cutlass/cutlass.h"
#include "cutlass/gemm/device/gemm.h"
#include "cutlass/gemm/kernel/default_gemm.h"
#include "cutlass/gemm/device/default_gemm_configuration.h"

using OperatorClass = cutlass::arch::OpClassSimt;
using ArchTag = cutlass::arch::Sm86;
using ThreadblockShape = cutlass::gemm::device::DefaultGemmConfiguration<
	OperatorClass, ArchTag, float, float, float, float>::ThreadblockShape;
/// Warp-level tile size (concept: GemmShape)
using WarpShape = cutlass::gemm::device::DefaultGemmConfiguration<
	OperatorClass, ArchTag, float, float, float, float>::WarpShape;
/// Instruction-level tile size (concept: GemmShape)
using InstructionShape = cutlass::gemm::device::DefaultGemmConfiguration<
	OperatorClass, ArchTag, float, float, float, float>::InstructionShape;
/// Epilogue output operator
using EpilogueOutputOp = cutlass::gemm::device::DefaultGemmConfiguration<
	OperatorClass, ArchTag, float, float, float, float>::EpilogueOutputOp;
using ThreadblockSwizzle = cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>;
static const int kStages = cutlass::gemm::device::DefaultGemmConfiguration<OperatorClass, ArchTag, float, float, float, float>::kStages;
/// Access granularity of A matrix in units of elements
static const int kAlignmentA = cutlass::gemm::device::DefaultGemmConfiguration<OperatorClass, ArchTag, float, float, float, float>::kAlignmentA;
/// Access granularity of B matrix in units of elements
static const int kAlignmentB = cutlass::gemm::device::DefaultGemmConfiguration<OperatorClass, ArchTag, float, float, float, float>::kAlignmentB;
static const bool kSplitKSerial = false;
template<typename LayoutA, typename LayoutB, typename LayoutC>
using CutlassGemmKernel = typename cutlass::gemm::kernel::DefaultGemm<
  float,
  LayoutA,
  kAlignmentA,
  float,
  LayoutB,
  kAlignmentB,
  float,
  LayoutC,
  float,
  OperatorClass,
  ArchTag,
  ThreadblockShape,
  WarpShape,
  InstructionShape,
  EpilogueOutputOp,
  ThreadblockSwizzle,
  kStages,
  kSplitKSerial,
  cutlass::gemm::device::DefaultGemmConfiguration<OperatorClass, ArchTag, float, float, float, float>::Operator
>::GemmKernel;

template<typename T>
void check(T result, char const *const func, const char *const file, int const line) {
	if (result) {
		fprintf(stderr, "CUDA error at %s:%d code=%d \"%s\" \n",
				file, line, static_cast<unsigned int>(result), func);
		// Make sure we call CUDA Device Reset before exiting
		abort();
	}
}
#define checkCudaErrors(val)           check((val), #val, __FILE__, __LINE__)

template<typename LayoutA, typename LayoutB, typename LayoutC>
__device__ void run(
	cutlass::gemm::GemmCoord problem_size,
	cutlass::TensorRef<float const, LayoutA> ref_A,
	cutlass::TensorRef<float const, LayoutB> ref_B,
	cutlass::TensorRef<float const, LayoutC> ref_C,
	cutlass::TensorRef<float, LayoutC> ref_D,
	typename EpilogueOutputOp::Params epilogue = EpilogueOutputOp::Params()
	//int split_k_slices=1
) {
	using TGemmKernel = CutlassGemmKernel<LayoutA, LayoutB, LayoutC>;
	ThreadblockSwizzle threadblock_swizzle;
	cutlass::gemm::GemmCoord grid_shape = threadblock_swizzle.get_tiled_shape(
		problem_size, 
		{ThreadblockShape::kM, ThreadblockShape::kN, ThreadblockShape::kK},
		1//split_k_slices
	);
	
	// Initialize the Params structure
	typename TGemmKernel::Params params{
		problem_size,
		grid_shape,
		ref_A.non_const_ref(),
		ref_B.non_const_ref(),
		ref_C.non_const_ref(),
		ref_D,
		epilogue,
		NULL //workspace
	};
	dim3 grid = threadblock_swizzle.get_grid_shape(params.grid_tiled_shape);
	dim3 block(TGemmKernel::kThreadCount, 1, 1);
	int smem_size = int(sizeof(typename TGemmKernel::SharedStorage));
	cutlass::Kernel<TGemmKernel><<<grid, block, smem_size >>> (params);
}

__global__ void gpu_master(float* a, float* b, float* c, int n) {
	int i = blockIdx.x * blockDim.x + threadIdx.x;
	a += i * n * n;
	b += i * n * n;
	c += i * n * n;
	run<cutlass::layout::RowMajor, cutlass::layout::RowMajor, cutlass::layout::RowMajor>(
		{n,n,n},
		{a, n},
		{b, n},
		{c, n},
		{c, n},
		{1.f, 0.f}
	);
}

int main() {
	float* a = NULL;
	float* b = NULL;
	float* c = NULL;
	int n = 128;
	int m = 7 * 32;
	cudaMallocHost((void**) & a, m * n * n * sizeof(float));
	cudaMallocHost((void**) & b, m * n * n * sizeof(float));
	cudaMallocHost((void**) & c, m * n * n * sizeof(float));
	cudaMemset(a, 0x3f, m * n * n * sizeof(float));
	cudaMemset(b, 0x3f, m * n * n * sizeof(float));
	cudaMemset(c, 0x3f, m * n * n * sizeof(float));
	gpu_master<<<7, 32 >>> (a, b, c, n);
	checkCudaErrors(cudaPeekAtLastError());
	float* cc = (float*)malloc(m * n * n * sizeof(float));
	cudaMemcpy(cc, c, m * n * n * sizeof(float), cudaMemcpyDeviceToHost);
	printf("%f %f %f\n", cc[0], cc[n * n + 1], cc[n * n * (m - 1) + n * n - 7]);
	return 0;
}
```

Tested with `-arch=compute_86 -code=sm_86 -rdc=true` on CUDA 11. Expected output:
```
71.4364 71.4364 71.4364
```
