### PR TITLE
Adds CUDA path for x86-64

### DIFF
--- a/CUDA.cmake
+++ b/CUDA.cmake
@@ -76,6 +76,7 @@ find_library(
   PATHS
   ${CUDA_TOOLKIT_ROOT_DIR}
   PATH_SUFFIXES
+  lib/x86_64-linux-gnu
   lib/x64
   lib64
   lib
@@ -120,6 +121,7 @@ find_library(
   PATHS
   ${CUDA_TOOLKIT_ROOT_DIR}
   PATH_SUFFIXES
+  lib/x86_64-linux-gnu
   lib/x64
   lib64
   lib


### PR DESCRIPTION
## The problem

Cmake won't detect CUDA libraries when they're installed to `/usr/lib/x86_64-linux-gnu`.
I previously thought it was just the environment I was on, but I'm noticing just now that most of the machines I use (all of which are on Ubuntu with an AMD chip) have CUDA libraries (among others) installed to that path.

## Solution

This PR adds the path `lib/x86_64-linux-gnu` to CUDA paths in the cmake file.
