### PR TITLE
Fix sign-compare warning in `reorder_array`

### DIFF
--- a/include/cutlass/gemm/device/base_grouped.h
+++ b/include/cutlass/gemm/device/base_grouped.h
@@ -157,7 +157,7 @@ private:
   static void reorder_array(T* data, const std::vector<size_t>& indices) {
     // For now, simply create a copy of the data and then copy over to the original.
     std::vector<T> copy(indices.size());
-    for (int i = 0; i < indices.size(); ++i) {
+    for (unsigned i = 0; i < indices.size(); ++i) {
       copy.at(i) = data[indices[i]];
     }
 


### PR DESCRIPTION
`std::vector<T>::size_type` is unsigned type, so let's iterate over unsigned type as well


Discovered, while trying to enable PyTorch building without `-Wno-sign-compare` warning suppression, see https://github.com/pytorch/pytorch/actions/runs/4418987999/jobs/7746850762#step:10:10532