### PR TITLE
fix tile_size_mnk compilation warning

### DIFF
--- a/include/cute/atom/mma_atom.hpp
+++ b/include/cute/atom/mma_atom.hpp
@@ -391,6 +391,8 @@ struct TiledMMA : MMA_Atom
     } else {
       return cute::max(core_size, perm_size);
     }
+
+    CUTE_GCC_UNREACHABLE;
   }
 
   CUTE_HOST_DEVICE constexpr


### PR DESCRIPTION
<img width="1550" alt="image" src="https://github.com/NVIDIA/cutlass/assets/26267436/78da7157-5630-419c-92f6-41931a70a6cc">

fix the compilation warning for `tile_size_mnk`
