### PR TITLE
fix predicated copy for rank-1 tensor

### DIFF
--- a/include/cute/algorithm/copy.hpp
+++ b/include/cute/algorithm/copy.hpp
@@ -154,7 +154,15 @@ copy_if(Copy_Atom<CopyArgs...>       const& copy_atom,
 {
   static_assert(SrcLayout::rank == DstLayout::rank, "CopyAtom rank-mismatch.");
   if constexpr (SrcLayout::rank == 1) {   // Dispatch the copy
-    copy_atom.call(src, dst);
+    if constexpr (detail::has_with_bool<Copy_Atom<CopyArgs...>>) {
+      copy_atom.with(pred).call(src, dst);
+    } else if constexpr (is_same_v<PredTensor, TrivialPredTensor>) {
+      copy_atom.call(src, dst);
+    } else {
+      if (pred) {
+        copy_atom.call(src, dst);
+      }
+    }
   } else {                                // Loop over all but the first mode
     constexpr int R = SrcLayout::rank;
     auto src_v = group_modes<1,R>(src);


### PR DESCRIPTION
in `copy_if` implementation, for the rank == 1 branch, the copy just ignore the predicated tensor.
I help fix it and provide a test.

```cpp
#include <cute/tensor.hpp>

template <typename T, typename G2GTiledCopy>
__global__ void pred_copy(T *output, const T *input, bool pred) {
  using namespace cute;

  Tensor S = make_tensor(make_gmem_ptr(input), make_shape(Int<1>{}), make_stride(Int<1>{}));
  Tensor D = make_tensor(make_gmem_ptr(output), make_shape(Int<1>{}), make_stride(Int<1>{}));

  G2GTiledCopy tiled_copy;
  auto thr_copy = tiled_copy.get_thread_slice(0);
  auto tS = thr_copy.partition_S(S);
  auto tD = thr_copy.partition_S(D);

  Tensor tSpS = make_tensor<bool>(make_shape(size<1>(tS)), make_stride(Int<1>{}));
  tSpS(0) = pred;

  // 1
  // copy(tiled_copy, tS, tD);

  // 2
  // copy_if(tiled_copy, tSpS, tS, tD);

  // 3
#pragma unroll
  for (int i = 0; i < size<0>(tSpS); ++i) {
    copy_if(tiled_copy, tSpS(i), tS(_, i), tD(_, i));
  }
}

int main() {
  using T = int; //cute::half_t;
  using namespace cute;
  using X = Underscore;

  constexpr int N = 1;

  T *input = nullptr;
  T *output = nullptr;

  T *input_host = nullptr;
  T *output_host = nullptr;

  input_host = (T*)malloc(sizeof(T) * N);
  output_host = (T*)malloc(sizeof(T) * N);


  input_host[0] = 100;

  cudaMalloc(&input, sizeof(T) * N);
  cudaMalloc(&output, sizeof(T) * N);
  cudaMemcpy(input, input_host, sizeof(T) * N, cudaMemcpyHostToDevice);
  cudaMemset(output, 0, sizeof(T) * N);

  using copy_op = UniversalCopy<T>;
  using copy_traits = Copy_Traits<copy_op>;
  using copy_atom = Copy_Atom<copy_traits, T>;

  auto thr_layout = make_layout(make_shape(Int<1>{}));
  auto val_layout = make_layout(make_shape(Int<1>{}));
  using G2GTiledCopy = decltype(make_tiled_copy(copy_atom{}, thr_layout, val_layout));

  bool pred = false;
  pred_copy<T, G2GTiledCopy><<<1, 1>>>(output, input, pred);

  cudaMemcpy(output_host, output, sizeof(T) * N, cudaMemcpyDeviceToHost);
  cudaDeviceSynchronize();
  auto err = cudaGetLastError();
  printf("err = %d, str = %s\n", err, cudaGetErrorString(err));

  assert(output_host[0] != input_host[0]);

  return 0;
}
```