### PR TITLE
Fix recursive print dispatch

### DIFF
--- a/include/cute/util/print.hpp
+++ b/include/cute/util/print.hpp
@@ -138,13 +138,6 @@ print(char const* format, T const&... t) {
   printf(format, t...);
 }
 
-template <class... T>
-CUTE_HOST_DEVICE
-void
-print(T const&... t) {
-  (print(t), ...);
-}
-
 CUTE_HOST_DEVICE
 void
 print(char const* format) {


### PR DESCRIPTION
```c++
#include <cute/tensor.hpp>

int main() {
  using T = float;
  using namespace cute;

  constexpr int M = 16;

  size_t size = sizeof(T) * M;

  T *data = (T*)malloc(size);
  auto t = make_tensor(data, make_shape(Int<M>{}));
  fill(t, 1.23);

  print(t);
  print_tensor(t);

  return 0;
}
```

When I print a tensor stored in cpu memory(as the code snippets shows), the print will call https://github.com/NVIDIA/cutlass/blob/e0aaa3c3b38db9a89c31f04fef91e92123ad5e2e/include/cute/util/print.hpp#L144 recursively and finally causes the program crash. 
I fix it by removing the self-recusive print. It worked for me. But I'm not sure whether it has side effect. Please help review.