### PR TITLE
upstream applyshape optimization

### DIFF
--- a/examples/35_gemm_softmax/gemm_softmax.cu
+++ b/examples/35_gemm_softmax/gemm_softmax.cu
@@ -218,6 +218,12 @@ struct Testbed {
   using OperatorClass = cutlass::arch::OpClassTensorOp;
   using ArchTag = cutlass::arch::Sm80;
 
+  // ApplyShape impacts the final Softmax performance a lot.
+  // Set ApplyShape::kColumn to be the next multiple of 32 number that is after
+  // (gemm_N / alignment).
+  // Set ApplyShape::kRow to max(1, 128 / ApplyShape::kColumn).
+  using ApplyShape = cutlass::MatrixShape<1, 1024>;
+
   static int const kStages = 3;
 
   /// Linear scaling operator
@@ -239,7 +245,8 @@ struct Testbed {
     WarpShape,
     InstructionShape,
     EpilogueFunctorOp,
-    kStages
+    kStages,
+    ApplyShape
   >;
 
   using ElementNorm = typename GemmSoftmax::ElementNorm;
@@ -710,6 +717,4 @@ int main(int argc, const char **argv) {
   return (disposition == Disposition::kPassed ? 0 : -1);
 }
 
-
 /////////////////////////////////////////////////////////////////////////////////////////////////
-


### PR DESCRIPTION
performance improvement by changing `ApplyShape` param.

This patch improves the performance of the element-wise operation followed after partial/full reduction operations of softmax.

Choosing different `ApplyShape` significantly influences the performance. A user is suggested to follow the suggestions in the comments of the code to choose `ApplyShape` parameter.

```
<1, 1024>:
m=1024, n=1024, k=512, batch = 16, GFLOPs: 54338.3  GFLOPs
<1, 128>:
m=1024, n=1024, k=512, batch = 16, GFLOPs: 78625  GFLOPs
<2, 64>:
m=1024, n=1024, k=512, batch = 16, GFLOPs: 75128.9  GFLOPs
```

CUDA 11.6, NVIDIA A100. frequence locked at 1005 MHz and power locked at 400W.