### PR TITLE
Fix MSVC compilation errors

### DIFF
--- a/include/cute/numeric/math.hpp
+++ b/include/cute/numeric/math.hpp
@@ -296,7 +296,7 @@ signum(T const& x) {
 }
 
 template <class T,
-          __CUTE_REQUIRES(not std::is_unsigned<T>::value)>
+          __CUTE_REQUIRES(!std::is_unsigned<T>::value)>
 CUTE_HOST_DEVICE constexpr
 int
 signum(T const& x) {

--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -148,7 +148,7 @@ template <typename T>
 struct maximum_with_nan_propogation {
   CUTLASS_HOST_DEVICE
   T operator()(T const &lhs, T const &rhs) const {
-    return lhs > rhs or std::isnan(lhs) ? lhs : rhs;
+    return lhs > rhs || std::isnan(lhs) ? lhs : rhs;
   }
 };
 
@@ -160,7 +160,7 @@ struct maximum_with_nan_propogation<float> {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
     asm volatile("max.NaN.f32 %0, %1, %2;\n" : "=f"(res) : "f"(lhs), "f"(rhs));
 #else
-    res = lhs > rhs or std::isnan(lhs) ? lhs : rhs;
+    res = lhs > rhs || std::isnan(lhs) ? lhs : rhs;
 #endif
     return res;
   }


### PR DESCRIPTION
Fix errors of MSVC 2022 compiler. 

It should not be needed to find the exact flags of MSVC that enables it to accept modern C++ 'not', 'and' and 'or' keywords.
