### PR TITLE
Use size_t index to iterate up to std::vector::size()

### DIFF
--- a/tools/util/include/cutlass/util/command_line.h
+++ b/tools/util/include/cutlass/util/command_line.h
@@ -185,7 +185,7 @@ struct CommandLine {
       vals.clear();
 
       // Recover from multi-value string
-      for (int i = 0; i < keys.size(); ++i) {
+      for (size_t i = 0; i < keys.size(); ++i) {
         if (keys[i] == string(arg_name)) {
           string val_string(values[i]);
           separate_string(val_string, vals, sep);


### PR DESCRIPTION
Fixes a different signedness compare warning:
```
../cutlass/tools/util/include/cutlass/util/command_line.h: In instantiation of ‘void cutlass::CommandLine::get_cmd_line_arguments(const char*, std::vector<value_t>&, char) const [with value_t = std::__cxx11::basic_string<char>]’:
../cutlass/tools/util/include/cutlass/util/command_line.h:222:29:   required from here
../cutlass/tools/util/include/cutlass/util/command_line.h:188:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  188 |       for (int i = 0; i < keys.size(); ++i) {
      |                 ~~^~~~~~~~~~~~~~~
```