### PR TITLE
Explicitly cast `blockIdx` to `uint3`

### DIFF
--- a/include/cutlass/gemm/kernel/sm70_gemm.hpp
+++ b/include/cutlass/gemm/kernel/sm70_gemm.hpp
@@ -201,7 +201,7 @@ public:
     // Get the appropriate blocks for this thread block -- potential for thread block locality
     int thread_idx = int(threadIdx.x);
     auto blk_shape = TileShape{};                                                                // (BLK_M,BLK_N,BLK_K)
-    auto [m_coord, n_coord, l_coord] = blockIdx;
+    auto [m_coord, n_coord, l_coord] = static_cast<uint3>(blockIdx);
     auto blk_coord_mnkl = make_coord(m_coord, n_coord, _, l_coord);                                        // (m,n,k,l)
 
     // Represent the full tensors


### PR DESCRIPTION
This works around a clang issue where blockIdx is of a different type.