### PR TITLE
Add missing checks for NVRTC in CuTe

### DIFF
--- a/include/cute/arch/copy_sm90_desc.hpp
+++ b/include/cute/arch/copy_sm90_desc.hpp
@@ -134,6 +134,7 @@ enum class SmemSwizzleBits : uint8_t {
   B128 = 3,
 };
 
+#if !defined(__CUDACC_RTC__)
 #if (__CUDACC_VER_MAJOR__ >= 12)
 
 template <class T>
@@ -164,9 +165,10 @@ inline CUtensorMapSwizzle to_CUtensorMapSwizzle(SmemSwizzleBits const& t) {
 }
 
 #endif // (__CUDACC_VER_MAJOR__ >= 12)
+#endif // !defined(__CUDACC_RTC__)
 } // end namespace TMA
 
-#if (__CUDACC_VER_MAJOR__ >= 12)
+#if (__CUDACC_VER_MAJOR__ >= 12) && !defined(__CUDACC_RTC__)
 using TmaDescriptor = CUtensorMap;
 #else
 using TmaDescriptor = struct { char bytes[128]; };


### PR DESCRIPTION
Types `CUtensorMapDataType` etc. are only defined when `cuda.h` is included, and when compiling CuTe with NVRTC it's not (as it's a host header):

```cpp
#if !defined(__CUDACC_RTC__)
#include <cuda.h>
#include <cinttypes>
#endif
...
```

New checks make sure undefined types are not use with NVRTC.