### PR TITLE
Get SM count with cudaDeviceGetAttribute in KernelHardwareInfo

### DIFF
--- a/include/cutlass/kernel_hardware_info.hpp
+++ b/include/cutlass/kernel_hardware_info.hpp
@@ -56,15 +56,16 @@ struct KernelHardwareInfo {
         << cudaGetErrorString(result));
       return 0;
     }
-    cudaDeviceProp properties;
-    result = cudaGetDeviceProperties(&properties, device_id);
+    int multiprocessor_count;
+    result = cudaDeviceGetAttribute(&multiprocessor_count,
+      cudaDevAttrMultiProcessorCount, device_id);
     if (result != cudaSuccess) {
       CUTLASS_TRACE_HOST(
-        "  cudaGetDeviceProperties() returned error "
+        "  cudaDeviceGetAttribute() returned error "
         << cudaGetErrorString(result));
       return 0;
     }
-    return properties.multiProcessorCount;
+    return multiprocessor_count;
   }
 };
 


### PR DESCRIPTION
Currently in the `KernelHardwareInfo` class, `cudaGetDeviceProperties` is called [here](https://github.com/NVIDIA/cutlass/blob/main/include/cutlass/kernel_hardware_info.hpp#L60) just to get the number of SMs. `cudaGetDeviceProperties` is quite heavy and can take from ~1 to 10s of milliseconds to complete. As it is called under the hood of every `GemmUniversalAdapter::initialize` when using SM90 TMA warp-specialized cooperative and pingpong kernel schedules, this makes the use cases where the arguments must be re-initialized on every kernel invocation quite inefficient.

In this PR, the `cudaGetDeviceProperties` call is replaced with much more lightweight `cudaDeviceGetAttribute` to get the `cudaDevAttrMultiProcessorCount` only. This takes in the order of 10ns and is virtually invisible in the trace.