### PR TITLE
Add config.yml issue template with Discord link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: CUTLASS Discord
+    url: https://discord.gg/nvidiadeveloper
+    about: Come chat about using and contributing to CUTLASS! 


### PR DESCRIPTION
Adds an entry to the New Issue page with a link to the CUTLASS Discord.

Example from CCCL repo: https://github.com/NVIDIA/cccl/issues/new/choose

![latest-screenshot](https://github.com/NVIDIA/cutlass/assets/15221289/4de7e9a7-d5e9-447d-a070-8a56e4741084)
