### PR TITLE
Add member function to Convert epilogue

### DIFF
--- a/include/cutlass/epilogue/thread/conversion_op.h
+++ b/include/cutlass/epilogue/thread/conversion_op.h
@@ -91,6 +91,12 @@ public:
   Convert(Params const &params = Params()) {
 
   }
+  
+  /// Functionally required for serial reduction in the epilogue
+  CUTLASS_HOST_DEVICE
+  void set_k_partition(int k_partition, int k_partition_count) {
+    
+  }
 
   /// Returns true if source is needed based on state of runtime arguments
   CUTLASS_HOST_DEVICE


### PR DESCRIPTION
A member function set_k_partition is required for the instatiation of cutlass::gemm::kernel::Gemm, even if SplitKSerial is false