### PR TITLE
Fused Two Gemms: great-equal instead of equal to arch version

### DIFF
--- a/examples/13_two_tensor_op_fusion/test_run.h
+++ b/examples/13_two_tensor_op_fusion/test_run.h
@@ -66,7 +66,7 @@ int testRun(int arch, std::vector<bool (*)()> & test_funcs, const std::string & 
     return -1;
   }
 
-  if (!(props.major == arch_major && props.minor == arch_minor)) {
+  if (!(props.major >= arch_major && props.minor >= arch_minor)) {
     supported = false;
   }
 


### PR DESCRIPTION
Tries to address #1081 . 

A (tiny) change to allow the device prop to be at least the specified arch, instead of requiring equality. 

