### PR TITLE
expose StoreT parameter for potential speed

### DIFF
--- a/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
+++ b/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
@@ -62,7 +62,8 @@ template <
   int ElementsPerAccess,
   typename ElementwiseOp_ = Identity<ElementCompute_>,
   typename BinaryOp_ = plus<ElementCompute_>,
-  typename ElementVector_ = ElementC_
+  typename ElementVector_ = ElementC_,
+  bool StoreT_ = true
 >
 class LinearCombinationBiasElementwise {
 public:
@@ -97,7 +98,7 @@ public:
   static bool const kStoreZ = true;
 
   /// If true, the 'T' tensor is stored
-  static bool const kStoreT = true;
+  static bool const kStoreT = StoreT_;
 
   /// Host-constructable parameters structure
   struct Params {

--- a/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
+++ b/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
@@ -62,8 +62,8 @@ template <
   int ElementsPerAccess,
   typename ElementwiseOp_ = Identity<ElementCompute_>,
   typename BinaryOp_ = plus<ElementCompute_>,
-  typename ElementVector_ = ElementC_,
-  bool StoreT_ = true
+  bool StoreT_ = true,
+  typename ElementVector_ = ElementC_
 >
 class LinearCombinationBiasElementwise {
 public:

--- a/include/cutlass/epilogue/thread/linear_combination_bias_relu.h
+++ b/include/cutlass/epilogue/thread/linear_combination_bias_relu.h
@@ -204,7 +204,7 @@ template <
   typename ElementCompute_,
   typename ElementZ_,
   int ElementsPerAccess,
-  bool StoreT = true,
+  bool StoreT_ = true,
   typename ElementVector_ = ElementC_
 >
 class LinearCombinationBiasRelu {
@@ -238,7 +238,7 @@ public:
   static bool const kStoreZ = true;
 
   /// If true, the 'T' tensor is stored
-  static bool const kStoreT = StoreT;
+  static bool const kStoreT = StoreT_;
 
   /// Host-constructable parameters structure
   struct Params {

--- a/include/cutlass/epilogue/thread/linear_combination_residual_block.h
+++ b/include/cutlass/epilogue/thread/linear_combination_residual_block.h
@@ -60,6 +60,7 @@ template <typename ElementOutput_, typename ElementAccumulator_,
           template <typename T> class BinaryOp1_,
           template <typename T> class UnaryOp_,
           template <typename T> class BinaryOp2_ = detail::NoOp,
+          bool StoreT_ = false,
           typename ElementVector_ = ElementC_>
 class LinearCombinationResidualBlock {
 public:
@@ -90,7 +91,7 @@ public:
 
   static bool const kIsHeavy = true;
   static bool const kStoreZ = true;
-  static bool const kStoreT = false;
+  static bool const kStoreT = StoreT_;
 
   /// Host-constructable parameters structure
   struct Params {
@@ -182,11 +183,12 @@ template <typename ElementOutput_, typename ElementAccumulator_,
           template <typename T> class ActivationOp_,
           template <typename T> class BinaryOp1_,
           template <typename T> class UnaryOp_,
+          bool StoreT_,
           typename ElementVector_>
 class LinearCombinationResidualBlock<ElementOutput_, ElementAccumulator_,
           ElementCompute_, ElementC_, ElementsPerAccess,
           ActivationOp_, BinaryOp1_, UnaryOp_,
-          detail::NoOp, ElementVector_> {
+          detail::NoOp, StoreT_, ElementVector_> {
 public:
   static bool const kIsSingleSource = true;
 
@@ -214,7 +216,7 @@ public:
 
   static bool const kIsHeavy = true;
   static bool const kStoreZ = true;
-  static bool const kStoreT = false;
+  static bool const kStoreT = StoreT_;
 
   /// Host-constructable parameters structure
   struct Params {


### PR DESCRIPTION
As per the suggestion in this question https://github.com/NVIDIA/cutlass/issues/783#issuecomment-1408687889 I experimented with toggling storing the T matrix off for speed. This gave us 5-6% throughput speed up for our problem size int8-int8-fp16 matmul. Wonder if it would be worth upstreaming exposing this option? 