### PR TITLE
Hide streams and typinfo from nvrtc

### DIFF
--- a/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h
+++ b/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h
@@ -43,10 +43,11 @@
 #include "cutlass/conv/conv3d_problem_size.h"
 #include "cutlass/gemm/threadblock/index_remat.h"
 
+#ifndef __CUDA_ARCH__
 #include <iostream>
 #include "cutlass/core_io.h"
 #include "cutlass/trace.h"
-
+#endif
 
 
 

--- a/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h
+++ b/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h
@@ -43,7 +43,7 @@
 #include "cutlass/conv/conv3d_problem_size.h"
 #include "cutlass/gemm/threadblock/index_remat.h"
 
-#ifndef __CUDA_ARCH__
+#if !defined(__CUDACC_RTC__)
 #include <iostream>
 #include "cutlass/core_io.h"
 #include "cutlass/trace.h"


### PR DESCRIPTION
Hello.

There are no "complex" c++ headers during nvrtc compilation. Looks like iostream, core_io and trace.h are used only for Debug Print().

So I hide them.