### PR TITLE
[BugFix] Fix call of GELU_Taylor in LinearCombinationGeneric

### DIFF
--- a/include/cutlass/epilogue/thread/activation.h
+++ b/include/cutlass/epilogue/thread/activation.h
@@ -572,7 +572,11 @@ struct GELU_taylor {
   }
 
   using Params = LinearCombinationGenericParams<T>;
-  
+
+  CUTLASS_HOST_DEVICE
+  T operator()(T const &scalar, Params const &params_) const {
+    return this->operator()(scalar);
+  }
 };
 
 template <int N>
@@ -601,6 +605,11 @@ struct GELU_taylor<Array<half_t, N> > {
   }
 
   using Params = LinearCombinationGenericParams<half_t>;
+
+  CUTLASS_HOST_DEVICE
+  Array<half_t, N> operator()(Array<half_t, N> const &rhs, Params const &params_) const {
+    return this->operator()(rhs);
+  }
 };
 
 template <typename T, int N>
@@ -620,6 +629,11 @@ struct GELU_taylor<Array<T, N> > {
   }
   
   using Params = LinearCombinationGenericParams<T>;
+
+  CUTLASS_HOST_DEVICE
+  Array<T, N> operator()(Array<T, N> const &rhs, Params const &params_) const {
+    return this->operator()(rhs);
+  }
 };
 
 /// Computes backwards pass for GELU operator assuming d_t is the layer gradient and


### PR DESCRIPTION
After commit e773429f7e31db051a67daeb58ed35d20095de9b (PR #622, see [here](https://github.com/NVIDIA/cutlass/commit/e773429f7e31db051a67daeb58ed35d20095de9b#diff-751b5c4a895ed535eb3e6e1fb8196d23e31c554ceaaf75538c162915d165c67aR163)), the invocation of activation functions changes from `activation(intermediate)` to `activation(intermediate, params_)`, but `GELU_taylor` currently has no operator for this invocation.

@kerrmudgeon  @hwu36 @ANIKET-SHIVAM 