### PR TITLE
Fix broken pipeline link in docs

### DIFF
--- a/media/docs/pipeline.md
+++ b/media/docs/pipeline.md
@@ -73,7 +73,7 @@ dozens of different kinds of asynchronously executing operations
 that synchronize using multiple barriers organized as a circular list.
 This complexity is too much for human programmers to manage by hand.
 As a result, we have developed
-[asynchronous Pipeline classes](/include/cutlass/pipeline.hpp).
+[asynchronous Pipeline classes](/include/cutlass/pipeline/).
 These classes help developers orchestrate a pipeline
 of asynchronous producer and consumer threads,
 without needing to worry about lower-level hardware details.


### PR DESCRIPTION
Pipeline is now a folder instead of a singular header file.

EDIT: it appears that the link does not work when opened in the "Files changed" window. When I try it in the actual commit branch it does point to the correct place.