### PR TITLE
Add a partial specialization for float <= int32_t x 4 in default_epilogue_tensor_op.h

### DIFF
--- a/include/cutlass/epilogue/threadblock/default_epilogue_tensor_op.h
+++ b/include/cutlass/epilogue/threadblock/default_epilogue_tensor_op.h
@@ -158,6 +158,30 @@ struct DefaultIteratorsTensorOp<int32_t, int32_t, 4, ThreadblockShape, WarpShape
   static int const kFragmentsPerIteration = 1;
 };
 
+/// Partial specialization for float <= int32_t x 4
+template <
+  typename ThreadblockShape,
+  typename WarpShape,
+  typename InstructionShape,
+  typename ThreadMap
+>
+struct DefaultIteratorsTensorOp<float, int32_t, 4, ThreadblockShape, WarpShape, InstructionShape, ThreadMap> {
+  
+  using WarpTileIterator = cutlass::epilogue::warp::TileIteratorTensorOp<
+    WarpShape,
+    InstructionShape,
+    int32_t,
+    layout::RowMajor
+  >;
+
+  using SharedLoadIterator = cutlass::epilogue::threadblock::SharedLoadIterator<
+    ThreadMap,
+    int32_t
+  >;
+
+  static int const kFragmentsPerIteration = 1;
+};
+
 /// Partial specialization for half <= float x 8 epilogues avoids shared memory bank conflicts.
 template <
   typename ThreadblockShape,


### PR DESCRIPTION
I add a partial specialization on `default_epilogue_tensor_op.h` in https://github.com/SpringWave1/cutlass/blob/1c754ff5688a6243412959aabee52e0697fc3091/include/cutlass/epilogue/threadblock/default_epilogue_tensor_op.h#L160-L184
The reason is that I want to fuse a dequant in my kernel and thus need an operation from s32 * scale = float. See details in QST issue.
https://github.com/NVIDIA/cutlass/issues/483
