### PR TITLE
Fix type bug in conv2d/gemm with broadcast

### DIFF
--- a/include/cutlass/conv/kernel/default_conv2d_fprop_with_broadcast.h
+++ b/include/cutlass/conv/kernel/default_conv2d_fprop_with_broadcast.h
@@ -107,7 +107,7 @@ struct DefaultConv2dFpropWithBroadcast {
     ImplicitGemmBase::Epilogue::kPartitionsK,
     ElementC,
     typename EpilogueOutputOp::ElementT,
-    ElementC,
+    typename EpilogueOutputOp::ElementCompute,
     EpilogueOutputOp,
     ImplicitGemmBase::Epilogue::kElementsPerAccess
   >::Epilogue;

--- a/include/cutlass/conv/kernel/default_conv2d_fprop_with_broadcast.h
+++ b/include/cutlass/conv/kernel/default_conv2d_fprop_with_broadcast.h
@@ -107,7 +107,7 @@ struct DefaultConv2dFpropWithBroadcast {
     ImplicitGemmBase::Epilogue::kPartitionsK,
     ElementC,
     typename EpilogueOutputOp::ElementT,
-    typename EpilogueOutputOp::ElementCompute,
+    typename EpilogueOutputOp::ElementVector,
     EpilogueOutputOp,
     ImplicitGemmBase::Epilogue::kElementsPerAccess
   >::Epilogue;

--- a/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
+++ b/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
@@ -61,7 +61,8 @@ template <
   typename ElementT_,
   int ElementsPerAccess,
   typename ElementwiseOp_ = Identity<ElementCompute_>,
-  typename BinaryOp_ = plus<ElementCompute_>
+  typename BinaryOp_ = plus<ElementCompute_>,
+  typename ElementVector_ = ElementC_
 >
 class LinearCombinationBiasElementwise {
 public:
@@ -72,6 +73,7 @@ public:
   using ElementCompute = ElementCompute_;
   using ElementZ = ElementZ_;
   using ElementT = ElementT_;
+  using ElementVector = ElementVector_;
   static int const kElementsPerAccess = ElementsPerAccess;
   static int const kCount = kElementsPerAccess;
 

--- a/include/cutlass/epilogue/thread/linear_combination_bias_relu.h
+++ b/include/cutlass/epilogue/thread/linear_combination_bias_relu.h
@@ -204,7 +204,8 @@ template <
   typename ElementCompute_,
   typename ElementZ_,
   int ElementsPerAccess,
-  bool StoreT = true
+  bool StoreT = true,
+  typename ElementVector_ = ElementC_
 >
 class LinearCombinationBiasRelu {
 public:
@@ -214,6 +215,7 @@ public:
   using ElementAccumulator = ElementAccumulator_;
   using ElementCompute = ElementCompute_;
   using ElementZ = ElementZ_;
+  using ElementVector = ElementVector_;
 
   using ElementT = uint1b_t;
 

--- a/include/cutlass/epilogue/thread/linear_combination_residual_block.h
+++ b/include/cutlass/epilogue/thread/linear_combination_residual_block.h
@@ -59,7 +59,8 @@ template <typename ElementOutput_, typename ElementAccumulator_,
           template <typename T> class ActivationOp_,
           template <typename T> class BinaryOp1_,
           template <typename T> class UnaryOp_,
-          template <typename T> class BinaryOp2_ = detail::NoOp>
+          template <typename T> class BinaryOp2_ = detail::NoOp,
+          typename ElementVector_ = ElementC_>
 class LinearCombinationResidualBlock {
 public:
   static bool const kIsSingleSource = false;
@@ -68,6 +69,7 @@ public:
   using ElementC = ElementC_;
   using ElementAccumulator = ElementAccumulator_;
   using ElementCompute = ElementCompute_;
+  using ElementVector = ElementVector_;
   static int const kElementsPerAccess = ElementsPerAccess;
   static int const kCount = kElementsPerAccess;
 
@@ -179,11 +181,12 @@ template <typename ElementOutput_, typename ElementAccumulator_,
           typename ElementCompute_, typename ElementC_, int ElementsPerAccess,
           template <typename T> class ActivationOp_,
           template <typename T> class BinaryOp1_,
-          template <typename T> class UnaryOp_>
+          template <typename T> class UnaryOp_,
+          typename ElementVector_>
 class LinearCombinationResidualBlock<ElementOutput_, ElementAccumulator_,
           ElementCompute_, ElementC_, ElementsPerAccess,
           ActivationOp_, BinaryOp1_, UnaryOp_,
-          detail::NoOp> {
+          detail::NoOp, ElementVector_> {
 public:
   static bool const kIsSingleSource = true;
 
@@ -191,6 +194,7 @@ public:
   using ElementC = ElementC_;
   using ElementAccumulator = ElementAccumulator_;
   using ElementCompute = ElementCompute_;
+  using ElementVector = ElementVector_;
   static int const kElementsPerAccess = ElementsPerAccess;
   static int const kCount = kElementsPerAccess;
 

--- a/include/cutlass/gemm/kernel/default_gemm_with_broadcast.h
+++ b/include/cutlass/gemm/kernel/default_gemm_with_broadcast.h
@@ -121,7 +121,7 @@ struct DefaultGemmWithBroadcast {
     GemmBase::Epilogue::kPartitionsK,
     ElementC_,
     typename EpilogueOutputOp::ElementT,
-    typename EpilogueOutputOp::ElementCompute,
+    typename EpilogueOutputOp::ElementVector,
     EpilogueOutputOp,
     GemmBase::Epilogue::kElementsPerAccess
   >::Epilogue;
@@ -221,7 +221,7 @@ struct DefaultGemmWithBroadcast<
     GemmBase::Epilogue::kPartitionsK,
     ElementC_,
     typename EpilogueOutputOp::ElementT,
-    typename EpilogueOutputOp::ElementCompute,
+    typename EpilogueOutputOp::ElementVector,
     EpilogueOutputOp,
     GemmBase::Epilogue::kElementsPerAccess
   >::Epilogue;

--- a/include/cutlass/gemm/kernel/default_gemm_with_broadcast.h
+++ b/include/cutlass/gemm/kernel/default_gemm_with_broadcast.h
@@ -121,7 +121,7 @@ struct DefaultGemmWithBroadcast {
     GemmBase::Epilogue::kPartitionsK,
     ElementC_,
     typename EpilogueOutputOp::ElementT,
-    ElementC_,
+    typename EpilogueOutputOp::ElementCompute,
     EpilogueOutputOp,
     GemmBase::Epilogue::kElementsPerAccess
   >::Epilogue;
@@ -221,7 +221,7 @@ struct DefaultGemmWithBroadcast<
     GemmBase::Epilogue::kPartitionsK,
     ElementC_,
     typename EpilogueOutputOp::ElementT,
-    ElementC_,
+    typename EpilogueOutputOp::ElementCompute,
     EpilogueOutputOp,
     GemmBase::Epilogue::kElementsPerAccess
   >::Epilogue;

--- a/test/unit/conv/device/conv2d_with_broadcast_testbed.h
+++ b/test/unit/conv/device/conv2d_with_broadcast_testbed.h
@@ -120,6 +120,7 @@ public:
   using EpilogueOutputOp = typename Conv2d::EpilogueOutputOp;
   using ElementZ = typename EpilogueOutputOp::ElementZ;
   using ElementT = typename EpilogueOutputOp::ElementT;
+  using ElementVector = typename EpilogueOutputOp::ElementVector;
 
   static cutlass::conv::Operator const kConvolutionalOperator = Conv2d::kConvolutionalOperator;
   static const bool kAddBroadcastFirst = AddBroadcastFirst;
@@ -142,7 +143,7 @@ public:
   cutlass::HostTensor<ElementT, LayoutC> tensor_T_computed;
   cutlass::HostTensor<ElementT, LayoutC> tensor_T_reference;
   cutlass::HostTensor<ElementAccumulator, LayoutC> tensor_Y_reference;
-  cutlass::HostTensor<ElementC, LayoutC> tensor_Broadcast;                 // Input Broadcast
+  cutlass::HostTensor<ElementVector, LayoutC> tensor_Broadcast;            // Input Broadcast
 
 public:
 

--- a/test/unit/gemm/device/testbed_gemm_with_broadcast.h
+++ b/test/unit/gemm/device/testbed_gemm_with_broadcast.h
@@ -105,7 +105,8 @@ struct TestbedGemmWithBroadcast {
   using OutputOp = typename Gemm::GemmKernel::Epilogue::OutputOp;
   using ElementC = typename Gemm::ElementC;
   using ElementAccumulator = typename Gemm::ElementAccumulator;
-  using ElementCOmpute = typename OutputOp::ElementCompute;
+  using ElementCompute = typename OutputOp::ElementCompute;
+  using ElementVector = typename OutputOp::ElementVector;
   using ElementZ = typename OutputOp::ElementZ;
   using ElementT = typename OutputOp::ElementT;
 
@@ -118,7 +119,7 @@ struct TestbedGemmWithBroadcast {
   cutlass::HostTensor<typename Gemm::ElementA, typename Gemm::LayoutA> tensor_A;          // Input A
   cutlass::HostTensor<typename Gemm::ElementB, typename Gemm::LayoutB> tensor_B;          // Input B
   cutlass::HostTensor<ElementC, typename Gemm::LayoutC> tensor_C;                         // Input C
-  cutlass::HostTensor<ElementC, typename Gemm::LayoutC> tensor_Broadcast;                 // Input Broadcast
+  cutlass::HostTensor<ElementVector, typename Gemm::LayoutC> tensor_Broadcast;            // Input Broadcast
 
   cutlass::HostTensor<ElementZ, typename Gemm::LayoutC> tensor_Z;
   cutlass::HostTensor<ElementT, typename Gemm::LayoutC> tensor_T;


### PR DESCRIPTION
When ElementC is INT8 and EpilogueOutputOp::ElementCompute is float, we should use float for compute