### PR TITLE
Make bias stride configurable in EpilogueTensorBroadcast

### DIFF
--- a/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp
+++ b/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp
@@ -112,6 +112,7 @@ public:
     ElementBias* ptr_Bias = nullptr;
     ElementC* ptr_C0 = nullptr;
     ElementC* ptr_C1 = nullptr;
+    StrideC dBias{};
   };
 
   // Device side epilogue params
@@ -174,7 +175,7 @@ public:
 
     auto stride_c    = detail::get_epilogue_stride<EpilogueSchedule>(params.dC);
     auto stride_d    = detail::get_epilogue_stride<EpilogueSchedule>(params.dD);
-    auto stride_bias = detail::get_epilogue_stride<EpilogueSchedule>(Stride<_1, _0, _0>{});
+    auto stride_bias = detail::get_epilogue_stride<EpilogueSchedule>(params.dBias);
 
     // Represent the full output tensor
     Tensor mC0_mnl = make_tensor(make_gmem_ptr(params.ptr_C0), make_shape(M,N,L), stride_c);                   // (m,n,l)


### PR DESCRIPTION
Currently, the bias stride is hard-coded to `Stride<_1, _0, _0>{}` (column-major) [here](https://github.com/NVIDIA/cutlass/blob/main/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp#L177) in `EpilogueTensorBroadcast`. This makes it impossible to use a row-major bias vector. This PR adds another parameter to the `EpilogueTensorBroadcast::Arguments`---`dBias`---following the `StrideC` of the source other tensors.

N.B.: I'm not sure the change would leave the unit tests [here](https://github.com/NVIDIA/cutlass/blob/fcfbd23e26328df8c8b720a161ada95a3eb725e8/test/unit/gemm/device/sm90_gemm_f16_f16_f16_tensor_op_f32_tensor_broadcast.cu) in consistent state. If not, and if the PR is acceptable, I'd kindly ask the reviewer to point out the inconsistencies in the tests and a desirable way to resolve them. Thanks!