### PR TITLE
Update mma_base.h

### DIFF
--- a/include/cutlass/gemm/threadblock/mma_base.h
+++ b/include/cutlass/gemm/threadblock/mma_base.h
@@ -192,7 +192,9 @@ class MmaBase {
 
   /// Iterator to load a warp-scoped tile of B operand from shared memory
   typename Operator::IteratorB warp_tile_iterator_B_;
-
+  
+  
+  SharedStorage &shared_storage_;
 public:
 
   /// Construct from tensor references
@@ -208,7 +210,8 @@ public:
       int lane_idx
     ):
       warp_tile_iterator_A_(shared_storage.operand_A_ref(), lane_idx),
-      warp_tile_iterator_B_(shared_storage.operand_B_ref(), lane_idx) {
+      warp_tile_iterator_B_(shared_storage.operand_B_ref(), lane_idx),
+      shared_storage_(shared_storage){
 
   }
 };


### PR DESCRIPTION
Keep a reference to SharedStorage in mma_base. Derived classes from mma_base can access shared mem storage, which is useful for building custom functions. 