### PR TITLE
Make files under tools/library/scripts/ use relative import 

### DIFF
--- a/tools/library/CMakeLists.txt
+++ b/tools/library/CMakeLists.txt
@@ -42,8 +42,8 @@ target_include_directories(
   )
 
 target_link_libraries(
-  cutlass_library_includes 
-  INTERFACE 
+  cutlass_library_includes
+  INTERFACE
   CUTLASS
   cutlass_tools_util_includes
   )
@@ -74,7 +74,7 @@ cutlass_add_library(
   # cutlass reduction instances in cutlass library
   src/reduction/reduction_device.cu
   src/reduction/init_reduction_operations.cu
-  
+
   # cutlass conv reference instances in cutlass library
   src/reference/conv2d.cu
   src/reference/conv3d.cu
@@ -87,17 +87,21 @@ file(GLOB_RECURSE GENERATOR_PYTHON_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOU
 # auto-instantiation of CUTLASS kernels
 #
 
-# set cutlass generator compiler version to filter kernels in the generator not supported by a specific toolkit. 
+# set cutlass generator compiler version to filter kernels in the generator not supported by a specific toolkit.
 set(CUTLASS_GENERATOR_CUDA_COMPILER_VERSION ${CMAKE_CUDA_COMPILER_VERSION})
 set(CUTLASS_LIBRARY_GENERATED_KERNEL_LIST_FILE ${CMAKE_CURRENT_BINARY_DIR}/generated_kernels.txt CACHE STRING "Generated kernel listing file")
+
+# export ${CMAKE_CURRENT_SOURCE_DIR} to PYTHONPATH so that relative import in
+# files under ${CMAKE_CURRENT_SOURCE_DIR}/scripts/ works.
+set(ENV{PYTHONPATH} ${CMAKE_CURRENT_SOURCE_DIR}:$ENV{PYTHONPATH})
 
 # --log-level is set to DEBUG to enable printing information about which kernels were excluded
 # from generation in /tools/library/scripts/manifest.py. To avoid having this information appear
 # in ${CMAKE_CURRENT_BINARY_DIR}/library_instance_generation.log, set this parameter to INFO
 execute_process(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generator.py
-    --operations "${CUTLASS_LIBRARY_OPERATIONS}" 
+  COMMAND ${Python3_EXECUTABLE} -m scripts.generator
+    --operations "${CUTLASS_LIBRARY_OPERATIONS}"
     --build-dir ${PROJECT_BINARY_DIR}
     --curr-build-dir ${CMAKE_CURRENT_BINARY_DIR}
     --generator-target library
@@ -135,8 +139,8 @@ target_include_directories(
   )
 
 target_link_libraries(
-  cutlass_library_objs 
-  PUBLIC 
+  cutlass_library_objs
+  PUBLIC
   cutlass_library_includes
   )
 
@@ -148,7 +152,7 @@ function(cutlass_add_cutlass_library)
   cmake_parse_arguments(_ "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   cutlass_add_library(
-    ${__NAME} 
+    ${__NAME}
     ${__TYPE}
     EXPORT_NAME ${__EXPORT_NAME}
     $<TARGET_OBJECTS:cutlass_library_objs>
@@ -156,12 +160,12 @@ function(cutlass_add_cutlass_library)
 
   target_link_libraries(
     ${__NAME}
-    PUBLIC 
+    PUBLIC
     cutlass_library_includes
     )
 
   set_target_properties(${__NAME} PROPERTIES DEBUG_POSTFIX "${CUTLASS_LIBRARY_DEBUG_POSTFIX}")
-  
+
   set(OUTPUT_NAME cutlass)
 
   if (WIN32 AND ${__TYPE} STREQUAL "STATIC")
@@ -186,7 +190,7 @@ install(
   )
 
 install(
-  TARGETS 
+  TARGETS
     cutlass_lib
     cutlass_library_static
     cutlass_library_includes

--- a/tools/library/scripts/conv2d_operation.py
+++ b/tools/library/scripts/conv2d_operation.py
@@ -9,7 +9,7 @@ import enum
 import os.path
 import shutil
 
-from library import *
+from .library import *
 
 ###################################################################################################
 
@@ -40,7 +40,7 @@ class Conv2dOperation:
       MathOperation.multiply_add_complex_gaussian
       ]
     return self.tile_description.math_instruction.math_operation in complex_operators
-  
+
   #
   def accumulator_type(self):
     accum = self.tile_description.math_instruction.element_accumulator
@@ -96,7 +96,7 @@ class Conv2dOperation:
     ''' The full procedural name indicates architecture, extended name, tile size, and layout. '''
 
     opcode_class_name = OpcodeClassNames[self.tile_description.math_instruction.opcode_class]
-    
+
     threadblock = self.tile_description.procedural_name()
 
     # grouped conv
@@ -137,13 +137,13 @@ class EmitConv2dInstance:
   def __init__(self):
     self.template = """
   // Conv2d${conv_kind_name} ${iterator_algorithm_name} kernel instance "${operation_name}"
-  using ${operation_name}_base = 
+  using ${operation_name}_base =
   typename cutlass::conv::kernel::DefaultConv2d${conv_kind_name}<
-    ${element_a}, 
+    ${element_a},
     ${layout_a},
-    ${element_b}, 
+    ${element_b},
     ${layout_b},
-    ${element_c}, 
+    ${element_c},
     ${layout_c},
     ${element_accumulator},
     ${opcode_class},
@@ -228,7 +228,7 @@ class EmitConv2dInstance:
           1,
           ${threadblock_output_shape_n},
           ${threadblock_output_shape_p},
-          ${threadblock_output_shape_q}>, 
+          ${threadblock_output_shape_q}>,
     ${stages},
     ${math_operator},
     ${iterator_algorithm},
@@ -254,7 +254,7 @@ class EmitConv2dInstance:
       'layout_b': LayoutTag[operation.B.layout],
       'element_c': DataTypeTag[operation.C.element],
       'layout_c': LayoutTag[operation.C.layout],
-      'element_accumulator': DataTypeTag[operation.accumulator_type()], 
+      'element_accumulator': DataTypeTag[operation.accumulator_type()],
       'opcode_class': OpcodeClassTag[operation.tile_description.math_instruction.opcode_class],
       'arch': "cutlass::arch::Sm%d" % operation.arch,
       'threadblock_shape_m': str(operation.tile_description.threadblock_shape[0]),
@@ -289,7 +289,7 @@ class EmitConv2dInstance:
       values['threadblock_output_shape_n'] = str(operation.tile_description.threadblock_output_shape[0])
       values['threadblock_output_shape_p'] = str(operation.tile_description.threadblock_output_shape[1])
       values['threadblock_output_shape_q'] = str(operation.tile_description.threadblock_output_shape[2])
-      
+
       values['groups_per_cta'] = str(operation.tile_description.threadblock_output_shape[3])
 
       values['filter_shape_r'] = str(operation.tile_description.filter_shape[0])
@@ -350,7 +350,7 @@ class EmitConv2dConfigurationLibrary:
 ${operation_instance}
 
 // Derived class
-struct ${operation_name} : 
+struct ${operation_name} :
   public ${operation_name}_base { };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -446,12 +446,12 @@ void initialize_${configuration_name}(Manifest &manifest) {
       if operation.group_mode == GroupMode.Depthwise:
         self.configuration_file.write(SubstituteTemplate(self.configuration_direct_conv_instance, {
           'configuration_name': self.configuration_name,
-          'operation_name': operation.procedural_name()  
+          'operation_name': operation.procedural_name()
         }))
-      else: 
+      else:
         self.configuration_file.write(SubstituteTemplate(self.configuration_instance, {
           'configuration_name': self.configuration_name,
-          'operation_name': operation.procedural_name()  
+          'operation_name': operation.procedural_name()
         }))
 
     self.configuration_file.write(self.configuration_epilogue)

--- a/tools/library/scripts/conv3d_operation.py
+++ b/tools/library/scripts/conv3d_operation.py
@@ -9,7 +9,7 @@ import enum
 import os.path
 import shutil
 
-from library import *
+from .library import *
 
 ###################################################################################################
 
@@ -74,7 +74,7 @@ class Conv3dOperation:
     ''' The full procedural name indicates architecture, extended name, tile size, and layout. '''
 
     opcode_class_name = OpcodeClassNames[self.tile_description.math_instruction.opcode_class]
-    
+
     threadblock = "%dx%d_%dx%d" % (
       self.tile_description.threadblock_shape[0],
       self.tile_description.threadblock_shape[1],
@@ -111,13 +111,13 @@ class EmitConv3dInstance:
   def __init__(self):
     self.template = """
   // Conv3d${conv_kind_name} ${iterator_algorithm_name} kernel instance "${operation_name}"
-  using ${operation_name}_base = 
+  using ${operation_name}_base =
   typename cutlass::conv::kernel::DefaultConv3d${conv_kind_name}<
-    ${element_a}, 
+    ${element_a},
     cutlass::layout::TensorNDHWC,
-    ${element_b}, 
+    ${element_b},
     cutlass::layout::TensorNDHWC,
-    ${element_c}, 
+    ${element_c},
     cutlass::layout::TensorNDHWC,
     ${element_accumulator},
     ${opcode_class},
@@ -223,7 +223,7 @@ class EmitConv3dConfigurationLibrary:
 ${operation_instance}
 
 // Derived class
-struct ${operation_name} : 
+struct ${operation_name} :
   public ${operation_name}_base { };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -308,7 +308,7 @@ void initialize_${configuration_name}(Manifest &manifest) {
     for operation in self.operations:
       self.configuration_file.write(SubstituteTemplate(self.configuration_instance, {
         'configuration_name': self.configuration_name,
-        'operation_name': operation.procedural_name()  
+        'operation_name': operation.procedural_name()
       }))
 
     self.configuration_file.write(self.configuration_epilogue)

--- a/tools/library/scripts/gemm_operation.py
+++ b/tools/library/scripts/gemm_operation.py
@@ -11,7 +11,7 @@ import functools
 import operator
 import collections
 
-from library import *
+from .library import *
 
 ###################################################################################################
 #

--- a/tools/library/scripts/generator.py
+++ b/tools/library/scripts/generator.py
@@ -10,8 +10,8 @@ import shutil
 import argparse
 import logging
 
-from library import *
-from manifest import *
+from .library import *
+from .manifest import *
 from itertools import product
 
 ###################################################################################################
@@ -4264,7 +4264,7 @@ def GenerateSM90_TensorOp_tf32_WGMMA_gemm(manifest, cuda_version):
       DataType.tf32, DataType.tf32, DataType.f32,
       OpcodeClass.TensorOp,
       MathOperation.multiply_add)
-  
+
   min_cc = 90
   max_cc = 90
 
@@ -4289,7 +4289,7 @@ def GenerateSM90_TensorOp_tf32_WGMMA_gemm(manifest, cuda_version):
     TileDescription([math_inst.instruction_shape[0]*2, math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
       0, [4, 1, 1], math_inst, min_cc, max_cc, [1,1,1]),
   ]
- 
+
   tile_descriptions_small = [
     TileDescription([math_inst.instruction_shape[0], math_inst.instruction_shape[1], math_inst.instruction_shape[2]*4],
       0, [4, 1, 1], math_inst, min_cc, max_cc, [2,1,1]),
@@ -4341,7 +4341,7 @@ def GenerateSM90_TensorOp_tf32_WGMMA_gemm(manifest, cuda_version):
       [KernelScheduleType.TmaWarpSpecializedPingpong, EpilogueScheduleType.TmaWarpSpecialized],
       [KernelScheduleType.TmaWarpSpecializedPingpong, EpilogueScheduleType.NoSmemWarpSpecialized]
     ])
-    
+
     CreateGemmUniversal3xOperator(manifest, layouts_tf32_tn_nn_nt, tile_descriptions_medium, data_types, [
       [KernelScheduleType.TmaWarpSpecializedPingpong, EpilogueScheduleType.TmaWarpSpecialized],
       [KernelScheduleType.TmaWarpSpecializedPingpong, EpilogueScheduleType.NoSmemWarpSpecialized]
@@ -4367,7 +4367,7 @@ def GenerateSM90_TensorOp_tf32_WGMMA_gemm(manifest, cuda_version):
     ])
   else:
     CreateGemmUniversal3xOperator(manifest, layouts_tf32_tn_nn_nt, tile_descriptions, data_types, schedules_default)
-  
+
   CreateGemmUniversal3xOperator(manifest, layouts_tf32_tt, tile_descriptions, data_types, schedules_transposed_epilogue)
 
 #
@@ -4653,7 +4653,7 @@ def GenerateSM90_TensorOp_fp8_WGMMA_gemm(manifest, cuda_version):
       ]
       stream_k_schedules = []
 
-    
+
     for data_type in data_types:
       # With No-SMEM epilogues
       CreateGemmUniversal3xOperator(manifest, layouts, tile_descriptions, data_type, schedules)

--- a/tools/library/scripts/manifest.py
+++ b/tools/library/scripts/manifest.py
@@ -8,14 +8,14 @@ import enum
 import os.path
 import shutil
 
-from library import *
-from gemm_operation import *
-from rank_k_operation import *
-from rank_2k_operation import *
-from trmm_operation import *
-from symm_operation import *
-from conv2d_operation import *
-from conv3d_operation import *
+from .library import *
+from .gemm_operation import *
+from .rank_k_operation import *
+from .rank_2k_operation import *
+from .trmm_operation import *
+from .symm_operation import *
+from .conv2d_operation import *
+from .conv3d_operation import *
 import logging
 
 ###################################################################################################
@@ -241,7 +241,7 @@ class Manifest:
     else:
         self.kernel_filter_list = self.get_kernel_filters(args.kernel_filter_file)
         _LOGGER.info("Using {filter_count} kernel filters from {filter_file}".format(
-            filter_count = len(self.kernel_filter_list), 
+            filter_count = len(self.kernel_filter_list),
             filter_file = args.kernel_filter_file))
 
     self.operation_count = 0

--- a/tools/library/scripts/rank_2k_operation.py
+++ b/tools/library/scripts/rank_2k_operation.py
@@ -3,7 +3,7 @@
 #
 # \brief Generates the CUTLASS Library's instances
 #
-# 
+#
 
 import enum
 import os.path
@@ -11,7 +11,7 @@ import shutil
 import functools
 import operator
 
-from library import *
+from .library import *
 
 
 ###################################################################################################
@@ -34,7 +34,7 @@ class Rank2KOperation:
     self.rank_k_kind = rank_k_kind
     # tensor A and B have same data type and layout
     self.A = A
-    self.B = A  
+    self.B = A
     self.C = C
     self.element_epilogue = element_epilogue
     self.epilogue_functor = epilogue_functor
@@ -43,7 +43,7 @@ class Rank2KOperation:
   #
   def is_complex(self):
     complex_operators = [
-      MathOperation.multiply_add_complex, 
+      MathOperation.multiply_add_complex,
       MathOperation.multiply_add_complex_gaussian,
       MathOperation.multiply_add_complex_fast_f32
     ]
@@ -73,7 +73,7 @@ class Rank2KOperation:
   #
   def core_name(self):
     ''' The basic operation kind is prefixed with a letter indicating the accumulation type. '''
-    
+
     inst_shape = ''
     inst_operation = ''
     intermediate_type = ''
@@ -127,7 +127,7 @@ class Rank2KOperation:
   def layout_name(self):
     if self.is_complex() or self.is_planar_complex():
       return "%s" % (
-        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)] 
+        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)]
       )
     return "%s" % (ShortLayoutTypeNames[self.A.layout])
 
@@ -174,10 +174,10 @@ class EmitRank2KUniversalInstance:
   def __init__(self):
     self.rank_k_template = """
 // Rank K operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::Rank2K<
-    ${element_a}, ${layout_a}, 
-    ${element_b}, ${layout_b}, 
+    ${element_a}, ${layout_a},
+    ${element_b}, ${layout_b},
     ${element_c}, ${layout_c}, ${fill_mode},
     ${element_accumulator},
     ${opcode_class},
@@ -201,10 +201,10 @@ using Operation_${operation_name} =
 """
     self.rank_k_complex_template = """
 // Rank K operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::Rank2K<
-    ${element_a}, ${layout_a}, 
-    ${element_b}, ${layout_b}, 
+    ${element_a}, ${layout_a},
+    ${element_b}, ${layout_b},
     ${element_c}, ${layout_c}, ${fill_mode},
     ${element_accumulator},
     ${opcode_class},
@@ -233,7 +233,7 @@ using Operation_${operation_name} =
   def emit(self, operation):
 
     threadblock_shape = operation.tile_description.threadblock_shape
-    
+
     warp_count = operation.tile_description.warp_count
     warp_shape = [threadblock_shape[idx] // warp_count[idx] for idx in range(3)]
 
@@ -267,7 +267,7 @@ using Operation_${operation_name} =
       'stages': str(operation.tile_description.stages),
       'align_a': str(operation.A.alignment),
       'align_b': str(operation.B.alignment),
-      'split_k_serial': 'false', 
+      'split_k_serial': 'false',
       'math_operation': MathOperationTag[operation.tile_description.math_instruction.math_operation],
       'transform_a': ComplexTransformTag[operation.A.complex_transform],
       'transform_b': ComplexTransformTag[operation.B.complex_transform],
@@ -376,7 +376,7 @@ void initialize_${configuration_name}(Manifest &manifest) {
       'compile_guard_start': SubstituteTemplate(self.wmma_guard_start, {'sm_number': str(operation.arch)}) \
         if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "",
       'compile_guard_end': "#endif" \
-        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "" 
+        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else ""
       }))
 
   def __exit__(self, exception_type, exception_value, traceback):
@@ -389,9 +389,9 @@ void initialize_${configuration_name}(Manifest &manifest) {
     self.configuration_file.write(SubstituteTemplate(self.initialize_function_template, {
       'configuration_name': self.configuration_name
       }))
-   
+
     for instance_wrapper in self.instance_wrappers:
-      self.configuration_file.write(instance_wrapper) 
+      self.configuration_file.write(instance_wrapper)
 
     self.configuration_file.write(self.epilogue_template)
     self.configuration_file.close()

--- a/tools/library/scripts/rank_k_operation.py
+++ b/tools/library/scripts/rank_k_operation.py
@@ -3,7 +3,7 @@
 #
 # \brief Generates the CUTLASS Library's instances
 #
-# 
+#
 
 import enum
 import os.path
@@ -11,7 +11,7 @@ import shutil
 import functools
 import operator
 
-from library import *
+from .library import *
 
 
 ###################################################################################################
@@ -41,7 +41,7 @@ class RankKOperation:
   #
   def is_complex(self):
     complex_operators = [
-      MathOperation.multiply_add_complex, 
+      MathOperation.multiply_add_complex,
       MathOperation.multiply_add_complex_gaussian,
       MathOperation.multiply_add_complex_fast_f32
     ]
@@ -71,7 +71,7 @@ class RankKOperation:
   #
   def core_name(self):
     ''' The basic operation kind is prefixed with a letter indicating the accumulation type. '''
-    
+
     inst_shape = ''
     inst_operation = ''
     intermediate_type = ''
@@ -125,7 +125,7 @@ class RankKOperation:
   def layout_name(self):
     if self.is_complex() or self.is_planar_complex():
       return "%s" % (
-        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)] 
+        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)]
       )
     return "%s" % (ShortLayoutTypeNames[self.A.layout])
 
@@ -172,9 +172,9 @@ class EmitRankKUniversalInstance:
   def __init__(self):
     self.rank_k_template = """
 // Rank K operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::RankK<
-    ${element_a}, ${layout_a}, 
+    ${element_a}, ${layout_a},
     ${element_c}, ${layout_c}, ${fill_mode},
     ${element_accumulator},
     ${opcode_class},
@@ -197,9 +197,9 @@ using Operation_${operation_name} =
 """
     self.rank_k_complex_template = """
 // Rank K operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::RankK<
-    ${element_a}, ${layout_a}, 
+    ${element_a}, ${layout_a},
     ${element_c}, ${layout_c}, ${fill_mode},
     ${element_accumulator},
     ${opcode_class},
@@ -226,7 +226,7 @@ using Operation_${operation_name} =
   def emit(self, operation):
 
     threadblock_shape = operation.tile_description.threadblock_shape
-    
+
     warp_count = operation.tile_description.warp_count
     warp_shape = [threadblock_shape[idx] // warp_count[idx] for idx in range(3)]
 
@@ -257,7 +257,7 @@ using Operation_${operation_name} =
       'swizzling_functor': SwizzlingFunctorTag[operation.swizzling_functor],
       'stages': str(operation.tile_description.stages),
       'align_a': str(operation.A.alignment),
-      'split_k_serial': 'false', 
+      'split_k_serial': 'false',
       'math_operation': MathOperationTag[operation.tile_description.math_instruction.math_operation],
       'transform_a': ComplexTransformTag[operation.A.complex_transform],
       'blas_mode': BlasModeTag[operation.blas_mode]
@@ -365,7 +365,7 @@ void initialize_${configuration_name}(Manifest &manifest) {
       'compile_guard_start': SubstituteTemplate(self.wmma_guard_start, {'sm_number': str(operation.arch)}) \
         if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "",
       'compile_guard_end': "#endif" \
-        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "" 
+        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else ""
       }))
 
   def __exit__(self, exception_type, exception_value, traceback):
@@ -378,9 +378,9 @@ void initialize_${configuration_name}(Manifest &manifest) {
     self.configuration_file.write(SubstituteTemplate(self.initialize_function_template, {
       'configuration_name': self.configuration_name
       }))
-   
+
     for instance_wrapper in self.instance_wrappers:
-      self.configuration_file.write(instance_wrapper) 
+      self.configuration_file.write(instance_wrapper)
 
     self.configuration_file.write(self.epilogue_template)
     self.configuration_file.close()

--- a/tools/library/scripts/symm_operation.py
+++ b/tools/library/scripts/symm_operation.py
@@ -3,7 +3,7 @@
 #
 # \brief Generates the CUTLASS Library's instances
 #
-# 
+#
 
 import enum
 import os.path
@@ -11,7 +11,7 @@ import shutil
 import functools
 import operator
 
-from library import *
+from .library import *
 
 
 ###################################################################################################
@@ -34,7 +34,7 @@ class SymmOperation:
     self.symm_kind = symm_kind
     # tensor A and B have same data type and layout
     self.A = A
-    self.B = B  
+    self.B = B
     self.C = C
     self.element_epilogue = element_epilogue
     self.epilogue_functor = epilogue_functor
@@ -43,7 +43,7 @@ class SymmOperation:
   #
   def is_complex(self):
     complex_operators = [
-      MathOperation.multiply_add_complex, 
+      MathOperation.multiply_add_complex,
       MathOperation.multiply_add_complex_gaussian,
       MathOperation.multiply_add_complex_fast_f32
     ]
@@ -73,7 +73,7 @@ class SymmOperation:
   #
   def core_name(self):
     ''' The basic operation kind is prefixed with a letter indicating the accumulation type. '''
-    
+
     inst_shape = ''
     inst_operation = ''
     intermediate_type = ''
@@ -127,7 +127,7 @@ class SymmOperation:
   def layout_name(self):
     if self.is_complex() or self.is_planar_complex():
       return "%s" % (
-        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)] 
+        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)]
       )
     return "%s" % (ShortLayoutTypeNames[self.A.layout])
 
@@ -179,10 +179,10 @@ class EmitSymmUniversalInstance:
   def __init__(self):
     self.symm_template = """
 // Symm operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::Symm<
-    ${element_a}, ${layout_a}, ${side_mode}, ${fill_mode}, 
-    ${element_b}, ${layout_b}, 
+    ${element_a}, ${layout_a}, ${side_mode}, ${fill_mode},
+    ${element_b}, ${layout_b},
     ${element_c}, ${layout_c},
     ${element_accumulator},
     ${opcode_class},
@@ -206,10 +206,10 @@ using Operation_${operation_name} =
 """
     self.symm_complex_template = """
 // Symm operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::Symm<
-    ${element_a}, ${layout_a}, ${side_mode}, ${fill_mode}, 
-    ${element_b}, ${layout_b}, 
+    ${element_a}, ${layout_a}, ${side_mode}, ${fill_mode},
+    ${element_b}, ${layout_b},
     ${element_c}, ${layout_c},
     ${element_accumulator},
     ${opcode_class},
@@ -236,7 +236,7 @@ using Operation_${operation_name} =
   def emit(self, operation):
 
     threadblock_shape = operation.tile_description.threadblock_shape
-    
+
     warp_count = operation.tile_description.warp_count
     warp_shape = [threadblock_shape[idx] // warp_count[idx] for idx in range(3)]
 
@@ -271,7 +271,7 @@ using Operation_${operation_name} =
       'stages': str(operation.tile_description.stages),
       'align_a': str(operation.A.alignment),
       'align_b': str(operation.B.alignment),
-      'split_k_serial': 'false', 
+      'split_k_serial': 'false',
       'math_operation': MathOperationTag[operation.tile_description.math_instruction.math_operation],
       'blas_mode': BlasModeTag[operation.blas_mode]
     }
@@ -378,7 +378,7 @@ void initialize_${configuration_name}(Manifest &manifest) {
       'compile_guard_start': SubstituteTemplate(self.wmma_guard_start, {'sm_number': str(operation.arch)}) \
         if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "",
       'compile_guard_end': "#endif" \
-        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "" 
+        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else ""
       }))
 
   def __exit__(self, exception_type, exception_value, traceback):
@@ -391,9 +391,9 @@ void initialize_${configuration_name}(Manifest &manifest) {
     self.configuration_file.write(SubstituteTemplate(self.initialize_function_template, {
       'configuration_name': self.configuration_name
       }))
-   
+
     for instance_wrapper in self.instance_wrappers:
-      self.configuration_file.write(instance_wrapper) 
+      self.configuration_file.write(instance_wrapper)
 
     self.configuration_file.write(self.epilogue_template)
     self.configuration_file.close()

--- a/tools/library/scripts/trmm_operation.py
+++ b/tools/library/scripts/trmm_operation.py
@@ -3,7 +3,7 @@
 #
 # \brief Generates the CUTLASS Library's instances
 #
-# 
+#
 
 import enum
 import os.path
@@ -11,7 +11,7 @@ import shutil
 import functools
 import operator
 
-from library import *
+from .library import *
 
 
 ###################################################################################################
@@ -40,7 +40,7 @@ class TrmmOperation:
   #
   def is_complex(self):
     complex_operators = [
-      MathOperation.multiply_add_complex, 
+      MathOperation.multiply_add_complex,
       MathOperation.multiply_add_complex_gaussian,
       MathOperation.multiply_add_complex_fast_f32
     ]
@@ -71,7 +71,7 @@ class TrmmOperation:
   #
   def core_name(self):
     ''' The basic operation kind is prefixed with a letter indicating the accumulation type. '''
-    
+
     inst_shape = ''
     inst_operation = ''
     intermediate_type = ''
@@ -123,8 +123,8 @@ class TrmmOperation:
   def layout_name(self):
     if self.is_complex() or self.is_planar_complex():
       return "%s%s" % (
-        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)], 
-        ShortComplexLayoutNames[(self.B.layout, self.B.complex_transform)] 
+        ShortComplexLayoutNames[(self.A.layout, self.A.complex_transform)],
+        ShortComplexLayoutNames[(self.B.layout, self.B.complex_transform)]
       )
     return "%s%s" % (ShortLayoutTypeNames[self.A.layout], ShortLayoutTypeNames[self.B.layout])
 
@@ -181,11 +181,11 @@ class EmitTrmmUniversalInstance:
   def __init__(self):
     self.trmm_template = """
 // Trmm operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::Trmm<
     ${element_a}, ${layout_a},
-    ${side_mode}, ${fill_mode}, ${diag_type}, 
-    ${element_b}, ${layout_b}, 
+    ${side_mode}, ${fill_mode}, ${diag_type},
+    ${element_b}, ${layout_b},
     ${element_c}, ${layout_c},
     ${element_accumulator},
     ${opcode_class},
@@ -210,11 +210,11 @@ using Operation_${operation_name} =
 """
     self.trmm_complex_template = """
 // Trmm operator ${operation_name}
-using Operation_${operation_name} = 
+using Operation_${operation_name} =
   typename cutlass::gemm::device::Trmm<
-    ${element_a}, ${layout_a}, 
-    ${side_mode}, ${fill_mode}, ${diag_type}, 
-    ${element_b}, ${layout_b}, 
+    ${element_a}, ${layout_a},
+    ${side_mode}, ${fill_mode}, ${diag_type},
+    ${element_b}, ${layout_b},
     ${element_c}, ${layout_c},
     ${element_accumulator},
     ${opcode_class},
@@ -235,7 +235,7 @@ using Operation_${operation_name} =
     ${align_b},
     ${split_k_serial},
     ${math_operation},
-    ${transform_a} 
+    ${transform_a}
 >;
 """
 
@@ -252,7 +252,7 @@ using Operation_${operation_name} =
       'operation_name': operation.procedural_name(),
       'element_a': DataTypeTag[operation.A.element],
       'layout_a': LayoutTag[operation.A.layout],
-      'side_mode' : SideModeTag[operation.A.side_mode], 
+      'side_mode' : SideModeTag[operation.A.side_mode],
       'fill_mode': FillModeTag[operation.A.fill_mode],
       'diag_type' : DiagTypeTag[operation.A.diag_type],
       'element_b': DataTypeTag[operation.B.element],
@@ -278,7 +278,7 @@ using Operation_${operation_name} =
       'stages': str(operation.tile_description.stages),
       'align_a': str(1),  # TRMM A's alignment is always 1 for no padding to work until we make zfill work with variable bytes
       'align_b': str(operation.B.alignment),
-      'split_k_serial': 'false', 
+      'split_k_serial': 'false',
       'math_operation': MathOperationTag[operation.tile_description.math_instruction.math_operation],
       'transform_a': ComplexTransformTag[operation.A.complex_transform]
     }
@@ -385,7 +385,7 @@ void initialize_${configuration_name}(Manifest &manifest) {
       'compile_guard_start': SubstituteTemplate(self.wmma_guard_start, {'sm_number': str(operation.arch)}) \
         if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "",
       'compile_guard_end': "#endif" \
-        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else "" 
+        if operation.tile_description.math_instruction.opcode_class == OpcodeClass.WmmaTensorOp else ""
       }))
 
   def __exit__(self, exception_type, exception_value, traceback):
@@ -398,9 +398,9 @@ void initialize_${configuration_name}(Manifest &manifest) {
     self.configuration_file.write(SubstituteTemplate(self.initialize_function_template, {
       'configuration_name': self.configuration_name
       }))
-   
+
     for instance_wrapper in self.instance_wrappers:
-      self.configuration_file.write(instance_wrapper) 
+      self.configuration_file.write(instance_wrapper)
 
     self.configuration_file.write(self.epilogue_template)
     self.configuration_file.close()


### PR DESCRIPTION
## Description
This is another attempt to use relative import for files under `tools/library/scripts/`, so that it's easier to import cutlass python scripts in other project. e.g. A related PR: https://github.com/pytorch/pytorch/pull/107802/.

Also updated `tools/library/CMakeLists.txt` to add `tools/library` to `PYTHONPATH` and use `python -m package.module` to execute `generator.py` to solve previous import errors.

## Testing
Commandlines below runs successfully:
```
cmake .. -DCUTLASS_NVCC_ARCHS=80
make cutlass_profiler -j16
```

