### PR TITLE
fix missing return warning for repeat and axpby

### DIFF
--- a/include/cute/algorithm/axpby.hpp
+++ b/include/cute/algorithm/axpby.hpp
@@ -75,6 +75,8 @@ axpby(Alpha                    const& alpha,
     else {
       return beta == Int<0>{};
     }
+
+    CUTE_GCC_UNREACHABLE;
   } ();
 
   CUTE_UNROLL

--- a/include/cute/algorithm/tuple_algorithms.hpp
+++ b/include/cute/algorithm/tuple_algorithms.hpp
@@ -743,6 +743,8 @@ repeat(X const& x)
   } else {
     return detail::construct(0, x, seq<>{}, make_seq<N>{}, seq<>{});
   }
+
+  CUTE_GCC_UNREACHABLE;
 }
 
 //


### PR DESCRIPTION
When I compile a test code in linux with g++9.4.0 and nvcc11.4, there are serval warnings:

<img width="1637" alt="image" src="https://github.com/NVIDIA/cutlass/assets/26267436/edf748ef-d31e-4d62-aa50-c50543552202">
<img width="1340" alt="image" src="https://github.com/NVIDIA/cutlass/assets/26267436/e2ae85dd-e0b6-4236-a196-5b9601224d75">

I fixed it following the other code blocks.
