### PR TITLE
fix(permute.h): incorrect comment in `Tensor5DPermute20314`

### DIFF
--- a/examples/39_gemm_permute/gemm_permute.cu
+++ b/examples/39_gemm_permute/gemm_permute.cu
@@ -224,7 +224,7 @@ struct Options {
       << " permute([0, 2, 1, 3]) to be in shape of [B/D1, M, D1, N].\n\n"
       << " 2) This example also profiles the performance of a normal GEMM kernel with output as permuted 5D Tensor."
       << " The GEMM matrix output in shape of [M, N]  is reshaped as [M/T1, T1, T2, T3, N/T2/T3] and then permuted"
-      << " with permute([2, 0, 3, 1, 4]) to be in shape of [T2, M/T1, T3, T1, N//T2/T3].\n\n"
+      << " with permute([2, 0, 3, 1, 4]) to be in shape of [T2, M/T1, T3, T1, N/T2/T3].\n\n"
       << " Note: D1, T1, T2, T3 are compile-time constants defined in gemm_permute.cu\n\n"
       << "Options:\n\n"
       << "  --help                      If specified, displays this usage statement.\n\n"

--- a/include/cutlass/layout/permute.h
+++ b/include/cutlass/layout/permute.h
@@ -254,7 +254,7 @@ public:
 };
 
 /// Permute layout function for 5-D permuted tensors with output matrix (dimension as [M, N]) reshaped
-/// as [M/T1, T1, T2, T3, N/(T2*T3)]. Then perform permute([2, 0, 3, 1, 4]) on the corresponding output tensor.
+/// as [M/T1, T1, T2, T3, N/T2/T3]. Then perform permute([2, 0, 3, 1, 4]) on the corresponding output tensor.
 template <int T1, int T2, int T3>
 class Tensor5DPermute20314 {
 public:

--- a/include/cutlass/layout/permute.h
+++ b/include/cutlass/layout/permute.h
@@ -254,7 +254,7 @@ public:
 };
 
 /// Permute layout function for 5-D permuted tensors with output matrix (dimension as [M, N]) reshaped
-/// as [M/T1, T1, T2, T3, N/T3]. Then perform permute([2, 0, 3, 1, 4]) on the corresponding output tensor.
+/// as [M/T1, T1, T2, T3, N/(T2*T3)]. Then perform permute([2, 0, 3, 1, 4]) on the corresponding output tensor.
 template <int T1, int T2, int T3>
 class Tensor5DPermute20314 {
 public:


### PR DESCRIPTION
The last dimension of the new tensor should be N/(T2*T3), otherwise the size of it would be M * N * T2(should be M * N).