### PR TITLE
Add missing #include directive.

### DIFF
--- a/include/cutlass/epilogue/thread/linear_combination_clamp.h
+++ b/include/cutlass/epilogue/thread/linear_combination_clamp.h
@@ -40,6 +40,7 @@
 #include "cutlass/array.h"
 #include "cutlass/functional.h"
 #include "cutlass/numeric_conversion.h"
+#include "cutlass/epilogue/thread/scale_type.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Currently [`cutlass/epilogue/thread/linear_combination_clamp.h`](include/cutlass/epilogue/thread/linear_combination_clamp.h) cannot be compiled standalone. This PR addresses this issue; see the commit message.