### PR TITLE
replace division with multiplication in GELU

### DIFF
--- a/include/cutlass/epilogue/thread/activation.h
+++ b/include/cutlass/epilogue/thread/activation.h
@@ -515,7 +515,7 @@ struct GELU {
   CUTLASS_HOST_DEVICE
   T operator()(T const &scalar) const {
     return T(cutlass::constants::half<T>() * scalar *
-      (cutlass::constants::one<T>() + (T)erff((float)(scalar / cutlass::constants::root_two<T>()))));
+      (cutlass::constants::one<T>() + (T)erff((float)(scalar * cutlass::constants::half_root_two<T>()))));
   }
 
   using Params = LinearCombinationGenericParams<T>;
@@ -531,7 +531,7 @@ struct GELU<float> {
   CUTLASS_HOST_DEVICE
   float operator()(float const &scalar) const {
     return cutlass::constants::half<float>() * scalar *
-      (cutlass::constants::one<float>() + erff( scalar / cutlass::constants::root_two<float>() ));
+      (cutlass::constants::one<float>() + erff( scalar * cutlass::constants::half_root_two<float>() ));
   }
 
   using Params = LinearCombinationGenericParams<float>;
@@ -547,7 +547,7 @@ struct GELU<double> {
   CUTLASS_HOST_DEVICE
   double operator()(double const &scalar) const {
     return cutlass::constants::half<double>() * scalar *
-      (cutlass::constants::one<double>() + erf( scalar / cutlass::constants::root_two<double>() ));
+      (cutlass::constants::one<double>() + erf( scalar * cutlass::constants::half_root_two<double>() ));
   }
 
   using Params = LinearCombinationGenericParams<double>;


### PR DESCRIPTION
We have observed a significant performance degradation when fusing a large fp16 GEMM (M=913920, N=1024, K=256) with GELU. 

For instance, on our device (A100-80GB), the plain GEMM runs in approximately 3.25ms using the optimal tile description. However, when fused with GELU, it increases to 12.14ms. (However, the performance gap is not consistently that large across different devices, we have found that on an sm_87 Orin GPU, the difference is relatively small. We suspect this may be due to differing bottlenecks).

We brokedown each of the operations in GELU, and discovered that the `division` and `erff` operations have the most significant impact on performance. The details are as follows:

| experiment                                     | time (ms) |
| ---------------------------------------------- | --------- |
| plain gemm                                     | 3.25      |
| fuse GELU                                      | 12.14     |
| fuse GELU + replace div with mul               | 4.73      |
| fuse GELU + replace div with mul + remove erff | 3.28      |

Therefore, in this PR, we replace the `scalar / sqrt(2)` with `scalar * (sqrt(2) / 2)`, where `sqrt(2) / 2` is a constant.