### PR TITLE
Adding Cublas as a provider for cutlass profiler

### DIFF
--- a/tools/profiler/include/cutlass/profiler/gemm_operation_profiler.h
+++ b/tools/profiler/include/cutlass/profiler/gemm_operation_profiler.h
@@ -268,6 +268,15 @@ protected:
     void *host_workspace,
     void *device_workspace);
 
+  /// Method to profile a CUTLASS Operation
+  Status profile_cublas_(
+    double &runtime,
+    Options const &options,
+    library::Operation const *operation,
+    void *arguments,
+    void *host_workspace,
+    void *device_workspace);
+
   /// Initialize reduction problem dimensions and library::Operation
   bool initialize_reduction_configuration_(
     library::Operation const *operation,

--- a/tools/profiler/src/cublas_helpers.cu
+++ b/tools/profiler/src/cublas_helpers.cu
@@ -267,8 +267,7 @@ Status cublas_satisfies(library::GemmDescription const &desc) {
   }
 
   // input type BF16 and TF32 not supported in cuBLAS
-  if (desc.A.element == library::NumericTypeID::kBF16 || 
-    desc.A.element == library::NumericTypeID::kTF32) {
+  if (desc.A.element == library::NumericTypeID::kTF32) {
 
     return Status::kErrorNotSupported;
   }


### PR DESCRIPTION
Cutlass profiler has a great set of flags to perform shmoos across different matrix shapes and sizes. While benchmarking GEMMs using the cutlass profiler, one can use Cublas as a means to verify the cutlass kernel. However, cublas could also serve as a means to benchmark cutlass kernel performance, as in some cases cublas can perform better than cutlass kernels. It would be helpful to add cublas as a provider to identify such  cases.

The pull request also corrects a condition which prevents bf16 matrix multiplication on cublas. Cublas supports bf16 matrix multiplication, see [Ref](https://docs.nvidia.com/cuda/cublas/index.html#cublasgemmstridedbatchedex)