### PR TITLE
Fix Stream-K reduce bug in epilogue with broadcast

### DIFF
--- a/include/cutlass/epilogue/threadblock/epilogue_with_broadcast.h
+++ b/include/cutlass/epilogue/threadblock/epilogue_with_broadcast.h
@@ -946,13 +946,13 @@ private:
       //
 
       if (OutputOp::kStoreZ) {
+        destination_iterator += reduce_fragment_idx;
         destination_iterator.store(frag_Z);
-        ++destination_iterator;
       }
 
       if (OutputOp::kStoreT) {
+        tensor_iterator += reduce_fragment_idx;
         tensor_iterator.store(frag_T);
-        ++tensor_iterator;
       }
     }
 };
@@ -1698,13 +1698,13 @@ private:
       //
 
       if (OutputOp::kStoreZ) {
+        destination_iterator += reduce_fragment_idx;
         destination_iterator.store(frag_Z);
-        ++destination_iterator;
       }
 
       if (OutputOp::kStoreT) {
+        tensor_iterator += reduce_fragment_idx;
         tensor_iterator.store(frag_T);
-        ++tensor_iterator;
       }
     }
 };


### PR DESCRIPTION
Fixes an issue that existed since Stream-K support was added to epilogue with broadcast in #892 .

`reduce` [is supposed to offset destination iterator by the reduction fragment index](https://github.com/NVIDIA/cutlass/blob/main/include/cutlass/epilogue/threadblock/epilogue.h#L381-L382), not by 1 like the typical epilogue call. 

@jackkosaian @hwu36 