### PR TITLE
Update functional.h

### DIFF
--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -1422,8 +1422,8 @@ struct negate<Array<half_t, N>> {
     }
 
     if (N % 2) {
-      half_t x = lhs[N - 1];
-      __half lhs_val = -reinterpret_cast<__half const &>(x);
+      half_t x = -lhs[N - 1];
+      __half lhs_val = reinterpret_cast<__half const &>(x);
       result[N - 1] = reinterpret_cast<half_t const &>(lhs_val);
     }
 


### PR DESCRIPTION
Line1426： - reinterpret_cast<__half const &>(x);   will cause an error: "no operator "-" matches these operands: operand types are: - const __half. "   when arch == "sm80/compute80".    
Moving the negative sign up one line(1425) can solve this error.  Take a minus sign for '__half' instead of a minus sign for "const __half"

Discovered by @furong@pjlab.org.cn @suzhongling@pjlab.org.cn @xuhaoran@pjlab.org.cn