### PR TITLE
Add missing schedules argument in SM90 WGMMA 16-bit op generation

### DIFF
--- a/tools/library/scripts/generator.py
+++ b/tools/library/scripts/generator.py
@@ -4160,7 +4160,7 @@ def GenerateSM90_TensorOp_16b_WGMMA_gemm(manifest, cuda_version):
         elif data_type_mixed["c_type"] in [DataType.f16, DataType.bf16]:
           layout[2][1] = 8
 
-      CreateGemmUniversal3xOperator(manifest, layouts, tile_descriptions, data_type_mixed)
+      CreateGemmUniversal3xOperator(manifest, layouts, tile_descriptions, data_type_mixed, schedules)
       # persistent kernels with TMA epilogues
       if data_type_mixed["c_type"] in [DataType.f16, DataType.bf16] and CudaToolkitVersionSatisfies(cuda_version, 12, 1):
         CreateGemmUniversal3xOperator(manifest, layouts, tile_descriptions, data_type_mixed,


### PR DESCRIPTION
Seems like the optional `schedules` argument was forgotten in generation of the mixed-precision SM90 WGMMA 16-bit operators [here](https://github.com/NVIDIA/cutlass/blob/main/tools/library/scripts/generator.py#L4163) (whereas it is passed a few lines above [here](https://github.com/NVIDIA/cutlass/blob/main/tools/library/scripts/generator.py#L4136)). As a result, mixed-precision warp-specialized operator instances are not generated. This PR adds the missing argument to the `CreateGemmUniversal3xOperator` call.