### PR TITLE
Add a missing platform include

### DIFF
--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -57,6 +57,7 @@
 
 #include <cuda_bf16.h>
 #include "cutlass/cutlass.h"
+#include "cutlass/platform/platform.h"
 
 namespace cutlass {
 


### PR DESCRIPTION
# Summary

While working on this PR:https://github.com/pytorch/pytorch/pull/118935
I found that the current version of PyTorch's cutlass v3.3.0 does not build with the updates to flash_attention_v2. And that when updating the cutlass to v3.4.0 the following error occurred:

```Shell
meta/pytorch/aten/src/ATen/native/transformers/cuda/attention.cu -o caffe2/CMakeFiles/torch_cuda.dir/__/aten/src/ATen/native/transformers/cuda/attention.cu.o
/home/drisspg/meta/pytorch/aten/src/ATen/../../../third_party/cutlass/include/cutlass/bfloat16.h(94): error: name followed by "::" must be a class or namespace name
      static_assert(cutlass::platform::is_integral<T>::value && sizeof(T) == 4, "Requires 32-bit integer");
                             ^

/home/drisspg/meta/pytorch/aten/src/ATen/../../../third_party/cutlass/include/cutlass/bfloat16.h(94): error: the global scope has no "value"
      static_assert(cutlass::platform::is_integral<T>::value && sizeof(T) == 4, "Requires 32-bit integer");
           
```

Adding this include fixed the build locally for me