### PR TITLE
Add const overloads for iterator functions.

### DIFF
--- a/include/cutlass/array.h
+++ b/include/cutlass/array.h
@@ -455,6 +455,11 @@ public:
   }
 
   CUTLASS_HOST_DEVICE
+  const_iterator begin() const {
+    return cbegin();
+  }
+
+  CUTLASS_HOST_DEVICE
   const_iterator cbegin() const {
     return const_iterator(storage);
   }
@@ -462,6 +467,11 @@ public:
   CUTLASS_HOST_DEVICE
   iterator end() {
     return iterator(reinterpret_cast<pointer>(storage + kStorageElements));
+  }
+
+  CUTLASS_HOST_DEVICE
+  const_iterator end() const {
+    return cend();
   }
 
   CUTLASS_HOST_DEVICE
@@ -475,6 +485,11 @@ public:
   }
 
   CUTLASS_HOST_DEVICE
+  const_reverse_iterator rbegin() const {
+    return crbegin();
+  }
+
+  CUTLASS_HOST_DEVICE
   const_reverse_iterator crbegin() const {
     return const_reverse_iterator(reinterpret_cast<const_pointer>(storage + kStorageElements));
   }
@@ -482,6 +497,11 @@ public:
   CUTLASS_HOST_DEVICE
   reverse_iterator rend() {
     return reverse_iterator(reinterpret_cast<pointer>(storage));
+  }
+
+  CUTLASS_HOST_DEVICE
+  const_reverse_iterator rend() const {
+    return crend();
   }
 
   CUTLASS_HOST_DEVICE


### PR DESCRIPTION
This PR adds `const`-correct overloads for `Array::{begin,end,rbegin,rend}`. These overloads are necessary for usage with [the GMock Container Matchers](http://google.github.io/googletest/reference/matchers.html#container-matchers), which cast the `Container` argument to a constant reference.