### PR TITLE
Add conversion from ElementBias to ElementCompute for collective bias-elementwise epilogue

### DIFF
--- a/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
+++ b/include/cutlass/epilogue/thread/linear_combination_bias_elementwise.h
@@ -95,7 +95,7 @@ public:
   using FragmentSource = FragmentC;
   using FragmentOutput = FragmentZ;
   using ElementBias = ElementVector;
-  using FragmentBias = FragmentCompute;
+  using FragmentBias = Array<ElementBias, kElementsPerAccess>;
   using ActivationFunctor = ElementwiseOp;
   static const ScaleType::Kind kScale = ScaleType::Default;
 


### PR DESCRIPTION
This MR adds a missing conversion from `ElementBias` to `ElementCompute` before calling `thread::LinearCombinationBiasElementwise` in the collective-level bias-elementwise epilogue.

cc @aakhundov 