### PR TITLE
fix unrecognized print format specifier for int8/uint8

### DIFF
--- a/include/cute/util/print.hpp
+++ b/include/cute/util/print.hpp
@@ -70,13 +70,13 @@ print(char c) {
 CUTE_HOST_DEVICE
 void
 print(signed char a) {
-  printf("%hhd", a);
+  printf("%d", (int)(a));
 }
 
 CUTE_HOST_DEVICE
 void
 print(unsigned char a) {
-  printf("%hhu", a);
+  printf("%u", (unsigned int)(a));
 }
 
 CUTE_HOST_DEVICE

--- a/include/cute/util/print.hpp
+++ b/include/cute/util/print.hpp
@@ -70,13 +70,13 @@ print(char c) {
 CUTE_HOST_DEVICE
 void
 print(signed char a) {
-  printf("%d", (int)(a));
+  printf("%d", static_cast<int>(a));
 }
 
 CUTE_HOST_DEVICE
 void
 print(unsigned char a) {
-  printf("%u", (unsigned int)(a));
+  printf("%u", static_cast<unsigned int>(a));
 }
 
 CUTE_HOST_DEVICE


### PR DESCRIPTION
when I debug an int8 kernel, I found the print(int8_tensor) could not perfom as expected(show in the following picture). Although it's a feature support problem for nvcc. I think we can work around it first.
The following snippet can reproduce the problem with nvcc-11.4 and nvcc-12.1.

```cpp
#include <cute/tensor.hpp>

__global__ void foo() {
  using namespace cute;

  int8_t i8 = 1;
  int16_t i16 = 1;
  int32_t i32 = 1;

  uint8_t u8 = 1;
  uint16_t u16 = 1;
  uint32_t u32 = 1;

  short s = 1;
  unsigned short us = 1;

  print(i8); print("\n");
  print(i16); print("\n");
  print(i32); print("\n");

  print(u8); print("\n");
  print(u16); print("\n");
  print(u32); print("\n");

  print(s); print("\n");
  print(us); print("\n");
}

int main() {
  foo<<<1, 1>>>();
  cudaDeviceSynchronize();
}
```
<img width="637" alt="image" src="https://github.com/NVIDIA/cutlass/assets/26267436/f847f428-bf63-479b-9b46-a3eb4702479e">
