### PR TITLE
fix: comment typo in example 23

### DIFF
--- a/examples/23_ampere_gemm_operand_reduction_fusion/ampere_gemm_operand_reduction_fusion.cu
+++ b/examples/23_ampere_gemm_operand_reduction_fusion/ampere_gemm_operand_reduction_fusion.cu
@@ -561,7 +561,7 @@ Result profile(Options const &options) {
   
     tensor_reduction.sync_host();
   
-    // Compute bias + relu in host code
+    // ReduceK in host code
     if (ReduceKForA) {
       for (int m = 0; m < options.problem_size.m(); ++m) {
         for (int k = 0; k < options.problem_size.k(); ++k) {


### PR DESCRIPTION
IMO example 23 has nothing to do with relu. This is only a reduction. This line might be copied from example 12.