### PR TITLE
Re-enable aarch64 support lost in 277bd6e5379e0c1e1eb64db1a654b30e1ef…

### DIFF
--- a/include/cutlass/uint128.h
+++ b/include/cutlass/uint128.h
@@ -54,7 +54,7 @@ namespace cutlass {
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Optionally enable GCC's built-in type
-#if defined(__x86_64) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
+#if (defined(__x86_64) || defined (__aarch64__)) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
 #define CUTLASS_UINT128_NATIVE
 #elif defined(_MSC_VER) && defined(_M_AMD64) && !defined(__CUDA_ARCH__)
 #define CUTLASS_INT128_ARITHMETIC


### PR DESCRIPTION
This change was lost in 277bd6e5379e0c1e1eb64db1a654b30e1efddc8e