### PR TITLE
fix matrix B indices

### DIFF
--- a/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu
+++ b/examples/48_hopper_warp_specialized_gemm/48_hopper_warp_specialized_gemm.cu
@@ -324,7 +324,7 @@ typename Gemm::Arguments args_from_options(const Options &options)
 
 bool verify(const Options &options) {
   cutlass::TensorRef ref_A(block_A.get(), Gemm::LayoutA::packed({options.m, options.k}));
-  cutlass::TensorRef ref_B(block_B.get(), Gemm::LayoutB::packed({options.n, options.k}));
+  cutlass::TensorRef ref_B(block_B.get(), Gemm::LayoutB::packed({options.k, options.n}));
   cutlass::TensorRef ref_C(block_C.get(), Gemm::LayoutC::packed({options.m, options.n}));
   cutlass::TensorRef ref_D(block_ref_D.get(), Gemm::LayoutD::packed({options.m, options.n}));
 


### PR DESCRIPTION
matrix B index swapped which fails the sanity check for non-square inputs.
quick fix addressing the issue https://github.com/NVIDIA/cutlass/issues/1088