### PR TITLE
Fix dimension error in implicit_gemm_convolution.md

### DIFF
--- a/media/docs/implicit_gemm_convolution.md
+++ b/media/docs/implicit_gemm_convolution.md
@@ -60,7 +60,7 @@ This computation may be mapped to the elements of a matrix product as follows.
 C = gemm(A, B)
 ```
 where
-- A is a row-major matrix of extent _NHW_-by-_RSC_ containing activations
+- A is a row-major matrix of extent _NPQ_-by-_RSC_ containing activations
 - B is a column-major matrix of extent _RSC_-by-_K_ containing filters
 - C is a row-major matrix of extent _NPQ_-by-_K_ containing the output
 


### PR DESCRIPTION
In `A` x `B` = C, the dimension is `NPQ-by-RSC` x `RSC-by-K` = `NPQ-by-K`.

After im2col, the `matrix A` should be `[N, P, Q, RSC]`. `P` and `Q` is the output height and width, instead of the input `H` and `W`.


