### PR TITLE
[BUGFIX]: falsely unroll loop

### DIFF
--- a/tools/util/include/cutlass/util/device_dump.h
+++ b/tools/util/include/cutlass/util/device_dump.h
@@ -95,7 +95,7 @@ CUTLASS_DEVICE void dump_fragment(Fragment const& frag, int N = 0, int M = 0,
   for (int tid = 0; tid < N; ++tid) {
     if (tid == thread_id) {
       printf("TB%d W%d T%d: ", block_id, tid / 32, tid & 31);
-      CUTLASS_PRAGMA_UNROLL
+      CUTLASS_PRAGMA_NO_UNROLL
       for (int i = 0; i < M; i += S) {
         printf("%.0f ", float(typename Fragment::value_type(frag[i])));
       }


### PR DESCRIPTION
Force unroll a loop that doesn't have compilation constant loop times is dangerous.

I cannot reproduce the failure using NVCC, but it did 100% crash using our clang tools while running examples/02_dump_reg_shmem.

Signed-off-by: Peter Han <fujun.han@iluvatar.ai>