### PR TITLE
torch.bfloat16 support in cutlass python

### DIFF
--- a/python/cutlass/utils/datatypes.py
+++ b/python/cutlass/utils/datatypes.py
@@ -150,6 +150,10 @@ try:
     import bfloat16
 
     bfloat16_available = True
+    if torch_available:
+        _torch_to_library_dict[torch.bfloat16] = cutlass.DataType.bf16
+        _library_to_torch_dict[cutlass.DataType.bf16] = torch.bfloat16
+    
 except ImportError:
     bfloat16_available = False
 


### PR DESCRIPTION
haven't tested, think this works. will test soon.

Previously:
```
>>> gemm = cutlass.op.Gemm(element_A=torch.bfloat16, element_B=torch.bfloat16, element_C=torch.float16, layout=cutlass.LayoutType.RowMajor)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspace/cutlass/python/cutlass/op/gemm.py", line 245, in __init__
    elements.append(datatypes.library_type(elt_to_set))
  File "/workspace/cutlass/python/cutlass/utils/datatypes.py", line 223, in library_type
    raise Exception(f"No available conversion from type {inp} to a library type.")
Exception: No available conversion from type torch.bfloat16 to a library type.
```