### PR TITLE
Fix several integer-signedness warnings

### DIFF
--- a/include/cute/atom/mma_traits_sm90_gmma.hpp
+++ b/include/cute/atom/mma_traits_sm90_gmma.hpp
@@ -208,7 +208,7 @@ make_gmma_desc(Tensor<TEngine,TLayout> const& tensor)
 
   // Start address (4LSB not included)
   uint32_t start_address = cast_smem_ptr_to_uint(raw_pointer_cast(u128_tensor.data()));
-  desc.bitfield.start_address_ = start_address >> 4;
+  desc.bitfield.start_address_ = uint16_t(start_address >> 4);
 
   constexpr uint8_t base_offset = 0;
   desc.bitfield.base_offset_ = base_offset;

--- a/include/cute/numeric/math.hpp
+++ b/include/cute/numeric/math.hpp
@@ -151,7 +151,7 @@ bit_width(T x) {
                     (numeric_limits<T>::digits ==  8 ? 3 : (assert(false),0)))));
   T r = 0;
   for (int i = N - 1; i >= 0; --i) {
-    T shift = (x > ((T(1) << (T(1) << i))-1)) << i;
+    T shift = T(x > ((T(1) << (T(1) << i))-1)) << i;
     x >>= shift;
     r  |= shift;
   }

--- a/include/cutlass/arch/mma_sm60.h
+++ b/include/cutlass/arch/mma_sm60.h
@@ -84,7 +84,7 @@ struct Mma<
 
 #else
     CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
+    for (size_t i = 0; i < 2; ++i) {
       d[i] = a[i] * b[0] + c[i];
     }
 #endif
@@ -130,7 +130,7 @@ struct Mma<
 
 #else
     CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
+    for (size_t i = 0; i < 2; ++i) {
       d[i] = a[0] * b[i] + c[i];
     }
 #endif
@@ -182,9 +182,9 @@ struct Mma <
 
 #else
     CUTLASS_PRAGMA_UNROLL
-    for (int j = 0; j < 2; ++j) {
+    for (size_t j = 0; j < 2; ++j) {
       CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < 2; ++i) {
+      for (size_t i = 0; i < 2; ++i) {
         d[i + 2 * j] = a[i] * b[j] + c[i + 2 * j];
       }
     }
@@ -236,9 +236,9 @@ struct Mma<
     D[1] = reinterpret_cast<Array<half_t, 2> &>(Dhi);
 #else
     CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
+    for (size_t i = 0; i < 2; ++i) {
       CUTLASS_PRAGMA_UNROLL
-      for (int j = 0; j < 2; ++j) {
+      for (size_t j = 0; j < 2; ++j) {
         d[i * 2 + j] = a[i] * b[j] + c[i * 2 + j];
       }
     }

--- a/include/cutlass/arch/mma_sm61.h
+++ b/include/cutlass/arch/mma_sm61.h
@@ -82,7 +82,7 @@ struct Mma<
     d[0] = c[0];
 
     CUTLASS_PRAGMA_UNROLL
-    for (int k = 0; k < 4; ++k) {
+    for (size_t k = 0; k < 4; ++k) {
       d[0] += a[k] * b[k];
     }
 
@@ -129,7 +129,7 @@ struct Mma<
     d[0] = c[0];
 
     CUTLASS_PRAGMA_UNROLL
-    for (int k = 0; k < 2; ++k) {
+    for (size_t k = 0; k < 2; ++k) {
       d[0] += a[k] * b[k];
     }
 #endif

--- a/include/cutlass/epilogue/warp/tile_iterator_tensor_op_mixed.h
+++ b/include/cutlass/epilogue/warp/tile_iterator_tensor_op_mixed.h
@@ -404,7 +404,7 @@ public:
     TensorRef const &ref,
     unsigned lane_id
   ):
-    stride_(ref.stride()[0] / AccessType::kElements) { 
+    stride_(size_t(ref.stride()[0]) / AccessType::kElements) {
 
     int quad_id = (lane_id / Detail::kLanesInQuad); 
     int lane_in_quad = (lane_id % Detail::kLanesInQuad);
@@ -605,7 +605,7 @@ public:
     TensorRef const &ref,
     unsigned lane_id
   ):
-    stride_(ref.stride()[0] / AccessType::kElements) { 
+    stride_(size_t(ref.stride()[0]) / AccessType::kElements) {
 
     int quad_id = (lane_id / Detail::kLanesInQuad); 
     int lane_in_quad = (lane_id % Detail::kLanesInQuad);

--- a/include/cutlass/fast_math.h
+++ b/include/cutlass/fast_math.h
@@ -246,7 +246,7 @@ template <typename value_t>
 CUTLASS_HOST_DEVICE value_t find_log2(value_t x) {
   int a = int(31 - clz(x));
   a += (x & (x - 1)) != 0;  // Round up, add 1 if not a power of 2.
-  return a;
+  return value_t(a);
 }
 
 
@@ -365,7 +365,7 @@ struct FastDivmod {
   FastDivmod(int divisor): divisor(divisor) {
 
     if (divisor != 1) {
-      unsigned int p = 31 + find_log2(divisor);
+      unsigned int p = 31 + unsigned(find_log2(divisor));
       unsigned m = unsigned(((1ull << p) + unsigned(divisor) - 1) / unsigned(divisor));
 
       multiplier = m;

--- a/include/cutlass/gemm/kernel/tile_scheduler_params.h
+++ b/include/cutlass/gemm/kernel/tile_scheduler_params.h
@@ -647,7 +647,7 @@ struct PersistentTileSchedulerSm90StreamKParams {
 
     // Calculate the number of stream-K units that would be needed if each stream-K unit
     // computed the minimum allowable k iterations. Truncate this to be in units of clusters.
-    auto cluster_size = cluster_shape.m() * cluster_shape.n();
+    uint64_t cluster_size = cluster_shape.m() * cluster_shape.n();
     uint64_t min_sized_sk_units = (k_tiles_sk_total / min_iters_per_sk_unit_);
     min_sized_sk_units = (min_sized_sk_units / cluster_size) * cluster_size;
 
@@ -915,7 +915,7 @@ struct PersistentTileSchedulerSm90StreamKParams {
 
     // Calculate the number of stream-K units that would be needed if each stream-K unit
     // computed the minimum allowable k iterations. Truncate this to be in units of clusters.
-    auto cluster_size = cluster_shape.m() * cluster_shape.n();
+    uint64_t cluster_size = cluster_shape.m() * cluster_shape.n();
     uint64_t min_sized_sk_units = (k_tiles_sk_total / min_iters_per_sk_unit_);
     min_sized_sk_units = (min_sized_sk_units / cluster_size) * cluster_size;
 
@@ -935,7 +935,7 @@ struct PersistentTileSchedulerSm90StreamKParams {
   CUTLASS_HOST_DEVICE
   static int
   get_reduction_workspace_size(uint64_t num_tiles, GemmCoord tile_shape, uint32_t accumulator_bits) {
-    auto output_tile_size = tile_shape.m() * tile_shape.n();
+    uint64_t output_tile_size = tile_shape.m() * tile_shape.n();
     auto workspace_bits = accumulator_bits * output_tile_size * num_tiles;
     return round_up_to_l2_alignment(bits_to_bytes(static_cast<int>(workspace_bits)));
   }
@@ -959,9 +959,9 @@ struct PersistentTileSchedulerSm90StreamKParams {
     uint32_t accumulator_bits,
     uint32_t epilogue_subtile = 1) {
 
-    auto log_swizzle_size = UnderlyingParams::get_log_swizzle_size(problem_blocks.x, problem_blocks.y, max_swizzle);
-    problem_blocks.x = round_up(problem_blocks.x, (1 << log_swizzle_size) * cluster_shape.m());
-    problem_blocks.y = round_up(problem_blocks.y, (1 << log_swizzle_size) * cluster_shape.n());
+    auto log_swizzle_size = UnderlyingParams::get_log_swizzle_size(int(problem_blocks.x), int(problem_blocks.y), max_swizzle);
+    problem_blocks.x = unsigned(round_up(int(problem_blocks.x), (1 << log_swizzle_size) * cluster_shape.m()));
+    problem_blocks.y = unsigned(round_up(int(problem_blocks.y), (1 << log_swizzle_size) * cluster_shape.n()));
 
     // Workspace is needed only for output tiles that will be split. Thus, we first determine the number
     // of output tiles that will be split, and then calculate the workspace needed to cover these.

--- a/include/cutlass/gemm/threadblock/threadblock_swizzle.h
+++ b/include/cutlass/gemm/threadblock/threadblock_swizzle.h
@@ -109,7 +109,10 @@ struct GemmIdentityThreadblockSwizzle {
   CUTLASS_HOST_DEVICE
   static dim3 get_grid_shape(GemmCoord tiled_shape) {
     int tile = 1 << get_log_tile(tiled_shape);
-    return dim3(tiled_shape.m() * tile, (tiled_shape.n() + tile - 1) / tile, tiled_shape.k());
+    return dim3(
+      unsigned(tiled_shape.m() * tile),
+      unsigned((tiled_shape.n() + tile - 1) / tile),
+      unsigned(tiled_shape.k()));
   }
 
   /// Calculates optimal swizzle width
@@ -301,7 +304,10 @@ struct GemmSplitKIdentityThreadblockSwizzle {
   CUTLASS_HOST_DEVICE
   static dim3 get_grid_shape(GemmCoord tiled_shape) {
     int tile = 1 << get_log_tile(tiled_shape);
-    return dim3(tiled_shape.m() * tile, (tiled_shape.n() + tile - 1) / tile, tiled_shape.k());
+    return dim3(
+      unsigned(tiled_shape.m() * tile),
+      unsigned((tiled_shape.n() + tile - 1) / tile),
+      unsigned(tiled_shape.k()));
   }
 
   /// Obtains the threadblock offset (in units of threadblock-scoped tiles)

--- a/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h
+++ b/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h
@@ -448,9 +448,9 @@ struct ThreadblockSwizzleStreamK {
       batch_count);
 
     size_t problem_bytes =
-              (element_C_bytes_ * problem_size.m() * problem_size.n()) +
-              (element_A_bytes_ * problem_size.m() * problem_size.k()) +
-              (element_B_bytes_ * problem_size.k() * problem_size.n());
+              (element_C_bytes_ * size_t(problem_size.m()) * size_t(problem_size.n())) +
+              (element_A_bytes_ * size_t(problem_size.m()) * size_t(problem_size.k())) +
+              (element_B_bytes_ * size_t(problem_size.k()) * size_t(problem_size.n()));
 
     size_t problem_flops = size_t(problem_size.m()) * size_t(problem_size.n()) * size_t(problem_size.k()) * 2;
 

--- a/include/cutlass/gemm/warp/mma_tensor_op.h
+++ b/include/cutlass/gemm/warp/mma_tensor_op.h
@@ -100,7 +100,7 @@ struct ConvertAndPack<bfloat16_t, float, N, Round> {
 
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < N; ++i) {
-      int idx = (((i << 1) & 2) | ((i >> 1) & 1) | (i & 0xfffffffc));
+      int idx = (((i << 1) & 2) | ((i >> 1) & 1) | (i & 0x7ffffffc));
       tmp[i] = source[idx];
     }
 
@@ -121,7 +121,7 @@ struct ConvertAndPack<half_t, float, N, Round> {
 
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < N; ++i) {
-      int idx = (((i << 1) & 2) | ((i >> 1) & 1) | (i & 0xfffffffc));
+      int idx = (((i << 1) & 2) | ((i >> 1) & 1) | (i & 0x7ffffffc));
       tmp[i] = source[idx];
     }
 

--- a/include/cutlass/half.h
+++ b/include/cutlass/half.h
@@ -224,7 +224,7 @@ struct alignas(2) half_t {
     #endif
 
     uint16_t sign = uint16_t((s >> 16) & 0x8000);
-    int16_t exp = uint16_t(((s >> 23) & 0xff) - 127);
+    int16_t exp = int16_t(((s >> 23) & 0xff) - 127);
     int mantissa = s & 0x7fffff;
     uint16_t u = 0;
 
@@ -248,7 +248,7 @@ struct alignas(2) half_t {
 
     if (exp >= -14) {
       // normal fp32 to normal fp16
-      exp = uint16_t(exp + uint16_t(15));
+      exp = exp + 15;
       u = uint16_t(((exp & 0x1f) << 10));
       u = uint16_t(u | (mantissa >> 13));
     } else {

--- a/include/cutlass/layout/permute.h
+++ b/include/cutlass/layout/permute.h
@@ -318,7 +318,7 @@ public:
   LongIndex operator()(MatrixCoord coord) const {
 
     // The batch index for BMM
-    Index BMM_batch_idx = blockIdx.z;
+    Index BMM_batch_idx = Index(blockIdx.z);
     
     // [i,j,k,l] -> [i,k,j,l]
     Index l = coord.column();
@@ -381,7 +381,7 @@ public:
   LongIndex operator()(MatrixCoord coord) const {
 
     // The batch index for BMM
-    Index BMM_batch_idx = blockIdx.z;
+    Index BMM_batch_idx = Index(blockIdx.z);
     
     // The following assumes grouping [(D0)->batch, (D2)->row, (D1,D3)->col]
     Index l = coord.column() % D3_;
@@ -453,7 +453,7 @@ public:
   CUTLASS_HOST_DEVICE
   LongIndex operator()(MatrixCoord coord) const {
 
-    Index BMM_batch_idx = blockIdx.z;
+    Index BMM_batch_idx = Index(blockIdx.z);
     
     // [i,j,k,l] -> [i,k,j,l]
     Index l = coord.column();
@@ -514,7 +514,7 @@ public:
   CUTLASS_HOST_DEVICE
   LongIndex operator()(MatrixCoord coord) const {
 
-    Index BMM_batch_idx = blockIdx.z;
+    Index BMM_batch_idx = Index(blockIdx.z);
     
     // The following assumes grouping [(D0)->batch, (D1,D2)->row, (D3)->col]
     Index l = coord.column();

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -3705,7 +3705,7 @@ struct PackPredicates {
       int word_idx = (i / kWordSize);
       int bit_idx = (i % kWordSize);
 
-      uint8_t mask = ((predicates[i] ? 1u : 0u) << bit_idx);
+      uint8_t mask = uint8_t((predicates[i] ? 1u : 0u) << bit_idx);
       bytes[word_idx] = (bytes[word_idx] | mask);
     }
     return packed;

--- a/include/cutlass/predicate_vector.h
+++ b/include/cutlass/predicate_vector.h
@@ -159,8 +159,8 @@ struct PredicateVector {
     int byte = (idx / kPredicatesPerByte);
     int bit_offset = (idx % kPredicatesPerByte);
 
-    word = byte / sizeof(Storage);
-    int byte_offset = (byte % sizeof(Storage));
+    word = byte / int(sizeof(Storage));
+    int byte_offset = (byte % int(sizeof(Storage)));
 
     bit = byte_offset * 8 + bit_offset + kPredicateStart;
   }

--- a/test/unit/gemm/device/testbed.h
+++ b/test/unit/gemm/device/testbed.h
@@ -156,7 +156,7 @@ struct Testbed {
     else if (dist_kind == cutlass::Distribution::Sequential) {
 
       cutlass::reference::host::BlockFillSequential(
-        view.data(), view.capacity());
+        view.data(), int64_t(view.capacity()));
     } 
     else {
       EXPECT_TRUE(false) << "Not implemented";

--- a/test/unit/gemm/device/testbed_universal.h
+++ b/test/unit/gemm/device/testbed_universal.h
@@ -133,7 +133,7 @@ struct TestbedUniversal {
     else if (dist_kind == cutlass::Distribution::Sequential) {
 
       cutlass::reference::host::BlockFillSequential(
-        view.data(), view.capacity());
+        view.data(), int64_t(view.capacity()));
     }
     else {
       EXPECT_TRUE(false) << "Not implemented";


### PR DESCRIPTION
I am building cutlass 3.4.1 using the Intel LLVM (oneAPI) compiler. There are a *lot* of warnings being produced related to implicit integer sign conversions.

This PR does not fix all of them, but it addresses all the instances that individually result in over a thousand warnings. Test suite results are left no worse off, but please review these changes carefully.

Here is the bulk of the warnings removed from the build output, sorted in order of decreasing count:
```
   2158 .../cutlass-3.4.1/include/cutlass/fast_math.h:249:8: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   2158 .../cutlass-3.4.1/include/cutlass/fast_math.h:368:17: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   2132 .../cutlass-3.4.1/include/cute/numeric/math.hpp:154:49: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1813 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:134:27: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1813 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:134:38: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1813 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:134:5: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1813 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:88:18: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1813 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:88:38: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1813 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:88:5: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:188:28: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:188:37: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:188:50: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:188:7: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:242:13: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:242:28: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:242:37: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm60.h:242:56: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm61.h:133:13: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm61.h:133:22: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm61.h:86:13: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1809 .../cutlass-3.4.1/include/cutlass/arch/mma_sm61.h:86:22: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   1788 .../cutlass-3.4.1/test/unit/gemm/device/testbed.h:158:60: warning: implicit conversion changes signedness: '::size_t' (aka 'unsigned long') to '::int64_t' (aka 'long') [-Wsign-conversion]
   1763 .../cutlass-3.4.1/include/cutlass/predicate_vector.h:162:9: warning: implicit conversion changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]
   1763 .../cutlass-3.4.1/include/cutlass/predicate_vector.h:163:19: warning: implicit conversion changes signedness: 'int' to 'unsigned long' [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/gemm/warp/mma_tensor_op.h:103:45: warning: implicit conversion changes signedness: 'unsigned int' to 'int' [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/gemm/warp/mma_tensor_op.h:103:48: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/gemm/warp/mma_tensor_op.h:124:45: warning: implicit conversion changes signedness: 'unsigned int' to 'int' [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/gemm/warp/mma_tensor_op.h:124:48: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/layout/permute.h:321:58: warning: implicit conversion changes signedness: 'const unsigned int' to 'Index' (aka 'int') [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/layout/permute.h:384:58: warning: implicit conversion changes signedness: 'const unsigned int' to 'Index' (aka 'int') [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/layout/permute.h:456:58: warning: implicit conversion changes signedness: 'const unsigned int' to 'Index' (aka 'int') [-Wsign-conversion]
   1761 .../cutlass-3.4.1/include/cutlass/layout/permute.h:517:58: warning: implicit conversion changes signedness: 'const unsigned int' to 'Index' (aka 'int') [-Wsign-conversion]
   1737 .../cutlass-3.4.1/include/cutlass/epilogue/warp/tile_iterator_tensor_op_mixed.h:405:21: warning: implicit conversion changes signedness: 'Index' (aka 'long') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1737 .../cutlass-3.4.1/include/cutlass/epilogue/warp/tile_iterator_tensor_op_mixed.h:606:21: warning: implicit conversion changes signedness: 'Index' (aka 'long') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1735 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h:450:131: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1735 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h:450:155: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1735 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h:450:201: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1735 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h:450:225: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1735 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h:450:62: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1735 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle_streamk.h:450:86: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
   1705 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle.h:112:31: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1705 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle.h:112:70: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1705 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle.h:112:90: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'unsigned int' [-Wsign-conversion]
   1631 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle.h:112:29: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1631 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle.h:112:68: warning: implicit conversion changes signedness: 'int' to 'unsigned int' [-Wsign-conversion]
   1631 .../cutlass-3.4.1/include/cutlass/gemm/threadblock/threadblock_swizzle.h:112:88: warning: implicit conversion changes signedness: 'Index' (aka 'int') to 'unsigned int' [-Wsign-conversion]
   1553 .../cutlass-3.4.1/test/unit/gemm/device/testbed_universal.h:135:60: warning: implicit conversion changes signedness: '::size_t' (aka 'unsigned long') to '::int64_t' (aka 'long') [-Wsign-conversion]
   1235 .../cutlass-3.4.1/include/cutlass/half.h:227:15: warning: implicit conversion changes signedness: 'uint16_t' (aka 'unsigned short') to 'int16_t' (aka 'short') [-Wsign-conversion]
   1235 .../cutlass-3.4.1/include/cutlass/half.h:251:8: warning: implicit conversion changes signedness: 'uint16_t' (aka 'unsigned short') to 'int16_t' (aka 'short') [-Wsign-conversion]
    929 .../cutlass-3.4.1/include/cute/atom/mma_traits_sm90_gmma.hpp:211:51: warning: implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'uint16_t' (aka 'unsigned short') [-Wimplicit-int-conversion]
    927 .../cutlass-3.4.1/include/cutlass/half.h:227:17: warning: implicit conversion changes signedness: '::uint16_t' (aka 'unsigned short') to '::int16_t' (aka 'short') [-Wsign-conversion]
    927 .../cutlass-3.4.1/include/cutlass/half.h:251:8: warning: implicit conversion changes signedness: '::uint16_t' (aka 'unsigned short') to '::int16_t' (aka 'short') [-Wsign-conversion]
    917 .../cutlass-3.4.1/include/cutlass/numeric_conversion.h:3708:46: warning: implicit conversion loses integer precision: 'unsigned int' to '::uint8_t' (aka 'unsigned char') [-Wimplicit-int-conversion]

```