### PR TITLE
Fix occupancy calculation for grouped GEMM

### DIFF
--- a/examples/24_gemm_grouped/gemm_grouped.cu
+++ b/examples/24_gemm_grouped/gemm_grouped.cu
@@ -756,12 +756,6 @@ public:
   /// Returns the number of threadblocks to launch if the kernel can run on the target
   /// device. Otherwise, returns zero.
   int sufficient() const {
-    //
-    // Determine SMEM requirements and waive if not satisfied
-    //
-
-    int smem_size = int(sizeof(typename Gemm::GemmKernel::SharedStorage));
-
     cudaDeviceProp properties;
     int device_idx;
     cudaError_t result = cudaGetDevice(&device_idx);
@@ -776,9 +770,10 @@ public:
       throw std::runtime_error("cudaGetDeviceProperties() failed");
     }
 
-    int occupancy = std::min(2, int(properties.sharedMemPerMultiprocessor / smem_size));
+    int occupancy = Gemm::maximum_active_blocks();
 
     return properties.multiProcessorCount * occupancy;
+
   }
 
 

--- a/test/unit/gemm/device/testbed_grouped.h
+++ b/test/unit/gemm/device/testbed_grouped.h
@@ -419,12 +419,6 @@ struct TestbedGrouped {
   /// Returns the number of threadblocks to launch if the kernel can run on the target
   /// device. Otherwise, returns zero.
   int sufficient() const {
-    //
-    // Determine SMEM requirements and waive if not satisfied
-    //
-
-    int smem_size = int(sizeof(typename Gemm::GemmKernel::SharedStorage));
-
     cudaDeviceProp properties;
     int device_idx;
     cudaError_t result = cudaGetDevice(&device_idx);
@@ -439,7 +433,7 @@ struct TestbedGrouped {
       throw std::runtime_error("cudaGetDeviceProperties() failed");
     }
 
-    int occupancy = std::min(2, int(properties.sharedMemPerMultiprocessor / smem_size));
+    int occupancy = Gemm::maximum_active_blocks();
 
     return properties.multiProcessorCount * occupancy;
   }


### PR DESCRIPTION
This change enables grouped GEMM to correctly use the [`cudaOccupancyMaxActiveBlocksPerMultiprocessor `](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__HIGHLEVEL.html#group__CUDART__HIGHLEVEL_1g5a5d67a3c907371559ba692195e8a38c) API, in part by setting  `cudaFuncAttributeMaxDynamicSharedMemorySize` when more than 48 KB of shared memory.

Example 24_gemm_grouped and unit test cutlass_test_unit_gemm_device_grouped each pass.