### PR TITLE
change 'not' to symbol '!' and unify the code style for 'else'

### DIFF
--- a/include/cute/algorithm/tuple_algorithms.hpp
+++ b/include/cute/algorithm/tuple_algorithms.hpp
@@ -392,7 +392,7 @@ CUTE_HOST_DEVICE constexpr
 auto
 none_of(T const& t, F&& f)
 {
-  return not any_of(t, f);
+  return !any_of(t, f);
 }
 
 //
@@ -525,11 +525,9 @@ back(T&& t)
     // We help it by peeling off the nonrecursive case a level "early."
     if constexpr (! is_tuple<remove_cvref_t<decltype(get<N - 1>(static_cast<T&&>(t)))>>::value) {
       return get<N - 1>(static_cast<T&&>(t));
-    }
-    else {
+    } else {
       return back(get<N - 1>(static_cast<T&&>(t)));
     }
-
   } else {
     return static_cast<T&&>(t);
   }
@@ -565,8 +563,7 @@ select(T const & t, Indices const & indices)
 {
   if constexpr (is_tuple<Indices>::value) {
     return cute::transform(indices, [&t](auto i) { return select(t, i); });
-  }
-  else {
+  } else {
     static_assert(is_static<Indices>::value, "Order must be static");
     return get<Indices::value>(t);
   }
@@ -615,7 +612,7 @@ template <class T>
 struct is_flat : true_type {};
 
 template <class... Ts>
-struct is_flat<tuple<Ts...>> : bool_constant<(true && ... && (not is_tuple<Ts>::value))> {};
+struct is_flat<tuple<Ts...>> : bool_constant<(true && ... && (!is_tuple<Ts>::value))> {};
 
 template <class T>
 CUTE_HOST_DEVICE constexpr
@@ -625,8 +622,7 @@ flatten_to_tuple(T const& t)
   if constexpr (is_tuple<T>::value) {
     if constexpr (is_flat<T>::value) {
       return t;
-    } else
-    {
+    } else {
       return filter_tuple(t, [](auto const& a) { return flatten_to_tuple(a); });
     }
   } else {
@@ -644,8 +640,7 @@ flatten(T const& t)
   if constexpr (is_tuple<T>::value) {
     if constexpr (is_flat<T>::value) {
       return t;
-    } else
-    {
+    } else {
       return filter_tuple(t, [](auto const& a) { return flatten_to_tuple(a); });
     }
   } else {
@@ -773,7 +768,7 @@ CUTE_HOST_DEVICE constexpr
 auto
 group(T const& t)
 {
-  if constexpr (not is_tuple<T>::value) {
+  if constexpr (!is_tuple<T>::value) {
     if constexpr (E == -1) {
       return group<B,1>(t);
     } else {

--- a/include/cute/algorithm/tuple_algorithms.hpp
+++ b/include/cute/algorithm/tuple_algorithms.hpp
@@ -392,7 +392,7 @@ CUTE_HOST_DEVICE constexpr
 auto
 none_of(T const& t, F&& f)
 {
-  return !any_of(t, f);
+  return not any_of(t, f);
 }
 
 //
@@ -612,7 +612,7 @@ template <class T>
 struct is_flat : true_type {};
 
 template <class... Ts>
-struct is_flat<tuple<Ts...>> : bool_constant<(true && ... && (!is_tuple<Ts>::value))> {};
+struct is_flat<tuple<Ts...>> : bool_constant<(true && ... && (not is_tuple<Ts>::value))> {};
 
 template <class T>
 CUTE_HOST_DEVICE constexpr
@@ -768,7 +768,7 @@ CUTE_HOST_DEVICE constexpr
 auto
 group(T const& t)
 {
-  if constexpr (!is_tuple<T>::value) {
+  if constexpr (not is_tuple<T>::value) {
     if constexpr (E == -1) {
       return group<B,1>(t);
     } else {


### PR DESCRIPTION
1. While the `not` operator is functional in C++, its usage is rather restricted. Therefore, I recommend employing the more prevalent `!` symbol to denote logical negation, which would enhance comprehension for subsequent readers.
2. make the `else` code style following the other code blocks in this file.

Reference:
https://en.cppreference.com/w/cpp/language/operator_alternative