### PR TITLE
add guards for __CUDA_ARCH__ >= 530

### DIFF
--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -89,7 +89,7 @@ struct multiplies {
   }
 };
 
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
 /// Partial specializations needed when __CUDA_NO_HALF2_OPERATORS__ is set
 template<>
 struct plus<__half2> {

--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -89,7 +89,7 @@ struct multiplies {
   }
 };
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
 /// Partial specializations needed when __CUDA_NO_HALF2_OPERATORS__ is set
 template<>
 struct plus<__half2> {


### PR DESCRIPTION
Should fix https://github.com/pytorch/pytorch/pull/94188 and potentially https://github.com/NVIDIA/cutlass/issues/4.
I used `>=  700` as cutlass==3.0 drops Pascal support, but let me know if I should decrease the version in this check.