### PR TITLE
[fix] fix comparison operator for integer_subbyte

### DIFF
--- a/include/cute/numeric/integer_subbyte.hpp
+++ b/include/cute/numeric/integer_subbyte.hpp
@@ -111,7 +111,7 @@ struct integer_subbyte
     if (sign_mask_ & storage) {
       return !(rhs.storage < storage);
     } else {
-      return storage < rhs.storage;
+      return storage <= rhs.storage;
     }
   }
 

--- a/include/cutlass/integer_subbyte.h
+++ b/include/cutlass/integer_subbyte.h
@@ -126,7 +126,7 @@ struct integer_subbyte {
         return !(rhs.storage < storage);
       }
     }
-    return storage < rhs.storage;
+    return storage <= rhs.storage;
   }
 
   /// Less than


### PR DESCRIPTION
The comparison operator `<=` for integer subbyte is incorrect. This fix addresses this issue.