### PR TITLE
Fix some typos in CuTe tutorials

### DIFF
--- a/media/docs/cute/01_layout.md
+++ b/media/docs/cute/01_layout.md
@@ -165,7 +165,7 @@ auto layout_2sx4s = make_layout(make_shape(Int<2>{},Int<4>{}));
 auto layout_2sx4d = make_layout(make_shape(Int<2>{},4));
 
 auto layout_2x4 = make_layout(make_shape (2, make_shape (2,2)),
-                              make_stride(4, make_stride(1,2)));
+                              make_stride(4, make_stride(2,1)));
 ```
 
 ## Using a `Layout`
@@ -199,9 +199,9 @@ which produces the following output for the above examples.
   4   6   5   7
 ```
 
-The multi-indices within the `layout_4x4` example are handled as expected and interpreted as a rank-2 layout.
+The multi-indices within the `layout_2x4` example are handled as expected and interpreted as a rank-2 layout.
 
-Note that for `layout_1x4`, we're using a 1-D coordinate for a 2-D multi-index in the second mode. In fact, we can generalize this and treat all of the above layouts as 1-D layouts.  For instance, the following `print1D` function
+Note that for `layout_2x4`, we're using a 1-D coordinate for a 2-D multi-index in the second mode. In fact, we can generalize this and treat all of the above layouts as 1-D layouts.  For instance, the following `print1D` function
 
 ```c++
 template <class Shape, class Stride>

--- a/media/docs/cute/02_layout_operations.md
+++ b/media/docs/cute/02_layout_operations.md
@@ -142,7 +142,7 @@ This code produces the following text output.
 ```
 
 `print(layout(1, 1))` prints the mapping of
-the logical 2-D coordinate (0,1) to 1-D index, which is 4.
+the logical 2-D coordinate (1,1) to 1-D index, which is 4.
 You can see that from the table,
 which shows the left logical index as the "row,"
 and the right logical index as the "column."
@@ -462,7 +462,7 @@ Shape ((3, 2), (4, 2)) and Stride ((16, 1), (4, 2)).
 | (2,1) | 33    | 37    | 41    | 45    | 35    | 39    | 43    | 47    |
 
 The tile is now interleaved or "raked" with the other 3x4 matrix-of-tiles
-instead of appearing as blocks. Other references call this is cyclic 
+instead of appearing as blocks. Other references call this cyclic 
 distribution.
 
 This might look familiar if you have ever used ScaLAPACK.
@@ -527,7 +527,6 @@ Layout mat = logical_divide(vec, col);   // (4,(2,2)) : (6,(3,24))
 
 ```c++
 Layout vec = Layout<_16,_3>{};           //  16 : 3
-Layout col = Layout< _4,_2>{};
 Layout col = Layout<Shape <_2,_2>,
                     Stride<_4,_1>>{};    // (2,2) : (4,1)
 Layout mat = logical_divide(vec, col);   // ((2,2),(2,2)) : ((12,3),(6,24))


### PR DESCRIPTION
Some typos, textual and in the code, are fixed in the CuTe tutorials [01_layout.md](https://github.com/NVIDIA/cutlass/blob/main/media/docs/cute/01_layout.md) and [02_layout_operations.md](https://github.com/NVIDIA/cutlass/blob/main/media/docs/cute/02_layout_operations.md).