### PR TITLE
min -> std::min

### DIFF
--- a/include/cutlass/gemm/device/base_grouped.h
+++ b/include/cutlass/gemm/device/base_grouped.h
@@ -342,7 +342,7 @@ public:
     // which are not assigned tiles still need to perform the work of iterating through
     // problem sizes to determine that they have no work to do. This competes for cycles
     // with those threadblocks that are assigned tiles to compute.
-    return min(total_tiles, occupancy_based_block_count);
+    return std::min(total_tiles, occupancy_based_block_count);
   }
 
 


### PR DESCRIPTION
Otherwise I got `error: no matching function for call to 'min'` when building with clang.