### PR TITLE
add missing header for size_t in `numeric_types.h`

### DIFF
--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -36,6 +36,7 @@
 
 #include "cutlass/cutlass.h"
 #include "cutlass/arch/cache_operation.h"
+#include "cutlass/platform/platform.h"
 
 namespace cutlass {
 namespace arch {

--- a/include/cutlass/numeric_types.h
+++ b/include/cutlass/numeric_types.h
@@ -43,6 +43,8 @@
 */
 #pragma once
 
+#include <cstddef>
+
 #include "cutlass/cutlass.h"
 #include "cutlass/numeric_size.h"
 

--- a/include/cutlass/numeric_types.h
+++ b/include/cutlass/numeric_types.h
@@ -43,9 +43,8 @@
 */
 #pragma once
 
-#include <cstddef>
-
 #include "cutlass/cutlass.h"
+#include "cutlass/platform/platform.h"
 #include "cutlass/numeric_size.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
tested by simple example
```cpp
#include <cutlass/numeric_types.h>
#include <cutlass/core_io.h>
#include <iostream>

int main() {
  cutlass::half_t x = 2.25_hf;
  std::cout << x << std::endl;
  return 0;
}

/*
clang++ test.cc -I include -I/usr/local/cuda/targets/x86_64-linux/include
In file included from test.cc:4:
include/cutlass/numeric_types.h:55:11: error: unknown type name 'size_t'
   55 | template <size_t... Seq>
      |           ^
include/cutlass/numeric_types.h:58:11: error: unknown type name 'size_t'
   58 | template <size_t N, size_t... Next>
      |           ^
include/cutlass/numeric_types.h:58:21: error: unknown type name 'size_t'
   58 | template <size_t N, size_t... Next>
      |                     ^
include/cutlass/numeric_types.h:61:11: error: unknown type name 'size_t'
   61 | template <size_t... Next>
      |           ^
include/cutlass/numeric_types.h:66:11: error: unknown type name 'size_t'
   66 | template <size_t N>                                                                                                   |           ^
5 errors generated.
```