### PR TITLE
Fixed template struct/class declaration mismatch 

### DIFF
--- a/include/cutlass/epilogue/warp/tile_iterator_volta_tensor_op.h
+++ b/include/cutlass/epilogue/warp/tile_iterator_volta_tensor_op.h
@@ -58,7 +58,7 @@ struct TileIteratorVoltaTensorOp;
 template <
   typename WarpShape_         ///< shape of warp-level GEMM (concept: MatrixShape)
 >
-class TileIteratorVoltaTensorOp<WarpShape_, gemm::GemmShape<32, 32, 4>, half_t, layout::RowMajor> {
+struct TileIteratorVoltaTensorOp<WarpShape_, gemm::GemmShape<32, 32, 4>, half_t, layout::RowMajor> {
 public:
 
   using WarpShape = WarpShape_;
@@ -244,7 +244,7 @@ public:
 template <
   typename WarpShape_         ///< shape of warp-level GEMM (concept: MatrixShape)
 >
-class TileIteratorVoltaTensorOp<WarpShape_, gemm::GemmShape<32, 32, 4>, float, layout::RowMajor> {
+struct TileIteratorVoltaTensorOp<WarpShape_, gemm::GemmShape<32, 32, 4>, float, layout::RowMajor> {
 public:
 
   using WarpShape = WarpShape_;

--- a/include/cutlass/transform/thread/transpose.h
+++ b/include/cutlass/transform/thread/transpose.h
@@ -38,7 +38,7 @@ template <
   int ElementCount, 
   typename TransposeShape, 
   typename Element
-> class Transpose;
+> struct Transpose;
 
 /// Specialization for int8_t 4x4 transpose
 template <int ElementCount_>


### PR DESCRIPTION
Compiler generates warning that such mismatch can produce problems with VS compilers ABI.

* I'm sorry, I closed previous PR by mistake (https://github.com/NVIDIA/cutlass/pull/451).