### PR TITLE
Enhancement: Addition of 128x256 Threadblock Tiles for 16b Hopper Warp Group MMA GEMM

### DIFF
--- a/tools/library/scripts/generator.py
+++ b/tools/library/scripts/generator.py
@@ -4084,6 +4084,8 @@ def GenerateSM90_TensorOp_16b_WGMMA_gemm(manifest, cuda_version):
         0, [4, 1, 1], math_inst, min_cc, max_cc, [2,1,1]),
       TileDescription([math_inst.instruction_shape[0]*2, math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
         0, [4, 1, 1], math_inst, min_cc, max_cc, [2,1,1]),
+      TileDescription([math_inst.instruction_shape[0]*2, math_inst.instruction_shape[1]*2, math_inst.instruction_shape[2]*4],
+        0, [4, 2, 1], math_inst, min_cc, max_cc, [2,1,1]),
       #TileDescription([math_inst.instruction_shape[0], math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
       #  0, [4, 1, 1], math_inst, min_cc, max_cc, [2,1,1]), - Not compatible with TmaWarpSpecializedCooperative
       TileDescription([math_inst.instruction_shape[0]*4, math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
@@ -4092,6 +4094,8 @@ def GenerateSM90_TensorOp_16b_WGMMA_gemm(manifest, cuda_version):
         0, [4, 1, 1], math_inst, min_cc, max_cc, [1,2,1]),
       TileDescription([math_inst.instruction_shape[0]*2, math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
         0, [4, 1, 1], math_inst, min_cc, max_cc, [1,2,1]),
+      TileDescription([math_inst.instruction_shape[0]*2, math_inst.instruction_shape[1]*2, math_inst.instruction_shape[2]*4],
+        0, [4, 2, 1], math_inst, min_cc, max_cc, [1,2,1]),
       #TileDescription([math_inst.instruction_shape[0], math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
       #  0, [4, 1, 1], math_inst, min_cc, max_cc, [1,2,1]),- Not compatible with TmaWarpSpecializedCooperative
       TileDescription([math_inst.instruction_shape[0]*4, math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],


### PR DESCRIPTION
This pull request introduces the addition of 128x256 threadblock tiles to support 16b Hopper Warp Group Matrix Multiply-Accumulate (WGMMA) General Matrix Multiply (GEMM). This enhancement is motivated by performance evaluations that highlighted an opportunity for improvement on larger GEMM shapes.

We noticed that with the current tile configurations, we were not able to fully utilize the computational capabilities of the H100 PCIe with 114 Streaming Multiprocessors (SMs), particularly for larger GEMM shapes such as `7296x2048x12288`. Despite using the existing tile sizes, we were unable to achieve peak performance, indicating a gap that could be addressed by introducing larger threadblock tiles.

The graph attached to this PR showcases the performance comparison between the existing tiles (light green) and the newly added 128x256 tiles (dark green). The data is arranged in increasing order of performance. It clearly indicates that the newly added 128x256 threadblock tiles significantly enhance the GEMM computation speed, particularly for the aforementioned larger GEMM shape.


![Hopper F16 Tensor Cores Performance - H100 PCIe 114 SMs - CUDA 12 1 Toolkit - Matmul Shape 7296x2048x1024](https://github.com/NVIDIA/cutlass/assets/3487276/5faba76b-a02f-483c-b24d-f44de1d6f3b5)


 
