### PR TITLE
Fix doc in testbed_gemm_with_broadcast

### DIFF
--- a/test/unit/gemm/device/testbed_gemm_with_broadcast.h
+++ b/test/unit/gemm/device/testbed_gemm_with_broadcast.h
@@ -89,7 +89,7 @@ struct GemmWithBroadcastReferenceOp {
 //
 //  Y = GEMM(AB, C)
 //
-//  T[i, j] = ReductionOp(Y[i, j], Broadcast[i])
+//  T[i, j] = BinaryOp(Y[i, j], Broadcast[i])
 //
 //  Z[i, j] = Elementwise(T[i, j])
 //


### PR DESCRIPTION
I believe `ReductionOp` should be `BinaryOp` in the doc for `TestbedGemmWithBroadcast`, based on the reference op example above:
https://github.com/NVIDIA/cutlass/blob/1eb6355182a5124639ce9d3ff165732a94ed9a70/test/unit/gemm/device/testbed_gemm_with_broadcast.h#L76-L83
and the correctness checking code:
https://github.com/NVIDIA/cutlass/blob/1eb6355182a5124639ce9d3ff165732a94ed9a70/test/unit/gemm/device/testbed_gemm_with_broadcast.h#L352-L363

But I might be completely wrong and please correct me. Thanks!