### PR TITLE
Avoid cute::print compiler warnings with -Wformat-security

### DIFF
--- a/include/cute/util/print.hpp
+++ b/include/cute/util/print.hpp
@@ -145,4 +145,10 @@ print(T const&... t) {
   (print(t), ...);
 }
 
+CUTE_HOST_DEVICE
+void
+print(char const* format) {
+  printf("%s", format);
+}
+
 } // end namespace cute


### PR DESCRIPTION
Fixes issue #1040.

`cute::print` failed to compile when compiler flags `-Wformat   -Wformat-security   -Werror=format-security` were passed. 

With this commit, `cute::print` works also when it is passed a single string and does not emit warnings (even when these compiler flags are present). 