### PR TITLE
Fix typo in docs, code comments

### DIFF
--- a/include/cutlass/arch/simd_sm61.h
+++ b/include/cutlass/arch/simd_sm61.h
@@ -23,7 +23,7 @@
  *
  **************************************************************************************************/
 /*! \file
-    \brief Templates exposing SIMD operators for SM60
+    \brief Templates exposing SIMD operators for SM61
 */
 
 #pragma once

--- a/include/cutlass/layout/tensor.h
+++ b/include/cutlass/layout/tensor.h
@@ -80,7 +80,7 @@ private:
   // Data members
   //
 
-  /// Stride data member - [stride_w, stride_h, stride_n]
+  /// Stride data member - [c, wc, hwc]
   Stride stride_;
 
 public:
@@ -227,7 +227,7 @@ private:
   // Data members
   //
 
-  /// Stride data member - [c, wc, hwc]
+  /// Stride data member - [w, hw, chw]
   Stride stride_;
 
 public:
@@ -312,7 +312,7 @@ private:
   // Data members
   //
 
-  /// Stride data member - [c, wc, hwc]
+  /// Stride data member - [Interleave x w, Interleave x wh, hwc]
   Stride stride_;
 
 public:
@@ -421,7 +421,7 @@ private:
   // Data members
   //
 
-  /// Stride data member - [c, wc, hwc]
+  /// Stride data member - [Interleave x n, Interleave x nw, Interleave x nwh]
   Stride stride_;
 
 public:

--- a/media/docs/layout.md
+++ b/media/docs/layout.md
@@ -126,8 +126,8 @@ This method is needed when an algorithm must define a buffer of arbitrary layout
 Example:
 ```c++
 
-typename ArbitraryLayout::TensorCord extent = make_Coord(...);
-typename ArbitraryLayout::TensorCord coord;
+typename ArbitraryLayout::TensorCoord extent = make_Coord(...);
+typename ArbitraryLayout::TensorCoord coord;
 
 ArbitraryLayout layout = ArbitraryLayout::packed(extent);
 


### PR DESCRIPTION
* fix typo in media/docs/layout.md
* fix typo in include/cutlass/arch/simd_61.h
* fix stride comment errors in TensorLayout