### PR TITLE
Make runtime assert more clear on CUDA

### DIFF
--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -123,7 +123,7 @@
 #define CUTE_STATIC_ASSERT_V(x,...) static_assert(decltype(x)::value, ##__VA_ARGS__)
 
 #if defined(__CUDA_ARCH__)
-#  define CUTE_RUNTIME_ASSERT(x) __brkpt()
+#  define CUTE_RUNTIME_ASSERT(x)  do { printf(x); __brkpt(); } while(0)
 #else
 #  define CUTE_RUNTIME_ASSERT(x) assert(0 && x)
 #endif


### PR DESCRIPTION
As stands, when a runtime assert is called on CUDA platforms your program just explodes with no stack trace and no mention of the error that was encountered. I just spent multiple hours debugging an issue where a `CUTE_RUNTIME_ASSERT` was called because I compiled for `sm90` instead of `sm90a`. If the error message had been printed when `CUTE_RUNTIME_ASSERT` was called, this would have taken thirty seconds.