### PR TITLE
Adding value_type to complex

### DIFF
--- a/include/cutlass/complex.h
+++ b/include/cutlass/complex.h
@@ -127,7 +127,8 @@ template <typename T>
 class complex
 {
  public:
-  /// Type alias for scalar type
+  /// Type alias for scalar type 
+  using value_type = T; 
 
  private:
   //


### PR DESCRIPTION
Added `value_type` trait to complex to make it an easier drop-in replacement for std::complex.