### PR TITLE
Fix typos in conv problem sizes

### DIFF
--- a/include/cutlass/conv/conv2d_problem_size.h
+++ b/include/cutlass/conv/conv2d_problem_size.h
@@ -221,12 +221,12 @@ public:
   CUTLASS_HOST_DEVICE
   bool operator==(Conv2dProblemSize const &conv) const {
     return (
-      (N == conv.N) && (W == conv.H) && (W == conv.W) && (C == conv.C) &&
+      (N == conv.N) && (H == conv.H) && (W == conv.W) && (C == conv.C) &&
       (K == conv.K) && (R == conv.R) && (S == conv.S) &&
       (P == conv.P) && (Q == conv.Q) &&
       (pad_h == conv.pad_h) && (pad_w == conv.pad_w) &&
       (stride_h == conv.stride_h) && (stride_w == conv.stride_w) &&
-      (dilation_h == conv.dilation_h) && (dilation_h == conv.dilation_h)
+      (dilation_h == conv.dilation_h) && (dilation_w == conv.dilation_w)
     );  
   }
 

--- a/include/cutlass/conv/conv2d_problem_size.h
+++ b/include/cutlass/conv/conv2d_problem_size.h
@@ -278,7 +278,7 @@ public:
     return (N * P * Q * K);
   }
   
-  /// Returns output extent as Tensor4DCoord
+  /// Returns padding as Tensor4DCoord
   CUTLASS_HOST_DEVICE
   cutlass::Tensor4DCoord padding() const {
 

--- a/include/cutlass/conv/conv3d_problem_size.h
+++ b/include/cutlass/conv/conv3d_problem_size.h
@@ -206,7 +206,7 @@ public:
       (Z == conv.Z) &&(P == conv.P) && (Q == conv.Q) &&
       (pad_d == conv.pad_d) && (pad_h == conv.pad_h) && (pad_w == conv.pad_w) &&
       (stride_d == conv.stride_d) && (stride_h == conv.stride_h) && (stride_w == conv.stride_h) &&
-      (dilation_d == conv.dilation_d) && (dilation_h == conv.dilation_h) && (dilation_h == conv.dilation_h)
+      (dilation_d == conv.dilation_d) && (dilation_h == conv.dilation_h) && (dilation_w == conv.dilation_w)
     );  
   }
 

--- a/include/cutlass/conv/conv3d_problem_size.h
+++ b/include/cutlass/conv/conv3d_problem_size.h
@@ -205,7 +205,7 @@ public:
       (K == conv.K) && (T == conv.T) && (R == conv.R) && (S == conv.S) &&
       (Z == conv.Z) &&(P == conv.P) && (Q == conv.Q) &&
       (pad_d == conv.pad_d) && (pad_h == conv.pad_h) && (pad_w == conv.pad_w) &&
-      (stride_d == conv.stride_d) && (stride_h == conv.stride_h) && (stride_w == conv.stride_h) &&
+      (stride_d == conv.stride_d) && (stride_h == conv.stride_h) && (stride_w == conv.stride_w) &&
       (dilation_d == conv.dilation_d) && (dilation_h == conv.dilation_h) && (dilation_w == conv.dilation_w)
     );  
   }


### PR DESCRIPTION
## What's the problem?

Noticed a few typos on the equality overloaders in Conv2dProblemSize and Conv3dProblemSize.
The former compares height to the target width, and compares dilation_h twice instead of dilation_h and dilation_w.
The latter's just getting dilations wrong.

Haven't really seen it repeated elsewhere but will keep any eye out and commit if I find any.