### PR TITLE
Python `Gemm` `tile_descriptions` fix

### DIFF
--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -403,7 +403,7 @@ class Gemm(OperationBase):
         """
         tds = [datatypes.td_from_profiler_op(op) for op in self.possible_operations.all_operations]
         if self._math_operation is not None:
-            tds = [td for td in tds if td.tile_description.math_instruction == self._math_operation]
+            tds = [td for td in tds if td.math_instruction.math_operation == self._math_operation]
         return tds
 
     def construct(

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -116,14 +116,8 @@
 
 from math import prod
 
-from cuda import cuda
-from cutlass_library import (
-    DataType,
-    DataTypeSize,
-    GemmUniversalMode,
-)
-
 import cutlass
+from cuda import cuda
 from cutlass import epilogue, swizzle
 from cutlass.backend import compiler
 from cutlass.backend.evt import EpilogueFunctorVisitor
@@ -132,6 +126,7 @@ from cutlass.backend.library import TensorDescription, TileDescription
 from cutlass.op.op import OperationBase
 from cutlass.shape import GemmCoord
 from cutlass.utils import check, datatypes
+from cutlass_library import DataType, DataTypeSize, GemmUniversalMode
 
 
 class Gemm(OperationBase):
@@ -403,7 +398,7 @@ class Gemm(OperationBase):
         """
         tds = [datatypes.td_from_profiler_op(op) for op in self.possible_operations.all_operations]
         if self._math_operation is not None:
-            tds = [td for td in tds if td.math_instruction == self._math_operation]
+            tds = [td for td in tds if td.math_instruction.math_operation == self._math_operation]
         return tds
 
     def construct(

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -403,7 +403,7 @@ class Gemm(OperationBase):
         """
         tds = [datatypes.td_from_profiler_op(op) for op in self.possible_operations.all_operations]
         if self._math_operation is not None:
-            tds = [td for td in tds if td.math_instruction.math_operation == self._math_operation]
+            tds = [td for td in tds if td.math_instruction == self._math_operation]
         return tds
 
     def construct(

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -116,8 +116,14 @@
 
 from math import prod
 
-import cutlass
 from cuda import cuda
+from cutlass_library import (
+    DataType,
+    DataTypeSize,
+    GemmUniversalMode,
+)
+
+import cutlass
 from cutlass import epilogue, swizzle
 from cutlass.backend import compiler
 from cutlass.backend.evt import EpilogueFunctorVisitor
@@ -126,7 +132,6 @@ from cutlass.backend.library import TensorDescription, TileDescription
 from cutlass.op.op import OperationBase
 from cutlass.shape import GemmCoord
 from cutlass.utils import check, datatypes
-from cutlass_library import DataType, DataTypeSize, GemmUniversalMode
 
 
 class Gemm(OperationBase):


### PR DESCRIPTION
# Cutlass Python `cutlass.Gemm` tile_descriptions method error

### Description
Currently the `tile_descriptions` method of a `cutlass.Gemm` has 2 errors when the `math_operation` of the `plan` is manually set:
```python
import torch
import cutlass

m = 128
n = m
k = m

dtype = torch.float32
plan = cutlass.Gemm(
    element=dtype, layout=cutlass.LayoutType.RowMajor, element_accumulator=dtype
)
plan.opclass = cutlass.OpcodeClass.TensorOp

plan.math_operation = cutlass.MathOperation.multiply_add_fast_f32

for td in plan.tile_descriptions():
    print(f"{td.procedural_name()} {td.math_instruction.math_operation}")
```
Running the above gives the following error
```
Traceback (most recent call last):
  File "/notebooks/Cutlass/cutlass-fix/test_td.py", line 18, in <module>
    print(plan.tile_descriptions())
  File "/notebooks/Cutlass/cutlass-fix/build/__editable__.nvidia_cutlass-3.5.0.0-py3-none-any/cutlass/op/gemm.py", line 406, in tile_descriptions
    tds = [td for td in tds if td.tile_description.math_instruction == self._math_operation]
  File "/notebooks/Cutlass/cutlass-fix/build/__editable__.nvidia_cutlass-3.5.0.0-py3-none-any/cutlass/op/gemm.py", line 406, in <listcomp>
    tds = [td for td in tds if td.tile_description.math_instruction == self._math_operation]
AttributeError: 'TileDescription' object has no attribute 'tile_description'
```

### Fix
Errors are in [cutlass.op.gemm](https://github.com/NVIDIA/cutlass/blob/main/python/cutlass/op/gemm.py#L406)
```python
 def tile_descriptions(self) -> list:
        """
        Returns a list of valid tile descriptions for the operations

        :returns: list of valid tile descriptions for the operations
        :rtype: list
        """
        tds = [datatypes.td_from_profiler_op(op) for op in self.possible_operations.all_operations]
        
        #Lines below are incorrect, see description below 
        if self._math_operation is not None:
            tds = [td for td in tds if td.tile_description.math_instruction == self._math_operation]
        #

        return tds
```
1) an `AttributeError` is raised due to incorrect attribute access when iterating through the `tile_descriptions` -->  `td.tile_description` should just be `td`.
2) a logical error when filtering the tile descriptions for only those with specified `math_operation` --> the line should be `td.math_instruction.math_operation == self._math_operation` and not `td.math_instruction == self._math_operation`, otherwise no tile descriptions will be returned, since `math_instruction` and `math_operation` are different types.

**Note**: only the above line needs to be changed.  My IDE keeps introducing additional formatting changes, which I've tried to minimize.