### PR TITLE
Improve python api setup

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -108,10 +108,15 @@ include_dirs = [
 ]
 
 
+library_dirs = [
+    cuda_install_path + '/lib64',
+]
+
 ext_modules = [
     Pybind11Extension('cutlass_bindings',
                       ['cutlass/cpp/cutlass_bindings.cpp'],
                       include_dirs=include_dirs,
+                      library_dirs=library_dirs,
                       extra_compile_args=['-Xcompiler="-fpermissive"', '-w', '-std=c++17'],
                       libraries=['cudart'])
 ]


### PR DESCRIPTION
The setup.py does not set library dir for cuda, which might leads to link error:

```
ld: cannot find -lcudart: No such file or directory
```
