### PR TITLE
cp async fallback

### DIFF
--- a/include/cutlass/arch/memory_sm80.h
+++ b/include/cutlass/arch/memory_sm80.h
@@ -104,6 +104,40 @@ static const uint32_t OOB_NAN_F16x2 = ((OOB_NAN_F16 << 16) | OOB_NAN_F16);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+/// Fallback specialization for 1 byte copies
+template <
+    /// Cache operation - ignored
+    CacheOperation::Kind cache_op>
+struct cp_async<1, cache_op> {
+
+  /// Copy
+  CUTLASS_DEVICE
+  cp_async(void *smem_ptr, void const *global_ptr, bool pred_guard = true) {
+      using AccessType  = Array<uint8_t, 1>;
+
+      if (pred_guard) {
+        *static_cast<AccessType *>(smem_ptr) = *static_cast<AccessType const *>(global_ptr);
+      }
+  }
+};
+
+/// Fallback specialization for 2 byte copies
+template <
+    /// Cache operation - ignored
+    CacheOperation::Kind cache_op>
+struct cp_async<2, cache_op> {
+
+  /// Copy
+  CUTLASS_DEVICE
+  cp_async(void *smem_ptr, void const *global_ptr, bool pred_guard = true) {
+      using AccessType  = Array<uint8_t, 2>;
+
+      if (pred_guard) {
+        *static_cast<AccessType *>(smem_ptr) = *static_cast<AccessType const *>(global_ptr);
+      }
+  }
+};
+
 /// Partial specialization
 template <
     /// Size of the access in bytes
@@ -140,6 +174,50 @@ struct cp_async<SizeInBytes, CacheOperation::Always> {
         *static_cast<AccessType *>(smem_ptr) = *static_cast<AccessType const *>(global_ptr);
       }
     #endif
+  }
+};
+
+/// Fallback specialization for 1 byte copies
+template <
+    /// Cache operation - ignored
+    CacheOperation::Kind cache_op>
+struct cp_async_zfill<1, cache_op> {
+
+  /// Copy with zero fill
+  CUTLASS_DEVICE
+  cp_async_zfill(void *smem_ptr, void const *global_ptr, bool pred_guard) {
+      using AccessType  = Array<uint8_t, 1>;
+
+      if (pred_guard) {
+        *static_cast<AccessType *>(smem_ptr) = *static_cast<AccessType const *>(global_ptr);
+      }
+      else {
+        AccessType zeros;
+        zeros.clear();
+        *static_cast<AccessType *>(smem_ptr) = zeros;
+      }
+  }
+};
+
+/// Fallback specialization for 2 byte copies
+template <
+    /// Cache operation - ignored
+    CacheOperation::Kind cache_op>
+struct cp_async_zfill<2, cache_op> {
+
+  /// Copy with zero fill
+  CUTLASS_DEVICE
+  cp_async_zfill(void *smem_ptr, void const *global_ptr, bool pred_guard) {
+      using AccessType  = Array<uint8_t, 2>;
+
+      if (pred_guard) {
+        *static_cast<AccessType *>(smem_ptr) = *static_cast<AccessType const *>(global_ptr);
+      }
+      else {
+        AccessType zeros;
+        zeros.clear();
+        *static_cast<AccessType *>(smem_ptr) = zeros;
+      }
   }
 };
 

--- a/include/cutlass/arch/mma.h
+++ b/include/cutlass/arch/mma.h
@@ -70,7 +70,7 @@ struct OpMultiplyAddFastF16 {};
 
 /// Tag indicating the input is converted to 2 (big and small) TF32 components
 //  Perform 3xTF32 or 4xTF32 for every F32 output element
-struct OpMultiplyAddFastF32 {}
+struct OpMultiplyAddFastF32 {};
 
 /// Tag indicating the input is converted to 2 (big and small) TF32 components
 //  Perform 3xTF32 or 4xTF32 for every complex<F32> output element


### PR DESCRIPTION
This PR adds partial specializations to `cp_async` and `cp_async_zfill` for SM80 to fall back to regular access when accessing 1 or 2 bytes (and not 4, 8, 16).

## The problem
Obviously this is just a temporary solution I've found to a problem I was facing. 

In one particular operation I'm working on, which contains a GEMM at the CTA level, the left hand side matrix is never 128 bit aligned. 
The contiguous dimension is actually odd-shaped, and as a result, float and tf32 can do a maximum 4 byte read at a time, but fp16 and bf16 are stuck with 2 byte reads.

I just did these partial specializations that basically defeat the purpose of asynchronous copies, but in a way were my only solution that didn't involve rewriting the GEMM main loop, which I didn't want to do because the rest of the operations deal with 128-bit aligned inputs.

## Other possible solutions

The async copy instruction appears to support arbitrary number of bytes to be written to shared memory, that's how the guard is working. I was thinking about using that and shifting bytes to get 2-byte reads to work, but that obviously introduces a race condition.

## Closing this PR

This is so far the only solution I've been able to think of, that would at least allow the code to compile and run, but obviously the solution is far from ideal.

Instead of starting a discussion, I figured I'd open this, just in case someone has a better solution, in which case I could close or modify this PR accordingly.

If that is not to your liking, feel free to close this.