### PR TITLE
Fix typo in scripts/library.py (wrong data size for u8)

### DIFF
--- a/tools/library/scripts/library.py
+++ b/tools/library/scripts/library.py
@@ -155,7 +155,7 @@ DataTypeTag = {
 DataTypeSize = {
   DataType.b1: 1,
   DataType.u4: 4,
-  DataType.u8: 4,
+  DataType.u8: 8,
   DataType.u16: 16,
   DataType.u32: 32,
   DataType.u64: 64,


### PR DESCRIPTION
Just found while reading this file.