### PR TITLE
Support half precision sigmoid activation

### DIFF
--- a/include/cutlass/epilogue/thread/activation.h
+++ b/include/cutlass/epilogue/thread/activation.h
@@ -110,14 +110,6 @@ struct Sigmoid<float> {
   }
 };
 
-template <>
-struct Sigmoid<half_t> {
-  CUTLASS_DEVICE
-  half_t operator()(half_t const &scalar) const {
-    return half_t(1) / (half_t(1) + half_t(::hexp(-scalar.to_half())));
-  }
-};
-
 template <typename T, int N>
 struct Sigmoid<Array<T, N> > {
   CUTLASS_HOST_DEVICE
@@ -188,6 +180,35 @@ struct HardSwish<Array<T, N> > {
     return y;
   }
 };
+
+template <>
+struct Sigmoid<half_t> {
+  CUTLASS_HOST_DEVICE
+  half_t operator()(half_t const& scalar) const {
+    half_t exp_res;
+    #if defined(__CUDA_ARCH__)
+    exp_res = half_t(::hexp(-scalar.to_half()));
+    #else
+    exp_res = half_t(std::exp(float(-scalar)));
+    #endif
+    return half_t(1) / (half_t(1) + exp_res);
+  }
+};
+
+#if defined(CUTLASS_USE_FAST_MATH)
+template <int N>
+struct Sigmoid<Array<half_t, N>> {
+  CUTLASS_HOST_DEVICE
+  Array<half_t, N> operator()(Array<half_t, N> const& z) const {
+    using T = half_t;
+    multiplies<Array<half_t, N>> mul;
+    plus<Array<half_t, N>> add;
+    fast_tanh_op<Array<half_t, N>> tanh;
+    return mul(add(tanh(mul(z, cutlass::constants::half<T>())), cutlass::constants::one<T>()),
+               cutlass::constants::half<T>());
+  }
+};
+#endif
 
 //
 // GELU function definitions implemented as described by

--- a/include/cutlass/epilogue/thread/activation.h
+++ b/include/cutlass/epilogue/thread/activation.h
@@ -134,7 +134,7 @@ struct Sigmoid<Array<half_t, N>> {
 #else
     divides<Array<T, N>> div;
     negate<Array<T, N>> neg;
-    fast_exp_op<Array<T, N>> exp;
+    fast_exp_op<Array<T, N>> fast_exp;
     return div(cutlass::constants::one<T>(),
                add(cutlass::constants::one<T>(),
                    fast_exp(neg(z))));

--- a/include/cutlass/epilogue/thread/activation.h
+++ b/include/cutlass/epilogue/thread/activation.h
@@ -110,6 +110,14 @@ struct Sigmoid<float> {
   }
 };
 
+template <>
+struct Sigmoid<half_t> {
+  CUTLASS_DEVICE
+  half_t operator()(half_t const &scalar) const {
+    return half_t(1) / (half_t(1) + half_t(::hexp(-scalar.to_half())));
+  }
+};
+
 template <typename T, int N>
 struct Sigmoid<Array<T, N> > {
   CUTLASS_HOST_DEVICE

--- a/include/cutlass/fast_math.h
+++ b/include/cutlass/fast_math.h
@@ -705,9 +705,18 @@ float fast_exp(float x) {
 CUTLASS_HOST_DEVICE
 double fast_exp(double x) {
   #if defined(__CUDA_ARCH__)
-  return ::exp(x);
+  return ::expf(x);
   #else
   return std::exp(x);
+  #endif
+}
+
+CUTLASS_HOST_DEVICE
+float fast_exp(half_t x) {
+  #if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 10) && (__CUDA_ARCH__ >= 750)
+      return ::hexp(x.to_half());
+  #else
+      return fast_exp(float(x));
   #endif
 }
 
@@ -764,6 +773,60 @@ half_t fast_tanh(half_t x) {
   return half_t(fast_tanh(float(x)));
   #endif
 }
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+struct fast_exp_op {
+  CUTLASS_HOST_DEVICE
+  T operator()(T const &rhs) const {
+    return fast_exp(rhs);
+  }
+};
+
+#if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 10) && (__CUDA_ARCH__ >= 750)
+template <int N>
+struct fast_exp_op<Array<half_t, N>> {
+  CUTLASS_DEVICE
+  Array<half_t, N> operator()(Array<half_t, N> const &rhs) const {
+
+    Array<half_t, N> result;
+
+    // use x2 specialization
+    __half2 const *in  = reinterpret_cast<__half2 const *>(&rhs);
+    __half2 *out = reinterpret_cast<__half2 *>(&result);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < N / 2; ++i) {
+      out[i] = ::h2exp(in[i]);
+    }
+
+    // residual
+    if (N % 2) {
+      result[N - 1] = ::hexp(rhs[N - 1].raw());
+    }
+
+    return result;
+  }
+};
+#endif // #if defined(__CUDA_ARCH__)
+
+template <typename T, int N>
+struct fast_exp_op<Array<T, N>> {
+  CUTLASS_HOST_DEVICE
+  Array<T, N> operator()(Array<T, N> const &rhs) const {
+
+    fast_exp_op<T> fast_op;
+    Array<T, N> y;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      y[i] = fast_op(rhs[i]);
+    }
+
+    return y;
+  }
+};
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/include/cutlass/fast_math.h
+++ b/include/cutlass/fast_math.h
@@ -804,7 +804,7 @@ struct fast_exp_op<Array<half_t, N>> {
     // residual
     if (N % 2) {
       half_t last = rhs[N - 1];
-      result[N - 1] = half_t(::hexp(last.raw()));
+      result[N - 1] = half_t(::hexp(last.to_half()));
     }
 
     return result;

--- a/include/cutlass/fast_math.h
+++ b/include/cutlass/fast_math.h
@@ -803,7 +803,8 @@ struct fast_exp_op<Array<half_t, N>> {
 
     // residual
     if (N % 2) {
-      result[N - 1] = ::hexp(rhs[N - 1].raw());
+      half_t last = rhs[N - 1];
+      result[N - 1] = half_t(::hexp(last.raw()));
     }
 
     return result;


### PR DESCRIPTION
Currently, trying to use sigmoid activation with `half_t` results in a compile error:
```
 error: no instance of overloaded function "cutlass::exp" matches the argument list                                                                                                                                  
            argument types are: (cutlass::half_t)       
```