### PR TITLE
Remove const qualifier from 3.x GemmUniversalAdapter::operator(cudaStream_t)

### DIFF
--- a/include/cutlass/gemm/device/gemm_universal_adapter.h
+++ b/include/cutlass/gemm/device/gemm_universal_adapter.h
@@ -385,7 +385,7 @@ public:
 
   /// Overload that allows a user to re-launch the same kernel without updating internal params struct.
   Status
-  operator()(cudaStream_t stream = nullptr) const {
+  operator()(cudaStream_t stream = nullptr) {
     return run(params_, stream);
   }
 };


### PR DESCRIPTION
The 3.x [`GemmUniversalAdapter::operator()(cudaStream_t)`](https://github.com/NVIDIA/cutlass/blob/master/include/cutlass/gemm/device/gemm_universal_adapter.h#L388) method is `const`-qualified. This is problematic, as it calls a non-`const`-qualified method [`run(Params&, cudaStream_t)`](https://github.com/NVIDIA/cutlass/blob/master/include/cutlass/gemm/device/gemm_universal_adapter.h#L327) from the same class.

Indeed, replacing `gemm.run()` call with `gemm()` [here](https://github.com/NVIDIA/cutlass/blob/master/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu#L378) in the `48_hopper_warp_specialized_gemm.cu` example leads to a compilation error:

```
$ nvcc -gencode=arch=compute_90a,code=[sm_90a,compute_90a] -O0 -std=c++17 --expt-relaxed-constexpr cutlass/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu ...

cutlass/include/cutlass/gemm/device/gemm_universal_adapter.h(389): error: no instance of overloaded function "cutlass::gemm::device::GemmUniversalAdapter<GemmKernel_, std::enable_if_t<cutlass::gemm::detail::IsCutlass3GemmKernel<GemmKernel_, void>::value, void>>::run [with GemmKernel_=GemmKernel]" matches the argument list
            argument types are: (const cutlass::gemm::kernel::GemmUniversal<cute::tuple<int, int, int>, CollectiveMainloop, CollectiveEpilogue, void, void>::Params, cudaStream_t)
          detected during:
            instantiation of "cutlass::Status cutlass::gemm::device::GemmUniversalAdapter<GemmKernel_, std::enable_if_t<cutlass::gemm::detail::IsCutlass3GemmKernel<GemmKernel_, void>::value, void>>::operator()(cudaStream_t) const [with GemmKernel_=GemmKernel]" 
cutlass/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu(378): here
            instantiation of "int run<Gemm>(Options &) [with Gemm=Gemm]" 
cutlass/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu(457): here
```

This PR suggest removing the `const` qualifier from the 3.x `GemmUniversalAdapter::operator()(cudaStream_t)`, as neither the equivalent 3.x [`GemmUniversalAdapter::run(cudaStream_t)`](https://github.com/NVIDIA/cutlass/blob/master/include/cutlass/gemm/device/gemm_universal_adapter.h#L382) nor the 2.x [`GemmUniversalAdapter::operator()(cudaStream_t)`](https://github.com/NVIDIA/cutlass/blob/master/include/cutlass/gemm/device/gemm_universal_adapter.h#L524) are `const`-qualified.

After the suggested change, the `48_hopper_warp_specialized_gemm.cu` example with the `gemm.run()` call replaced by `gemm()` compiles and runs successfully (on H100 / CUDA 12.0 / Driver Version 525.85.12):

```
$ nvcc -gencode=arch=compute_90a,code=[sm_90a,compute_90a] -O0 -std=c++17 --expt-relaxed-constexpr cutlass/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu ...

  Disposition: Passed
  Problem Size: 5120x4096x4096
  Avg runtime: 0.540956 ms
  GFLOPS: 317583
```