### PR TITLE
Allow per-column bias in EpilogueTensorBroadcast

### DIFF
--- a/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp
+++ b/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp
@@ -69,7 +69,8 @@ template <
   class StrideC_,
   class StrideD_,
   class ThreadEpilogueOp_,
-  class EpilogueSchedule_
+  class EpilogueSchedule_,
+  bool PerColumnBias_ = false
 >
 class EpilogueTensorBroadcast {
 public:
@@ -100,6 +101,9 @@ public:
   static constexpr bool IsBinaryOp0Enabled = ThreadEpilogueOp::IsBinaryOp0Enabled;
   static constexpr bool IsBinaryOp1Enabled = ThreadEpilogueOp::IsBinaryOp1Enabled;
   static constexpr bool IsUnaryOpEnabled = ThreadEpilogueOp::IsUnaryOpEnabled;
+
+  static constexpr bool PerColumnBias = PerColumnBias_;
+  using BiasStride = typename std::conditional<PerColumnBias, Stride<_0, _1, _0>, Stride<_1, _0, _0>>::type;
 
   struct SharedStorage { };
 
@@ -194,7 +198,7 @@ public:
 
     auto stride_c    = detail::get_epilogue_stride<EpilogueSchedule>(params.dC);
     auto stride_d    = detail::get_epilogue_stride<EpilogueSchedule>(params.dD);
-    auto stride_bias = detail::get_epilogue_stride<EpilogueSchedule>(Stride<_1, _0, _0>{});
+    auto stride_bias = detail::get_epilogue_stride<EpilogueSchedule>(BiasStride{});
 
     // Represent the full output tensor
     Tensor mC0_mnl = make_tensor(make_gmem_ptr(params.ptr_C0), make_shape(M,N,L), stride_c);                   // (m,n,l)

--- a/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp
+++ b/include/cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp
@@ -103,7 +103,7 @@ public:
   static constexpr bool IsUnaryOpEnabled = ThreadEpilogueOp::IsUnaryOpEnabled;
 
   static constexpr bool PerColumnBias = PerColumnBias_;
-  using BiasStride = typename std::conditional<PerColumnBias, Stride<_0, _1, _0>, Stride<_1, _0, _0>>::type;
+  using BiasStride = typename cute::conditional_t<PerColumnBias, Stride<_0, _1, _0>, Stride<_1, _0, _0>>;
 
   struct SharedStorage { };
 


### PR DESCRIPTION
EpilogueTensorBroadcast only supports per-row vector broadcast, because the bias stride is hardcoded.

It can easily support both if the bias stride is made conditional, and the original behavior is maintained by defaulting to per-row.

Existing unit tests with `EpilogueTensorBroadcast` pass, and equivalent tests with per-col bias have been added.