### PR TITLE
Auxiliary debugging block

### DIFF
--- a/include/cutlass/gemm/device/gemm.h
+++ b/include/cutlass/gemm/device/gemm.h
@@ -372,7 +372,7 @@ public:
       return Status::kErrorMemoryAllocation;
     }
 
-    int smem_capacity = static_cast<int>(properties.sharedMemPerMultiprocessor);
+    int smem_capacity = static_cast<int>(properties.sharedMemPerBlockOptin);
     if (smem_size > smem_capacity) {
       return Status::kErrorMemoryAllocation;
     }

--- a/include/cutlass/gemm/device/gemm.h
+++ b/include/cutlass/gemm/device/gemm.h
@@ -365,11 +365,15 @@ public:
     
     // MaxDynamicSharedMemorySize must be smaller than the device attribute cudaDevAttrMaxSharedMemoryPerBlockOptin minus the function attribute sharedSizeBytes  
     int smem_size = int(sizeof(typename GemmKernel::SharedStorage));
-    cudaFuncAttributes attr;
-    cudaFuncGetAttributes(&attr, Kernel<GemmKernel>);
-    int max_mem = 0;
-    cudaDeviceGetAttribute(&max_mem, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
-    if (smem_size > (int) (max_mem - attr.sharedSizeBytes)) {
+    cudaDeviceProp properties;
+    result = cudaGetDeviceProperties(&properties, device_idx);
+
+    if (result != cudaSuccess) {
+      return Status::kErrorMemoryAllocation;
+    }
+
+    smem_capacity = static_cast<int>(properties.sharedMemPerMultiprocessor);
+    if (smem_size > smem_capacity) {
       return Status::kErrorMemoryAllocation;
     }
 

--- a/include/cutlass/gemm/device/gemm.h
+++ b/include/cutlass/gemm/device/gemm.h
@@ -364,7 +364,7 @@ public:
     }
     
     // MaxDynamicSharedMemorySize must be smaller than the device attribute cudaDevAttrMaxSharedMemoryPerBlockOptin minus the function attribute sharedSizeBytes  
-    int smem_size = int(sizeof(typename GemmKernel::SharedStorage));
+    int smem_size = static_cast<int>(sizeof(typename GemmKernel::SharedStorage));
     cudaDeviceProp properties;
     result = cudaGetDeviceProperties(&properties, device_idx);
 
@@ -372,7 +372,7 @@ public:
       return Status::kErrorMemoryAllocation;
     }
 
-    smem_capacity = static_cast<int>(properties.sharedMemPerMultiprocessor);
+    int smem_capacity = static_cast<int>(properties.sharedMemPerMultiprocessor);
     if (smem_size > smem_capacity) {
       return Status::kErrorMemoryAllocation;
     }

--- a/include/cutlass/gemm/device/gemm_universal_base.h
+++ b/include/cutlass/gemm/device/gemm_universal_base.h
@@ -276,7 +276,7 @@ public:
           return -1;
         }
 
-        smem_capacity = static_cast<int>(properties.sharedMemPerMultiprocessor);
+        smem_capacity = static_cast<int>(properties.sharedMemPerBlockOptin);
       }
 
       int occupancy = std::min(max_active_blocks, smem_capacity / smem_size);


### PR DESCRIPTION
Add an extra block of code which tests if the required size of dynamically allocated shared memory can be implemented. This is helpful for identifying invalid shapes