### PR TITLE
Fix example 47

### DIFF
--- a/examples/47_ampere_gemm_universal_streamk/ampere_gemm_universal_streamk_broadcast.cu
+++ b/examples/47_ampere_gemm_universal_streamk/ampere_gemm_universal_streamk_broadcast.cu
@@ -85,7 +85,7 @@
 
 #include "cutlass/epilogue/threadblock/fusion/visitors.hpp"
 #include "cutlass/gemm/kernel/default_gemm_universal_with_visitor.h"
-#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/device/gemm_universal_base.h"
 
 #include "helper.h"
 
@@ -257,7 +257,7 @@ using EVTKernelStreamK =
     EVTEpilogueStages
 >::GemmKernel;
 
-using DeviceGemmStreamK = cutlass::gemm::device::GemmUniversalAdapter<EVTKernelStreamK>;
+using DeviceGemmStreamK = cutlass::gemm::device::GemmUniversalBase<EVTKernelStreamK>;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Testbed utility types


### PR DESCRIPTION
This pull request fixes the error of example 47. Originally the GemmUniversalAdapter performs internal transpose for row-major layout C. Yet under EVT with row-major output, internal transpose is not required. Using GemmUniversalBase can avoid this internal transpose.