### PR TITLE
Adds missing semicolon

### DIFF
--- a/include/cutlass/arch/mma.h
+++ b/include/cutlass/arch/mma.h
@@ -70,7 +70,7 @@ struct OpMultiplyAddFastF16 {};
 
 /// Tag indicating the input is converted to 2 (big and small) TF32 components
 //  Perform 3xTF32 or 4xTF32 for every F32 output element
-struct OpMultiplyAddFastF32 {}
+struct OpMultiplyAddFastF32 {};
 
 /// Tag indicating the input is converted to 2 (big and small) TF32 components
 //  Perform 3xTF32 or 4xTF32 for every complex<F32> output element


### PR DESCRIPTION
This PR just adds a missing semicolon to arch/mma.h.

I figured it might not be worth either raising an issue or opening a PR, but the latter just seemed the most efficient.