### PR TITLE
Support use of external/system GTest installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,7 +689,10 @@ include(CTest)
 enable_testing()
 
 if (CUTLASS_ENABLE_GTEST_UNIT_TESTS)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/googletest.cmake)
+  find_package(GTest QUIET)
+  if (NOT GTest_FOUND)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/googletest.cmake)
+  endif()
 endif()
 
 if (NOT TARGET test_all)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,7 @@ set(CUTLASS_DEFAULT_ACTIVE_TEST_SETS "default" CACHE STRING "Default
   with CUTLASS_TEST_SETS environment variable when running the ctest
   executable.")
 
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CUTLASS_CTEST_TEMPLATE_FILE ${CMAKE_CURRENT_LIST_DIR}/cmake/CTestTestfile.configure.cmake)
 set(CUTLASS_CTEST_GENERATED_FILES "" CACHE INTERNAL "")
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(
   CUTLASS
   cutlass_tools_util_includes
   $<$<BOOL:${CUTLASS_ENABLE_CUBLAS}>:nvidia::cublas>
-  gtest
+  GTest::gtest
   cudart
   cuda_driver
   )
@@ -84,7 +84,7 @@ function(cutlass_test_unit_add_executable NAME)
     target_link_libraries(
       ${NAME}
       PUBLIC
-      gtest
+      GTest::gtest
     )
   else()
     target_link_libraries(


### PR DESCRIPTION
I am building the project in a restricted environment that does not allow network access (so FetchContent is not usable), and I already have a pre-compiled build of GTest ready to go. With this change, I can pass `-DGTest_ROOT=/path/to/gtest-install` to CMake, and the tests will build using the specified install. A system install of GTest will also be picked up. If neither is available, the configuration falls back to FetchContent.

The second commit fixes a related issue. I was running into this problem:
```
$ make test ARGS="--exclude-regex fmha_backward_python"
make[1]: Entering directory '.../cutlass-3.4.1-build'
Running tests...
Test project .../cutlass-3.4.1-build
                    Start   1: ctest_profiler_gemm
Failed to change working directory to ./bin : No such file or directory
  1/176 Test   #1: ctest_profiler_gemm ....................................***Not Run   0.00 sec
                    Start   2: ctest_profiler_conv2d
Failed to change working directory to ./bin : No such file or directory
  2/176 Test   #2: ctest_profiler_conv2d ..................................***Not Run   0.00 sec
                    Start   3: ctest_profiler_conv3d
Failed to change working directory to ./bin : No such file or directory
[...]
176/176 Test #176: ctest_unit_nvrtc_thread ................................***Not Run   0.00 sec

0% tests passed, 174 tests failed out of 174

Total Test time (real) =   0.03 sec
```

I've observed that the `./bin` directory is created when building from a default configuration, but once I customized the build to my needs, it was absent. It's not clear where this is coming from, so I added an explicit `MAKE_DIRECTORY` to ensure that the tests will run.