### PR TITLE
Added missing synchronization to avoid WAR hazards between tiles in Grouped GEMM

### DIFF
--- a/include/cutlass/gemm/kernel/gemm_grouped.h
+++ b/include/cutlass/gemm/kernel/gemm_grouped.h
@@ -546,6 +546,9 @@ public:
       // Compute threadblock-scoped matrix multiply-add
       int gemm_k_iterations = (problem_size.k() + Mma::Shape::kK - 1) / Mma::Shape::kK;
 
+      // Wait for all threads to finish their epilogue phases from the previous tile.
+      __syncthreads();
+      
       // Compute threadblock-scoped matrix multiply-add
       mma(
         gemm_k_iterations, 


### PR DESCRIPTION
Added missing synchronization to avoid WAR hazards between tiles in Grouped GEMM. Compute Sanitizer `--tool=racecheck` reports zero errors now.