### PR TITLE
Modify comments in code  examples/08_turing_tensorop_gemm/

### DIFF
--- a/examples/08_turing_tensorop_gemm/turing_tensorop_gemm.cu
+++ b/examples/08_turing_tensorop_gemm/turing_tensorop_gemm.cu
@@ -140,8 +140,8 @@ using ElementInputA = int8_t;                       // <- data type of elements 
 using ElementInputB = int8_t;                       // <- data type of elements in input matrix B
 using ElementOutput = int32_t;                      // <- data type of elements in output matrix D
 
-// The code section below describes matrix layout of input and output matrices. Column Major for
-// Matrix A, Row Major for Matrix B and Row Major for Matrix C
+// The code section below describes matrix layout of input and output matrices. Row Major for
+// Matrix A, Column Major for Matrix B and Row Major for Matrix C
 using LayoutInputA = cutlass::layout::RowMajor;
 using LayoutInputB = cutlass::layout::ColumnMajor;
 using LayoutOutput = cutlass::layout::RowMajor;


### PR DESCRIPTION
 Modify some comments in code  examples/08_turing_tensorop_gemm/turing_tensorop_gemm.cu , because i found that there is some wrong description for A and B matrix‘s layout in line 143-144