### PR TITLE
Fix for dangling references in the MHA example

### DIFF
--- a/examples/41_fused_multi_head_attention/iterators/predicated_tile_access_iterator_residual_last.h
+++ b/examples/41_fused_multi_head_attention/iterators/predicated_tile_access_iterator_residual_last.h
@@ -175,7 +175,7 @@ class PredicatedTileAccessIteratorResidualLast<
   Mask residual_tile_mask;
 
   /// Parameters object with precomputed internal state
-  Params const& params_;
+  Params params_;
 
   /// Internal pointer to first access of tile
   BytePointer pointer_;
@@ -1018,7 +1018,7 @@ class PredicatedTileAccessIteratorResidualLast<
   //
 
   /// Parameters object with precomputed internal state
-  Params const& params_;
+  Params params_;
 
   /// Internal pointer to first access of tile
   BytePointer pointer_;


### PR DESCRIPTION
There is a dangling reference for the params_ class member that does not survive the iterator's constructor. This PR replaces the dangling reference with a copy.