### PR TITLE
ex24[gemm_grouped]: Allow to change layout/dtype

### DIFF
--- a/examples/24_gemm_grouped/gemm_grouped.cu
+++ b/examples/24_gemm_grouped/gemm_grouped.cu
@@ -960,8 +960,10 @@ public:
       };
 
       Gemm gemm_op;
+      size_t workspace_size = gemm_op.get_workspace_size(arguments);
+      cutlass::DeviceAllocation<uint8_t> workspace(workspace_size);
 
-      cutlass::Status status = gemm_op.initialize(arguments);
+      cutlass::Status status = gemm_op.initialize(arguments, workspace.get());
 
       if (status != cutlass::Status::kSuccess) {
         std::cerr << "CUTLASS error on line " << __LINE__ << std::endl;
@@ -1070,8 +1072,10 @@ public:
         };
 
         Gemm gemm_op;
+        size_t workspace_size = gemm_op.get_workspace_size(arguments);
+        cutlass::DeviceAllocation<uint8_t> workspace(workspace_size);
 
-        cutlass::Status status = gemm_op.initialize(arguments);
+        cutlass::Status status = gemm_op.initialize(arguments, workspace.get());
 
         if (status != cutlass::Status::kSuccess) {
           std::cerr << "CUTLASS error on line " << __LINE__ << std::endl;
@@ -1487,8 +1491,8 @@ int main(int argc, char const **args) {
 
   // Gemm operator cutlass_tensorop_f16_s16816gemm_f16_128x128_32x4_nt_align8
   using GemmBatched = cutlass::gemm::device::GemmUniversal<
-    cutlass::half_t, LayoutA,
-    cutlass::half_t, LayoutB,
+    ElementA, LayoutA,
+    ElementB, LayoutB,
     ElementOutput,   LayoutC,
     ElementAccumulator,
     cutlass::arch::OpClassTensorOp,
@@ -1510,11 +1514,11 @@ int main(int argc, char const **args) {
   // for scheduling mode. This will be used as the template for all scheduling
   // modes executed.
   using GemmKernel = typename cutlass::gemm::kernel::DefaultGemmGrouped<
-    cutlass::half_t, 
+    ElementA,
     LayoutA,
     cutlass::ComplexTransform::kNone,
     8,
-    cutlass::half_t,
+    ElementB,
     LayoutB,
     cutlass::ComplexTransform::kNone,
     8,


### PR DESCRIPTION
Changing all layouts from ColumnMajor to RowMajor was causing compilation errors because we didn't pass the workspace.