### PR TITLE
fix stride compilation warning

### DIFF
--- a/include/cute/stride.hpp
+++ b/include/cute/stride.hpp
@@ -436,6 +436,8 @@ compact_order(Shape const& shape, Order const& order)
     } else {
       return v;
     }
+
+    CUTE_GCC_UNREACHABLE;
   });
   // Replace any dynamic elements within order with large-static elements
   auto max_seq = make_range<max_order+1, max_order+1+rank(flat_order)>{};
@@ -445,6 +447,8 @@ compact_order(Shape const& shape, Order const& order)
     } else {
       return seq_v;
     }
+
+    CUTE_GCC_UNREACHABLE;
   });
 
   auto new_order = unflatten(ref_order, order);


### PR DESCRIPTION
After updating to version 3.5, there are some compilation warnings for my code.
I help fix it.

<img width="1790" alt="image" src="https://github.com/NVIDIA/cutlass/assets/26267436/7e336d11-ba83-4b1e-b291-4f0ff4b1314d">
