### PR TITLE
Fix bug in single source GEMM with residual + streamk

### DIFF
--- a/include/cutlass/gemm/kernel/gemm_streamk_with_fused_epilogue.h
+++ b/include/cutlass/gemm/kernel/gemm_streamk_with_fused_epilogue.h
@@ -1552,14 +1552,17 @@ struct GemmStreamkWithFusedEpilogue<Mma_, Epilogue_, ThreadblockSwizzle_, true> 
 
       // Initialize the block mapping structure
       block_mapping = ThreadblockSwizzle(
-        typename ThreadblockSwizzle::template KernelTraits<GemmStreamkWithFusedEpilogue>(),
         args.mode,
         args.problem_size,
         {ThreadblockShape::kM, ThreadblockShape::kN, ThreadblockShape::kK},
         args.batch_count,
         sm_occupancy,
         device_sms,
-        avail_sms);
+        avail_sms,
+        sizeof(ElementA),
+        sizeof(ElementB),
+        sizeof(ElementC),
+        Epilogue::kAccumulatorFragments);
     }
 
     /// Returns the workspace size (in bytes) needed for these parameters


### PR DESCRIPTION
Followup to #1224.

A change in the stream-k threadblock swizzle ctor since 3.3 breaks single source GEMM with fused epilogue and stream-k. Multi-source was already corrected.