### PR TITLE
Fix init-self compiler warnings

### DIFF
--- a/include/cutlass/gemm/kernel/gemm_universal.h
+++ b/include/cutlass/gemm/kernel/gemm_universal.h
@@ -145,9 +145,9 @@ public:
       mode(GemmUniversalMode::kGemm), 
       batch_count(1), 
       ptr_A(nullptr), ptr_B(nullptr), ptr_C(nullptr), ptr_D(nullptr),
-      ptr_gather_A_indices(ptr_gather_A_indices),
-      ptr_gather_B_indices(ptr_gather_B_indices),
-      ptr_scatter_D_indices(ptr_scatter_D_indices) {}
+      ptr_gather_A_indices(nullptr),
+      ptr_gather_B_indices(nullptr),
+      ptr_scatter_D_indices(nullptr) {}
 
     /// constructs an arguments structure
     Arguments(

--- a/tools/library/include/cutlass/library/library.h
+++ b/tools/library/include/cutlass/library/library.h
@@ -654,7 +654,7 @@ struct TrmmDescription : public OperationDescription {
     TensorDescription const &A = TensorDescription(),
     SideMode side_mode = SideMode::kInvalid,
     FillMode fill_mode = FillMode::kInvalid,
-    DiagType daig_type = DiagType::kInvalid,
+    DiagType diag_type = DiagType::kInvalid,
     TensorDescription const &B = TensorDescription(),
     TensorDescription const &D = TensorDescription(),
     NumericTypeID element_epilogue = NumericTypeID::kInvalid,


### PR DESCRIPTION
Fix a few errors caused by trying to initialize a class member with itself. These errors can turn into errors if you compile with `-Winit-self`.