### PR TITLE
Extend DualGemm: support batched mode + decouple B0/B1 layouts

### DIFF
--- a/examples/41_fused_multi_head_attention/kernel_forward.h
+++ b/examples/41_fused_multi_head_attention/kernel_forward.h
@@ -163,8 +163,6 @@ struct AttentionKernel {
     int32_t num_heads;
 
     CUTLASS_HOST_DEVICE int32_t o_strideM() const {
-      // Note: Note in sync with cutlass' main branch!! Make sure to apply
-      // when updating cutlass.
       return head_dim_value * num_heads;
     }
 

--- a/examples/41_fused_multi_head_attention/kernel_forward.h
+++ b/examples/41_fused_multi_head_attention/kernel_forward.h
@@ -163,7 +163,9 @@ struct AttentionKernel {
     int32_t num_heads;
 
     CUTLASS_HOST_DEVICE int32_t o_strideM() const {
-      return head_dim_value;
+      // Note: Note in sync with cutlass' main branch!! Make sure to apply
+      // when updating cutlass.
+      return head_dim_value * num_heads;
     }
 
     // Moves pointers to what we should process

--- a/examples/41_fused_multi_head_attention/kernel_forward.h
+++ b/examples/41_fused_multi_head_attention/kernel_forward.h
@@ -163,7 +163,7 @@ struct AttentionKernel {
     int32_t num_heads;
 
     CUTLASS_HOST_DEVICE int32_t o_strideM() const {
-      return head_dim_value * num_heads;
+      return head_dim_value;
     }
 
     // Moves pointers to what we should process

--- a/examples/45_dual_gemm/dual_gemm.cu
+++ b/examples/45_dual_gemm/dual_gemm.cu
@@ -43,8 +43,6 @@ D2 = element_wise(D0, D1)
     D0 and D1 will be optionally stored in gmem (`kStoreD0` / `kStoreD1`)
 */
 
-// #define IS_PROFILING
-
 #include <iostream>
 
 #include "cutlass/cutlass.h"
@@ -66,10 +64,12 @@ D2 = element_wise(D0, D1)
 ////////////////////////////////////////////////////////////////////////////////
 
 cutlass::gemm::GemmCoord problem_size(4096, 4096, 8192);
+cutlass::gemm::GemmCoord batch_problem_size(321, 256, 512);
 
 constexpr int kStages = 3;
 constexpr bool kSplitKSerial = false;
 constexpr bool kUseBias = true;
+constexpr int kBatchCount = 37;
 
 
 #if 0
@@ -165,7 +165,16 @@ bool run_nonfused_gemm_f16_sm80() {
   NonFusedDualGemmRun<Gemm0, Gemm1> nonFusedGemm;
 
   std::cout << "Running Non-fused GEMMs FP16 TN GEMMs...\n";
-  bool pass = nonFusedGemm.run(problem_size, alpha0, beta0, alpha1, beta1);
+
+  bool pass = nonFusedGemm.run(
+    problem_size, 
+    alpha0, 
+    beta0, 
+    alpha1, 
+    beta1,
+    true  /* is_profiling */
+  );
+
   if(pass)
     std::cout << "Pass\n";
   else
@@ -246,14 +255,78 @@ bool run_fused_gemm_f16_sm80_shmem() {
 
 }
 
+bool run_batched_fused_gemm_f16_sm80_shmem() {
+  using ThreadblockShape = cutlass::gemm::GemmShape<128, 64, 32>;
+  using WarpShape = cutlass::gemm::GemmShape<64, 32, 32>;
+  using InstructionShape = cutlass::gemm::GemmShape<16, 8, 16>;
+
+  // Optionally, we might not need intermediate GEMM outputs
+  constexpr bool kStoreD0 = true;
+  constexpr bool kStoreD1 = true;
+
+  using DualGemm = cutlass::gemm::device::DualGemm<
+    ElementOperandA,
+    cutlass::layout::RowMajor,
+    ElementOperandB,
+    cutlass::layout::ColumnMajor,
+    ElementOutput,
+    cutlass::layout::RowMajor,
+    ElementAccumulator,
+    cutlass::arch::OpClassTensorOp,
+    cutlass::arch::Sm80,
+    ThreadblockShape,
+    WarpShape,
+    InstructionShape,
+    EpilogueOutputOp0,
+    EpilogueOutputOp1,
+    EpilogueOutputOp2,
+    cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<1>,
+    kStages,
+    kStoreD0,
+    kStoreD1,
+    kSplitKSerial
+  >;
+
+  DualFusedGemmRun<DualGemm> fusedGemm;
+
+  std::cout << "Running Batched Fused FP16 TN GEMMs + Epilogue2...\n";
+
+  bool passed = fusedGemm.run(
+    batch_problem_size, 
+    alpha0, 
+    beta0, 
+    alpha1, 
+    beta1, 
+    kBatchCount,
+    false  /* is_profiling */
+  );
+
+  if(passed)
+    std::cout << "Pass\n";
+  else
+    std::cout << "Fail\n";
+
+  return passed;
+
+}
+
 int main() {
 
   std::vector<bool (*)()>funcs = {
     &run_nonfused_gemm_f16_sm80,
-    &run_fused_gemm_f16_sm80_shmem
+    &run_fused_gemm_f16_sm80_shmem,
+    &run_batched_fused_gemm_f16_sm80_shmem
   };
 
-  std::string test_name = "dual-gemm f16 bias=" + std::to_string(kUseBias) + " split_k_serial=" + std::to_string(kSplitKSerial);
+  std::string test_name = (
+    "dual-gemm f16 bias=" + 
+    std::to_string(kUseBias) + 
+    " split_k_serial=" + 
+    std::to_string(kSplitKSerial) +
+    " batch_count=" + 
+    std::to_string(kBatchCount)
+  );
+
   return testRun(80, funcs, test_name);
 }
 

--- a/examples/45_dual_gemm/dual_gemm_common.h
+++ b/examples/45_dual_gemm/dual_gemm_common.h
@@ -1,0 +1,52 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Defines common types used for all DualGemm operators.
+*/
+#pragma once
+
+namespace cutlass {
+namespace gemm {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+enum class DualGemmMode {
+  kGemm,
+  kBatched,
+  kInvalid
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace gemm
+} // namespace cutlass
+
+////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/45_dual_gemm/dual_gemm_run.h
+++ b/examples/45_dual_gemm/dual_gemm_run.h
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <type_traits>
 
 #include "cutlass/util/host_tensor.h"
 #include "cutlass/util/tensor_view_io.h"
@@ -44,6 +45,10 @@
 #include "cutlass/util/reference/device/gemm.h"
 #include "cutlass/util/reference/device/tensor_relu.h"
 
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/device/gemm_universal.h"
+
+#include "dual_gemm_common.h"
 #include "helper.h"
 
 #define CHECK_GT(val1, val2) \
@@ -205,6 +210,7 @@ struct NonFusedDualGemmRun
     ElementCompute beta0 = ElementCompute(0),
     ElementCompute alpha1 = ElementCompute(1),
     ElementCompute beta1 = ElementCompute(0),
+    bool is_profiling = true,
     bool relu = false,
     int warm_ups = 1,
     int runs = 100) {
@@ -335,40 +341,41 @@ struct NonFusedDualGemmRun
         status = gemm_op_1();
         CUTLASS_CHECK(status);
     }
-#ifdef IS_PROFILING
-    return true;
-#endif
-    //
-    // Run the GEMM
-    //
-    cudaEvent_t start, stop1, stop2;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop1);
-    cudaEventCreate(&stop2);
 
-    cudaEventRecord(start);
+    if (is_profiling) {
+      //
+      // Profile the GEMM
+      //
 
-    for(int i = 0; i < runs; i++) {
-        status = gemm_op_0();
-    
-        CUTLASS_CHECK(status);
+      cudaEvent_t start, stop1, stop2;
+      cudaEventCreate(&start);
+      cudaEventCreate(&stop1);
+      cudaEventCreate(&stop2);
+
+      cudaEventRecord(start);
+
+      for(int i = 0; i < runs; i++) {
+          status = gemm_op_0();
+      
+          CUTLASS_CHECK(status);
+      }
+      cudaEventRecord(stop1);
+      for(int i = 0; i < runs; i++) {
+          status = gemm_op_1();
+      
+          CUTLASS_CHECK(status);
+      }
+
+      cudaEventRecord(stop2);
+      cudaDeviceSynchronize();
+      float gemm0Time, gemm1Time, totalTime;
+      cudaEventElapsedTime(&gemm0Time, start, stop1);
+      cudaEventElapsedTime(&gemm1Time, stop1, stop2);
+      cudaEventElapsedTime(&totalTime, start, stop2);
+      std::cout << "gemm 0 time " << gemm0Time / (float)runs << " ms\n";
+      std::cout << "gemm 1 time " << gemm1Time / (float)runs << " ms\n";
+      std::cout << "Non-fusion GEMM only time " << totalTime / (float)runs << " ms\n";
     }
-    cudaEventRecord(stop1);
-    for(int i = 0; i < runs; i++) {
-        status = gemm_op_1();
-    
-        CUTLASS_CHECK(status);
-    }
-
-    cudaEventRecord(stop2);
-    cudaDeviceSynchronize();
-    float gemm0Time, gemm1Time, totalTime;
-    cudaEventElapsedTime(&gemm0Time, start, stop1);
-    cudaEventElapsedTime(&gemm1Time, stop1, stop2);
-    cudaEventElapsedTime(&totalTime, start, stop2);
-    std::cout << "gemm 0 time " << gemm0Time / (float)runs << " ms\n";
-    std::cout << "gemm 1 time " << gemm1Time / (float)runs << " ms\n";
-    std::cout << "Non-fusion GEMM only time " << totalTime / (float)runs << " ms\n";
 
     tensor_D0.sync_host();
     tensor_D1.sync_host();
@@ -543,6 +550,8 @@ struct DualFusedGemmRun
     ElementCompute beta0 = ElementCompute(1),
     ElementCompute alpha1 = ElementCompute(1),
     ElementCompute beta1 = ElementCompute(1),
+    int batch_count = 1,
+    bool is_profiling = true,
     bool relu = false,
     int warm_ups = 1,
     int runs = 100) {
@@ -553,55 +562,88 @@ struct DualFusedGemmRun
 
     cutlass::HostTensor<
       typename DualGemm::ElementA,
-      typename DualGemm::LayoutA> tensor_A0(problem_size.mk());
+      typename DualGemm::LayoutA> tensor_A0(
+        std::is_same<typename DualGemm::LayoutA, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.k()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.k()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementB,
-      typename DualGemm::LayoutB> tensor_B0(problem_size.kn());
+      typename DualGemm::LayoutB> tensor_B0(
+        std::is_same<typename DualGemm::LayoutB, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.k(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.k(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> tensor_C0(problem_size.mn());
+      typename DualGemm::LayoutC> tensor_C0(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutScaleBias> tensor_Bias0({1, problem_size.n()});
+      typename DualGemm::LayoutScaleBias> tensor_Bias0({batch_count, problem_size.n()});
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> tensor_D0(problem_size.mn());
+      typename DualGemm::LayoutC> tensor_D0(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> reference_D0(problem_size.mn());
+      typename DualGemm::LayoutC> reference_D0(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementB,
-      typename DualGemm::LayoutB> tensor_B1(problem_size.kn());
+      typename DualGemm::LayoutB> tensor_B1(
+        std::is_same<typename DualGemm::LayoutB, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.k(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.k(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> tensor_C1(problem_size.mn());
+      typename DualGemm::LayoutC> tensor_C1(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutScaleBias> tensor_Bias1({1, problem_size.n()});
+      typename DualGemm::LayoutScaleBias> tensor_Bias1({batch_count, problem_size.n()});
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> tensor_D1(problem_size.mn());
+      typename DualGemm::LayoutC> tensor_D1(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> tensor_D2(problem_size.mn());
+      typename DualGemm::LayoutC> tensor_D2(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> reference_D1(problem_size.mn());
+      typename DualGemm::LayoutC> reference_D1(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     cutlass::HostTensor<
       typename DualGemm::ElementC,
-      typename DualGemm::LayoutC> reference_D2(problem_size.mn());
+      typename DualGemm::LayoutC> reference_D2(
+        std::is_same<typename DualGemm::LayoutC, cutlass::layout::RowMajor>::value ? 
+          cutlass::MatrixCoord(batch_count * problem_size.m(), problem_size.n()) : 
+          cutlass::MatrixCoord(problem_size.m(), batch_count * problem_size.n()));
 
     CHECK_TRUE(initialize_tensor(tensor_A0.host_view(), init_A, seed + 2019));
     CHECK_TRUE(initialize_tensor(tensor_B0.host_view(), init_B, seed + 2118));
@@ -639,6 +681,15 @@ struct DualFusedGemmRun
     reference_D2.sync_device();
 
     //
+    // Batch strides (irrelevant when batch_count == 1)
+    //
+
+    int64_t batch_stride_A = problem_size.m() * problem_size.k();
+    int64_t batch_stride_B = problem_size.k() * problem_size.n();
+    int64_t batch_stride_Bias = problem_size.n();
+    int64_t batch_stride_D = problem_size.m() * problem_size.n();
+
+    //
     // Initialize the GEMM operator
     //
 
@@ -652,6 +703,9 @@ struct DualFusedGemmRun
       ref_B1 = {tensor_Bias1.device_data(), typename DualGemm::LayoutC::Stride(0)};
     }
     typename DualGemm::Arguments arguments{
+      (batch_count > 1 ? 
+        cutlass::gemm::DualGemmMode::kBatched : 
+        cutlass::gemm::DualGemmMode::kGemm),
       problem_size,
       tensor_A0.device_ref(),
       tensor_B0.device_ref(),
@@ -664,8 +718,17 @@ struct DualFusedGemmRun
       {alpha0, beta0},
       {alpha1, beta1},
       {},
-      split_k_slices
+      split_k_slices,
+      batch_count,
+      batch_stride_A,
+      batch_stride_B,
+      batch_stride_Bias,
+      batch_stride_D,
     };
+
+    //
+    // Run the GEMM
+    //
 
     DualGemm b2b_gemm_op;
 
@@ -684,30 +747,28 @@ struct DualFusedGemmRun
         CUTLASS_CHECK(status);
     }
 
-#ifdef IS_PROFILING
-    return true;
-#endif
-    //
-    // Run the GEMM
-    //
+    if (is_profiling) {
+      //
+      // Profile the GEMM
+      //
 
-    cudaEvent_t start, stop;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
+      cudaEvent_t start, stop;
+      cudaEventCreate(&start);
+      cudaEventCreate(&stop);
 
-    cudaEventRecord(start);
+      cudaEventRecord(start);
 
-    for(int i = 0; i < runs; i++) {
-        status = b2b_gemm_op();
+      for(int i = 0; i < runs; i++) {
+          status = b2b_gemm_op();
+          CUTLASS_CHECK(status);
+      }
 
-        CUTLASS_CHECK(status);
+      cudaEventRecord(stop);
+      cudaDeviceSynchronize();
+      float gemmTime;
+      cudaEventElapsedTime(&gemmTime, start, stop);
+      std::cout << "Fusion time " << gemmTime / (float)runs << " ms\n";
     }
-
-    cudaEventRecord(stop);
-    cudaDeviceSynchronize();
-    float gemmTime;
-    cudaEventElapsedTime(&gemmTime, start, stop);
-    std::cout << "Fusion time " << gemmTime / (float)runs << " ms\n";
 
     tensor_D0.sync_host();
     tensor_D1.sync_host();
@@ -717,45 +778,72 @@ struct DualFusedGemmRun
     // Verify
     //
 
-    cutlass::reference::device::Gemm<
-        typename DualGemm::ElementA, typename DualGemm::LayoutA,
-        typename DualGemm::ElementB, typename DualGemm::LayoutB,
-        typename DualGemm::ElementC, typename DualGemm::LayoutC, 
-        ElementAccumulator, ElementAccumulator>
-        reference_gemm_0;
+    using GemmUniversal = cutlass::gemm::device::GemmUniversal<
+      typename DualGemm::ElementA, typename DualGemm::LayoutA,
+      typename DualGemm::ElementB, typename DualGemm::LayoutB,
+      typename DualGemm::ElementC, typename DualGemm::LayoutC, 
+      ElementAccumulator
+    >;
 
-    cutlass::reference::device::Gemm<
-        typename DualGemm::ElementA, typename DualGemm::LayoutA,
-        typename DualGemm::ElementB, typename DualGemm::LayoutB,
-        typename DualGemm::ElementC, typename DualGemm::LayoutC, ElementCompute,
-        ElementAccumulator, typename DualGemm::Operator>
-        reference_gemm_1;
+    GemmUniversal reference_gemm;
 
-    reference_gemm_0(
+    typename GemmUniversal::Arguments args0 {
+      (batch_count > 1 ? 
+        cutlass::gemm::GemmUniversalMode::kBatched : 
+        cutlass::gemm::GemmUniversalMode::kGemm),
       problem_size,
-      alpha0,
-      tensor_A0.device_ref(), 
-      tensor_B0.device_ref(), 
-      beta0,
-      {tensor_Bias0.device_data(), typename DualGemm::LayoutC::Stride(0)},
-      reference_D0.device_ref()
-    );
+      batch_count,
+      {alpha0, beta0},
+      tensor_A0.device_data(),
+      tensor_B0.device_data(),
+      tensor_Bias0.device_data(),
+      reference_D0.device_data(),
+      batch_stride_A,
+      batch_stride_B,
+      batch_stride_Bias,
+      batch_stride_D,
+      tensor_A0.stride(0),
+      tensor_B0.stride(0),
+      0,  // zero stride for the bias vector
+      reference_D0.stride(0),
+    };
+
+    status = reference_gemm.can_implement(args0);
+    CUTLASS_CHECK(status);
+    status = reference_gemm(args0);
+    CUTLASS_CHECK(status);
+
+    typename GemmUniversal::Arguments args1 {
+      (batch_count > 1 ? 
+        cutlass::gemm::GemmUniversalMode::kBatched : 
+        cutlass::gemm::GemmUniversalMode::kGemm),
+      problem_size,
+      batch_count,
+      {alpha1, beta1},
+      tensor_A0.device_data(),
+      tensor_B1.device_data(),
+      tensor_Bias1.device_data(),
+      reference_D1.device_data(),
+      batch_stride_A,
+      batch_stride_B,
+      batch_stride_Bias,
+      batch_stride_D,
+      tensor_A0.stride(0),
+      tensor_B1.stride(0),
+      0,  // zero stride for the bias vector
+      reference_D1.stride(0),
+    };
+
+    status = reference_gemm.can_implement(args1);
+    CUTLASS_CHECK(status);
+    status = reference_gemm(args1);
+    CUTLASS_CHECK(status);
+
     if(relu) {
        cutlass::reference::device::TensorReLu(reference_D0.device_view()); 
-    }
-
-    reference_gemm_1(
-      problem_size,
-      alpha1, 
-      tensor_A0.device_ref(), 
-      tensor_B1.device_ref(), 
-      beta1,
-      {tensor_Bias1.device_data(), typename DualGemm::LayoutC::Stride(0)},
-      reference_D1.device_ref()
-    );
-    if(relu) {
        cutlass::reference::device::TensorReLu(reference_D1.device_view()); 
     }
+
     TensorEpilogueForEach<EpilogueOutputOp2>(reference_D0.device_view(), reference_D1.device_view(), reference_D2.device_view());
     cudaDeviceSynchronize();
     reference_D0.sync_host();

--- a/examples/45_dual_gemm/kernel/dual_gemm.h
+++ b/examples/45_dual_gemm/kernel/dual_gemm.h
@@ -42,6 +42,7 @@
 
 #include "../threadblock/dual_mma_multistage.h"
 #include "../threadblock/dual_epilogue.h"
+#include "../dual_gemm_common.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -92,6 +93,10 @@ struct DualGemm {
       true // IterationsUnroll
   >;
 
+  using ElementA = typename DualMma::IteratorA::Element;
+  using ElementB = typename DualMma::IteratorB::Element;
+  using ElementC = typename DualEpilogue::OutputTileIterator::Element;
+
   static bool const kSplitKSerial = SplitKSerial;
   static_assert(!kSplitKSerial || (kStoreD0 && kStoreD1),
     "Split-K serial requires buffers for D0/D1 for reduction");
@@ -102,6 +107,7 @@ struct DualGemm {
 
   /// Parameters structure
   struct Params {
+    DualGemmMode mode;
     cutlass::gemm::GemmCoord problem_size;
     cutlass::gemm::GemmCoord grid_tiled_shape;
     int swizzle_log_tile;
@@ -133,6 +139,11 @@ struct DualGemm {
     int *semaphore;
     int gemm_k_size;
 
+    int64_t batch_stride_A;
+    int64_t batch_stride_B;
+    int64_t batch_stride_C;
+    int64_t batch_stride_D;
+
     //
     // Methods
     //
@@ -142,6 +153,7 @@ struct DualGemm {
 
     CUTLASS_HOST_DEVICE
     Params(
+      DualGemmMode mode,
       cutlass::gemm::GemmCoord const & problem_size,
       cutlass::gemm::GemmCoord const & grid_tiled_shape,
       // Mma0: D0 = A @ B0 + C0
@@ -158,8 +170,13 @@ struct DualGemm {
       typename OutputOp0::Params output_op_0 = typename OutputOp0::Params(),
       typename OutputOp1::Params output_op_1 = typename OutputOp1::Params(),
       typename OutputOp2::Params output_op_2 = typename OutputOp2::Params(),
-      int *workspace = nullptr
+      int *workspace = nullptr,
+      int64_t batch_stride_A = 1,
+      int64_t batch_stride_B = 1,
+      int64_t batch_stride_C = 1,
+      int64_t batch_stride_D = 1
     ):
+      mode(mode),
       problem_size(problem_size),
       grid_tiled_shape(grid_tiled_shape),
       swizzle_log_tile(ThreadblockSwizzle().get_log_tile(grid_tiled_shape)),
@@ -183,13 +200,17 @@ struct DualGemm {
       ref_D2(ref_D2),
       output_op_0(output_op_0),
       output_op_1(output_op_1),
-      output_op_2(output_op_2) {
+      output_op_2(output_op_2),
+      batch_stride_A(batch_stride_A),
+      batch_stride_B(batch_stride_B),
+      batch_stride_C(batch_stride_C),
+      batch_stride_D(batch_stride_D) {
 
       int total_gemm_k_iterations = (problem_size.k() + DualMma::Shape::kK - 1) / DualMma::Shape::kK;
       int gemm_k_iterations = (total_gemm_k_iterations + grid_tiled_shape.k() - 1) / grid_tiled_shape.k();
       gemm_k_size = gemm_k_iterations * DualMma::Shape::kK;
 
-    semaphore = workspace;
+      semaphore = workspace;
     }
   };
 
@@ -273,30 +294,44 @@ struct DualGemm {
       return;
     }
 
+    int offset_k = 0;
+    int problem_size_k = params.problem_size.k();
+
+    ElementA *ptr_A0 = static_cast<ElementA *>(params.ref_A0.data()); 
+    ElementB *ptr_B0 = static_cast<ElementB *>(params.ref_B0.data());
+    ElementB *ptr_B1 = static_cast<ElementB *>(params.ref_B1.data());
+
+    //
+    // Fetch pointers based on mode.
+    //
+    if (params.mode == DualGemmMode::kGemm) {
+      if (threadblock_tile_offset.k() + 1 < params.grid_tiled_shape.k()) {
+        problem_size_k = (threadblock_tile_offset.k() + 1) * params.gemm_k_size; 
+      }
+
+      offset_k = threadblock_tile_offset.k() * params.gemm_k_size;
+    }
+    else if (params.mode == DualGemmMode::kBatched) {
+      ptr_A0 += threadblock_tile_offset.k() * params.batch_stride_A;
+      ptr_B0 += threadblock_tile_offset.k() * params.batch_stride_B;
+      ptr_B1 += threadblock_tile_offset.k() * params.batch_stride_B;
+    }
+
     // Compute initial location in logical coordinates
     cutlass::MatrixCoord tb_offset_A0{
       threadblock_tile_offset.m() * DualMma::Shape::kM,
-      threadblock_tile_offset.k() * params.gemm_k_size,
+      offset_k,
     };
 
     cutlass::MatrixCoord tb_offset_B0{
-      threadblock_tile_offset.k() * params.gemm_k_size,
+      offset_k,
       threadblock_tile_offset.n() * DualMma::Shape::kN
     };
 
     cutlass::MatrixCoord tb_offset_B1{
-      threadblock_tile_offset.k() * params.gemm_k_size,
+      offset_k,
       threadblock_tile_offset.n() * DualMma::Shape::kN
     };
-
-    // Problem size is a function of threadblock index in the K dimension
-    int problem_size_k =
-      (params.problem_size.k() < (threadblock_tile_offset.k() + 1) * params.gemm_k_size) ?
-       params.problem_size.k() :
-       (threadblock_tile_offset.k() + 1) * params.gemm_k_size;
-
-    // Compute threadblock-scoped matrix multiply-add
-    int gemm_k_iterations = (problem_size_k - tb_offset_A0.column() + DualMma::Shape::kK - 1) / DualMma::Shape::kK;
 
     // Compute position within threadblock
     int thread_idx = threadIdx.x;
@@ -304,21 +339,21 @@ struct DualGemm {
     // Construct iterators to A and B operands
     typename DualMma::IteratorA iterator_A0(
       params.params_A0,
-      params.ref_A0.data(),
+      ptr_A0,
       {params.problem_size.m(), problem_size_k},
       thread_idx,
       tb_offset_A0);
 
     typename DualMma::IteratorB iterator_B0(
       params.params_B0,
-      params.ref_B0.data(),
+      ptr_B0,
       {problem_size_k, params.problem_size.n()},
       thread_idx,
       tb_offset_B0);
 
     typename DualMma::IteratorB iterator_B1(
       params.params_B1,
-      params.ref_B1.data(),
+      ptr_B1,
       {problem_size_k, params.problem_size.n()},
       thread_idx,
       tb_offset_B1);
@@ -339,6 +374,9 @@ struct DualGemm {
     typename DualMma::FragmentC accum1;
     accum0.clear();
     accum1.clear();
+
+    // Compute threadblock-scoped matrix multiply-add
+    int gemm_k_iterations = (problem_size_k - offset_k + DualMma::Shape::kK - 1) / DualMma::Shape::kK;
 
     DualMma mma(shared_storage.main_loop, thread_idx, warp_idx, lane_idx);
     if (!kSplitKSerial || gemm_k_iterations > 0) {
@@ -372,31 +410,46 @@ struct DualGemm {
 
     int block_idx = threadblock_tile_offset.m() + threadblock_tile_offset.n() * params.grid_tiled_shape.m();
 
+    ElementC *ptr_C0 = static_cast<ElementC *>(params.ref_C0.data()); 
+    ElementC *ptr_C1 = static_cast<ElementC *>(params.ref_C1.data()); 
+    ElementC *ptr_D0 = static_cast<ElementC *>(params.ref_D0.data()); 
+    ElementC *ptr_D1 = static_cast<ElementC *>(params.ref_D1.data()); 
+    ElementC *ptr_D2 = static_cast<ElementC *>(params.ref_D2.data()); 
+
     // Construct the semaphore.
     Semaphore semaphore(params.semaphore + block_idx, thread_idx);
 
-    // If performing a reduction via split-K, fetch the initial synchronization
-    if (kSplitKSerial && params.grid_tiled_shape.k() > 1) {
-      
-      // Fetch the synchronization lock initially but do not block.
-      semaphore.fetch();
+    if (params.mode == DualGemmMode::kGemm) {
+      // If performing a reduction via split-K, fetch the initial synchronization
+      if (kSplitKSerial && params.grid_tiled_shape.k() > 1) {
+        
+        // Fetch the synchronization lock initially but do not block.
+        semaphore.fetch();
 
-      // Indicate which position in a serial reduction the output operator is currently updating
-      output_op_0.set_k_partition(threadblock_tile_offset.k(), params.grid_tiled_shape.k());
-      output_op_1.set_k_partition(threadblock_tile_offset.k(), params.grid_tiled_shape.k());
+        // Indicate which position in a serial reduction the output operator is currently updating
+        output_op_0.set_k_partition(threadblock_tile_offset.k(), params.grid_tiled_shape.k());
+        output_op_1.set_k_partition(threadblock_tile_offset.k(), params.grid_tiled_shape.k());
+      }
+    }
+    else if (params.mode == DualGemmMode::kBatched) {
+      ptr_C0 += threadblock_tile_offset.k() * params.batch_stride_C;
+      ptr_C1 += threadblock_tile_offset.k() * params.batch_stride_C;
+      ptr_D0 += threadblock_tile_offset.k() * params.batch_stride_D;
+      ptr_D1 += threadblock_tile_offset.k() * params.batch_stride_D;
+      ptr_D2 += threadblock_tile_offset.k() * params.batch_stride_D;
     }
 
     // Tile iterator loading from source tensor.
     typename Epilogue0::OutputTileIterator iterator_C0(
       params.params_C0,
-      params.ref_C0.data(),
+      ptr_C0,
       params.problem_size.mn(),
       thread_idx,
       threadblock_offset
     );
     typename Epilogue1::OutputTileIterator iterator_C1(
       params.params_C1,
-      params.ref_C1.data(),
+      ptr_C1,
       params.problem_size.mn(),
       thread_idx,
       threadblock_offset
@@ -405,21 +458,21 @@ struct DualGemm {
     // Tile iterator writing to destination tensor.
     typename Epilogue0::OutputTileIterator iterator_D0(
       params.params_D0,
-      params.ref_D0.data(),
+      ptr_D0,
       params.problem_size.mn(),
       thread_idx,
       threadblock_offset
     );
     typename Epilogue1::OutputTileIterator iterator_D1(
       params.params_D1,
-      params.ref_D1.data(),
+      ptr_D1,
       params.problem_size.mn(),
       thread_idx,
       threadblock_offset
     );
     typename Epilogue1::OutputTileIterator iterator_D2(
       params.params_D2,
-      params.ref_D2.data(),
+      ptr_D2,
       params.problem_size.mn(),
       thread_idx,
       threadblock_offset


### PR DESCRIPTION
The two extensions are suggested for the `DualGemm` in the `examples/45_dual_gemm` folder:

1. Following the `GemmUniversalMode::kBatched` [implementation](https://github.com/NVIDIA/cutlass/blob/add4ba622f1cdebc145d1df0e9620c3c84c00a52/include/cutlass/gemm/kernel/gemm_universal.h#L481), batched mode is added to the `DualGemm`. `DualGemmMode::kBatched` and `SplitKSerial` are incompatible: `Status::kErrorInvalidProblem` is returned if both are set.

2. The `DualGemm` template currently assumes the same layout, `LayoutB`, for both right operand matrices `B0` and `B1`. This is problematic if the layouts of the two matrices are different. In particular, this may be the case when one of the matrices is row-major, while the other is a (column) vector that has to be broadcasted in column-major with zero stride (e.g., as `{B1.device_data(), 0}`) for the `DualGemm` implementation to be able to process `B0` and `B1` simultaneously. In this PR, `LayoutB0` and `LayoutB1` are decoupled throughout the `DualGemm` code (device, kernel, and mma). The batch strides of `B0` and `B1` are also decoupled to accommodate the column vector `B1` case described above.

The unit tests in `dual_gemm.cu` are extended accordingly.

Plus a bug fix in the MHA kernel.