### PR TITLE
Change the position of minus sign in line1549 array.h

### DIFF
--- a/include/cutlass/array.h
+++ b/include/cutlass/array.h
@@ -1545,8 +1545,8 @@ struct negate<Array<half_t, N>> {
     }
 
     if constexpr (N % 2) {
-      half_t x = lhs[N - 1];
-      __half lhs_val = -reinterpret_cast<__half const &>(x);
+      half_t x = -lhs[N - 1];
+      __half lhs_val = reinterpret_cast<__half const &>(x);
       result[N - 1] = reinterpret_cast<half_t const &>(lhs_val);
     }
 


### PR DESCRIPTION
when I use `cutlass::epilogue::thread::LinearCombinationSigmoid`, I encounter the this error: `cutlass/include/cutlass/array.h(1549): error: no operator "-" matches these operands` 

Moving  operator "-" from line 1549 to 1548 can solve this error.

Discovered by @furong@pjlab.org.cn @suzhongling@pjlab.org.cn @xuhaoran@pjlab.org.cn