### PR TITLE
Fix typo in shared memory layout description

### DIFF
--- a/media/docs/implicit_gemm_convolution.md
+++ b/media/docs/implicit_gemm_convolution.md
@@ -596,7 +596,7 @@ As described in the CUTLASS GTC 2019 presentation [slides](https://developer.dow
 [recording](https://developer.nvidia.com/gtc/2019/video/S9593), an access to Shared Memory will be conflict-free if
 the following conditions are satisfied across each warp:
 - {T0, T1, .., T7} do not access the same 128-bit bank
-- {T8, T9, .., T16} do not access the same 128-bit bank
+- {T8, T9, .., T15} do not access the same 128-bit bank
 - {T16, T17, .., T23} do not access the same 128-bit bank
 - {T24, T25, .., T31} do not access the same 128-bit bank
 


### PR DESCRIPTION
Reading https://github.com/NVIDIA/cutlass/blob/master/media/docs/implicit_gemm_convolution.md#shared-memory-layouts, I was confused because the figure shows T11 and T16 accessing the same bank while the explanation says `{T8, T9, .., T16} do not access the same 128-bit bank`.

@hwu36 @manishucsd 