### PR TITLE
Hotfix for Pytorch Windows build issue #1171

### DIFF
--- a/include/cutlass/detail/helper_macros.hpp
+++ b/include/cutlass/detail/helper_macros.hpp
@@ -143,11 +143,11 @@ namespace cutlass {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#define CUTLASS_CONSTEXPR constexpr
+
 #if (201700L <= __cplusplus)
-#define CUTLASS_CONSTEXPR_IF_CXX17 constexpr
 #define CUTLASS_CXX17_OR_LATER 1
 #else
-#define CUTLASS_CONSTEXPR_IF_CXX17
 #define CUTLASS_CXX17_OR_LATER 0
 #endif
 

--- a/include/cutlass/fast_math.h
+++ b/include/cutlass/fast_math.h
@@ -168,7 +168,7 @@ value_t abs_for_integer(value_t a) {
  */
 template <typename value_t>
 CUTLASS_HOST_DEVICE
-CUTLASS_CONSTEXPR_IF_CXX17
+CUTLASS_CONSTEXPR
 value_t gcd(value_t a, value_t b) {
   for (;;) {
     if (a == 0) return cutlass::abs_for_integer(b);
@@ -183,7 +183,7 @@ value_t gcd(value_t a, value_t b) {
  */
 template <typename value_t>
 CUTLASS_HOST_DEVICE
-CUTLASS_CONSTEXPR_IF_CXX17
+CUTLASS_CONSTEXPR
 value_t lcm(value_t a, value_t b) {
   value_t temp = gcd(a, b);
 
@@ -211,14 +211,14 @@ value_t lcm_cxx11(value_t a, value_t b) {
 }
 /// Returns the smallest value in the half-open range [a, a+b) that is a multiple of b
 CUTLASS_HOST_DEVICE
-CUTLASS_CONSTEXPR_IF_CXX17
+CUTLASS_CONSTEXPR
 int round_up(int a, int b) {
   return ((a + b - 1) / b) * b;
 }
 
 /// Returns the ceiling of (a / b)
 CUTLASS_HOST_DEVICE
-CUTLASS_CONSTEXPR_IF_CXX17
+CUTLASS_CONSTEXPR
 int ceil_div(int a, int b) {
   return (a + b - 1) / b;
 }
@@ -679,12 +679,12 @@ struct Max {
 };
 
 CUTLASS_HOST_DEVICE
-CUTLASS_CONSTEXPR_IF_CXX17 int const_min(int a, int b) {
+CUTLASS_CONSTEXPR int const_min(int a, int b) {
     return (b < a ? b : a);
 }
 
 CUTLASS_HOST_DEVICE
-CUTLASS_CONSTEXPR_IF_CXX17 int const_max(int a, int b) {
+CUTLASS_CONSTEXPR int const_max(int a, int b) {
     return (b > a ? b : a);
 }
 


### PR DESCRIPTION
In Pytorch we're seeing a build failure on Windows with VS 2019, Cuda 11.8 and Cutlass 3.2.2 ( likely also with 3.3 ) that's currently blocking Pytorch to upgrade to Cutlass 3.2.2 or later.

See #1171

this is a hotfix, which seems to resolve the problem in Pytorch. Creating a draft PR to also check it against Cutlass CI.