### PR TITLE
Adds f16 reduction kernel to profiler and fixes `--split-k-mode` command line argument

### DIFF
--- a/tools/library/src/reduction/init_reduction_operations.cu
+++ b/tools/library/src/reduction/init_reduction_operations.cu
@@ -42,6 +42,7 @@ namespace library {
 ///////////////////////////////////////////////////////////////////////////////////////////////
 //                             CUTLASS Reduction Instances                                   //
 ///////////////////////////////////////////////////////////////////////////////////////////////
+void initialize_reduce_add_linear_combination_f16_f16_f16(Manifest &manifest);
 void initialize_reduce_add_linear_combination_f32_f32_f16(Manifest &manifest);
 void initialize_reduce_add_linear_combination_f32_f32_f32(Manifest &manifest);
 void initialize_reduce_add_linear_combination_f64_f64_f64(Manifest &manifest);
@@ -52,6 +53,7 @@ void initialize_reduce_add_linear_combination_cf32_cf32_cf32(Manifest &manifest)
 //
 void initialize_all_reduction_op(Manifest &manifest) {
 
+  initialize_reduce_add_linear_combination_f16_f16_f16(manifest);
   initialize_reduce_add_linear_combination_f32_f32_f16(manifest);
   initialize_reduce_add_linear_combination_f32_f32_f32(manifest);
   initialize_reduce_add_linear_combination_f64_f64_f64(manifest);

--- a/tools/profiler/src/gemm_operation_profiler.cu
+++ b/tools/profiler/src/gemm_operation_profiler.cu
@@ -62,7 +62,6 @@ GemmOperationProfiler::GemmOperationProfiler(Options const &options):
     library::OperationKind::kGemm,
     {
       {ArgumentTypeID::kEnumerated, {"gemm_kind"}, "Variant of GEMM (gemm, batched, array, universal, planar_complex, planar_complex_array)"},
-      {ArgumentTypeID::kEnumerated, {"split_k_mode"}, "Variant of split K mode(serial, parallel)"},
       {ArgumentTypeID::kInteger, {"m", "problem-size::m"}, "M dimension of the GEMM problem space"},
       {ArgumentTypeID::kInteger, {"n", "problem-size::n"}, "N dimension of the GEMM problem space"},
       {ArgumentTypeID::kInteger, {"k", "problem-size::k"}, "K dimension of the GEMM problem space"},
@@ -71,6 +70,7 @@ GemmOperationProfiler::GemmOperationProfiler(Options const &options):
       {ArgumentTypeID::kTensor, {"C"}, "Tensor storing the C operand"},
       {ArgumentTypeID::kScalar, {"alpha", "epilogue::alpha"}, "Epilogue scalar alpha"},
       {ArgumentTypeID::kScalar, {"beta", "epilogue::beta"}, "Epilogue scalar beta"},
+      {ArgumentTypeID::kEnumerated, {"split_k_mode", "split-k-mode"}, "Variant of split K mode(serial, parallel)"},
       {ArgumentTypeID::kInteger, {"split_k_slices", "split-k-slices"}, "Number of partitions of K dimension"},
       {ArgumentTypeID::kInteger, {"batch_count", "batch-count"}, "Number of GEMMs computed in one batch"},
     },
@@ -298,8 +298,6 @@ void GemmOperationProfiler::GemmProblem::initialize_result(
 
   set_argument(result, "gemm_kind", problem_space, library::to_string(operation_desc.gemm_kind));
 
-  set_argument(result, "split_k_mode", problem_space, library::to_string(split_k_mode));
-
   set_argument(result, "A", problem_space,
     std::string(library::to_string(operation_desc.A.element)) + ":" + library::to_string(operation_desc.A.layout));
 
@@ -313,6 +311,7 @@ void GemmOperationProfiler::GemmProblem::initialize_result(
   set_argument(result, "n", problem_space, n);
   set_argument(result, "k", problem_space, k);
 
+  set_argument(result, "split_k_mode", problem_space, library::to_string(split_k_mode));
   set_argument(result, "split_k_slices", problem_space, split_k_slices);
   set_argument(result, "batch_count", problem_space, batch_count);
 

--- a/tools/profiler/src/gemm_operation_profiler.h
+++ b/tools/profiler/src/gemm_operation_profiler.h
@@ -66,9 +66,8 @@ public:
 
   /// Problem structure obtained from problem space
   struct GemmProblem {
-
+    
     cutlass::library::GemmUniversalMode mode; 
-    cutlass::library::SplitKMode split_k_mode;
     int64_t m;
     int64_t n;
     int64_t k;
@@ -77,6 +76,8 @@ public:
     int64_t ldc;
     std::vector<uint8_t> alpha;
     std::vector<uint8_t> beta;
+
+    cutlass::library::SplitKMode split_k_mode;
     int split_k_slices;
     int batch_count;
 


### PR DESCRIPTION
- Adds `cutlass::reduction::device::ReduceSplitK` on f16 input, with f16 accumulation, and f16 output. 

- Fixes the absence of  `--split-k-mode` in `GemmOperationProfiler::ArgumentDescriptionVector::arguments_`'s `aliases` vector that will be matched for "--split-k-mode."
 
- nit: moves the `split-k-mode` closer to `split-k-slices` to ease readability by grouping related concepts together. 

Without the PR, one would not be able to run the parallel reduction on`cutlass_tensorop_h*gemm_*`. For example, consider the profiler run on `cutlass_tensorop_h16816gemm_128x128_32x5_nn_align8` with `--split-k-mode=parallel` and  `--split-k-slices=2` will return nothing. 

**Example, run with this PR:** 
```bash
./tools/profiler/cutlass_profiler --kernels=cutlass_tensorop_h16816gemm_128x128_32x5_nn_align8 --split-k-mode=parallel --split-k-slices=2



=============================
  Problem ID: 1

        Provider: CUTLASS
   OperationKind: gemm
       Operation: cutlass_tensorop_h16816gemm_128x128_32x5_nn_align8

          Status: Success
    Verification: ON
     Disposition: Passed

reference_device: Passed
          cuBLAS: Not run

       Arguments: --gemm_kind=universal --m=1024 --n=1024 --k=1024 --A=f16:column --B=f16:column --C=f16:column --alpha=1  \
                  --beta=0 --split_k_mode=parallel --split_k_slices=2 --batch_count=1 --op_class=tensorop --accum=f16  \
                  --cta_m=128 --cta_n=128 --cta_k=32 --cluster_m=1 --cluster_n=1 --cluster_k=1 --stages=5 --warps_m=2  \
                  --warps_n=2 --warps_k=1 --inst_m=16 --inst_n=8 --inst_k=16 --min_cc=80 --max_cc=1024

           Bytes: 6291456  bytes
           FLOPs: 2149580800  flops
           FLOPs/Byte: 341

         Runtime: 0.0323072  ms
          Memory: 181.364 GiB/s

            Math: 66535.7 GFLOP/s


=============================
```