### PR TITLE
Refactor to use FastDivmod for predicated strided dgrad iterators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/ 
 # PyCache files
 __pycache__/
 cutlass_library.egg-info/

--- a/include/cutlass/epilogue/threadblock/predicated_tile_iterator_strided_dgrad.h
+++ b/include/cutlass/epilogue/threadblock/predicated_tile_iterator_strided_dgrad.h
@@ -116,6 +116,9 @@ public:
     /// Convolution problem size
     cutlass::conv::Conv2dProblemSize problem_size;
     int tiled_rows_per_filter;
+    
+    FastDivmod divmod;
+    FastDivmod divmod_two;
 
     CUTLASS_HOST_DEVICE
     Params() { }
@@ -234,7 +237,8 @@ public:
   ): 
     params_(params)
   {
-
+    
+    
     TensorCoord thread_offset = ThreadMap::initial_offset(thread_idx) + threadblock_offset;
 
     int r = start_r;
@@ -254,6 +258,8 @@ public:
 
     p_ = (params_.problem_size.H - start_h_ + params_.problem_size.stride_h - 1) / params_.problem_size.stride_h;
     q_ = (params_.problem_size.W - start_w_ + params_.problem_size.stride_w - 1) / params_.problem_size.stride_w;
+    params_.divmod = FastDivmod(p_*q_);
+    params_.divmod_two = FastDivmod(params_.problem_size.Q);
 
     extent_row_ = extent.row();
     thread_start_row_ = thread_offset.row();
@@ -312,11 +318,19 @@ public:
           int npq_offset = (row_offset + thread_start_row_) % params_.tiled_rows_per_filter;
 
           // (STEP 4.a) [order NHW rows to be loaded and stored in output Dx NHWxC layout]
-          int n = npq_offset / (p_ * q_); 
-          int residual = npq_offset % (p_ * q_);
-          int p = residual / q_;
+
+          // The subsequent fast_divmod() operations are equivalent to the following logical computation:
+          int nzpq = npq_offset;
+          int n = nzpq / (p_ * q_); 
+          int residual = nzpq %  (p_ * q_);
+          int p = residual / q_; 
           int q = residual % q_;
-        
+
+          // int p, q, residual, n; 
+
+          // params_.divmod(n, residual, npq_offset);
+          // params_.divmod_two(p, q, residual);         
+
           int mapped_row_offset = n * (params_.problem_size.H * params_.problem_size.W) +
                                   (start_h_ + p * params_.problem_size.stride_h) * params_.problem_size.W +
                                   (start_w_ + q * params_.problem_size.stride_w);
@@ -379,11 +393,18 @@ public:
           int npq_offset = (row_offset + thread_start_row_) % params_.tiled_rows_per_filter;
 
           // (STEP 4.a) [order NHW rows to be loaded and stored in output Dx NHWxC layout]
-          int n = npq_offset / (p_ * q_); 
-          int residual = npq_offset % (p_ * q_);
-          int p = residual / q_;
-          int q = residual % q_;
-        
+
+          // The subsequent fast_divmod() operations are equivalent to the following logical computation:
+
+          // int n = npq_offset / (p_ * q_); 
+          // int residual = npq_offset % (p_ * q_);
+          // int p = residual / q_;
+          // int q = residual % q_;
+
+          int n, residual, p, q;
+          params_.divmod(n, residual, npq_offset);
+          params_.divmod_two(p, q, residual);
+
           int mapped_row_offset = n * (params_.problem_size.H * params_.problem_size.W) +
                                   (start_h_ + p * params_.problem_size.stride_h) * params_.problem_size.W +
                                   (start_w_ + q * params_.problem_size.stride_w);


### PR DESCRIPTION
On my 3080
**BEFORE**
line:
`int n = npq_offset / (p_ * q_);`
translates to 
[before_first_line_sass.txt](https://github.com/NVIDIA/cutlass/files/14826990/before_first_line_sass.txt)
line:
`int residual = npq_offset % (p_ * q_);`
translates to 
[before_second_line_sass.txt](https://github.com/NVIDIA/cutlass/files/14826999/before_second_line_sass.txt)
(i'll omit the other two lines assembly for brevity for now)
***AFTER***
this code:
```
params_.divmod(n, residual, npq_offset);
params_.divmod_two(p, q, residual);
```
leads to 
```
2651	0000000f 00c699a0	      ISETP.NE.AND P4, PT, R9, 0x1, PT 	133	0	0									


2720	0000000f 00c69df0	      ISETP.NE.AND P0, PT, R42, 0x1, PT 	149	0	0									
2721	0000000f 00c69e00	      IMAD.MOV.U32 R40, RZ, RZ, R11 	150	0	0									
2722	0000000f 00c69e10	@P0   IMAD.HI.U32 R2, R40, R2, RZ 	149	0	0									
2723	0000000f 00c69e20	      MOV R11, R7 	150	0	0									
2724	0000000f 00c69e30	      IMAD.MOV.U32 R7, RZ, RZ, R0 	150	0	0									
2725	0000000f 00c69e40	      IMAD.MOV.U32 R0, RZ, RZ, R40 	150	0	0									
2726	0000000f 00c69e50	@P0   SHF.R.U32.HI R0, RZ, R43, R2 	150	0	0
```
assembly

Last 3 columns are:
`Live Registers, Warp Stall Sampling, Instructions Executed`

the `FastDivmod` was formed like this:

```
    params_.divmod = FastDivmod(p_*q_);
    params_.divmod_two = FastDivmod(params_.problem_size.Q);
```
all tests pass. @hwu36 


Here are the benchmarks from `cutlass_profiler`

```
Operation,normal,Load_Store,Load,Store
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x128_32x3_nhwc_align8,36093.7,35460.4,34779.9,35521.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x128_32x3_nhwc_align4,38092.7,35749.1,33229.5,33216.6
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x128_32x3_nhwc_align2,37974.5,28202.3,26924.2,38842.2
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x256_32x3_nhwc_align8,46247.2,45844.8,46530.2,46529.9
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x256_32x3_nhwc_align4,45534,44948.4,45967.9,46057.5
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x256_32x3_nhwc_align2,42966.6,41820.4,41601.9,43779.3
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x64_32x3_nhwc_align8,32767,27551.1,31058.6,31742.2
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x64_32x3_nhwc_align4,27299.7,20540.9,24321.3,26288.8
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x64_32x3_nhwc_align2,3102.06,3124.94,3107.72,2785.73
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x64_32x4_nhwc_align8,32597,26568.1,29991.2,30956.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x64_32x4_nhwc_align4,21633.2,18499.1,21158.8,21662
cutlass_tensorop_f16_s16816dgrad_optimized_f16_256x64_32x4_nhwc_align2,3086.17,3099.21,3102.85,2779.92
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x256_32x4_nhwc_align8,46073,44842.5,44539.3,44795.6
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x256_32x4_nhwc_align4,44521.9,43695.6,43267.6,43731.8
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x256_32x4_nhwc_align2,35434.7,33203.7,33205.3,35853.8
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x3_nhwc_align8,43928.1,43993,43341.7,44614.7
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x3_nhwc_align4,40625,39896.3,39928.8,40649.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x3_nhwc_align2,37330.9,29725.7,30495.9,29953.2
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x4_nhwc_align8,40452.3,44186,40779.8,44001.5
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x4_nhwc_align4,36466.5,38333.6,37859,37978.7
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x4_nhwc_align2,28703.2,23201.9,28286,23159.5
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x5_nhwc_align8,44606,43841,43317.1,43667.7
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x5_nhwc_align4,38175.5,37856.9,37391.8,38196.8
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_32x5_nhwc_align2,25967.9,23727.5,26534.2,27765.5
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x64_32x6_nhwc_align8,32081.1,30121.8,29639.6,28661.2
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x64_32x6_nhwc_align4,30862.7,28736.9,27380.5,28620.5
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x64_32x6_nhwc_align2,25429.1,26662.2,23412,26904.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x128_32x6_nhwc_align8,43407.6,38710.5,37886.3,37235.5
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x128_32x6_nhwc_align4,40653.9,36616.6,35717.4,36235
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x128_32x6_nhwc_align2,38451.9,34824.1,33954.2,34735.8
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x64_32x10_nhwc_align8,27577.8,23630.1,23171.3,23665.9
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x64_32x10_nhwc_align4,25456.5,22367.1,21874.3,21462.4
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x64_32x10_nhwc_align2,23168.2,20486.2,20086.8,19702
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_64x3_nhwc_align8,44608.9,39704.4,43358.2,43835.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_64x3_nhwc_align4,37134.6,25871.8,33237.6,32667
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x128_64x3_nhwc_align2,5909.46,5473.34,5598.99,5362.67
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x64_64x3_nhwc_align8,32847.1,30383.6,29649.8,30323.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x64_64x3_nhwc_align4,30918.4,28999.7,27692.6,28686.4
cutlass_tensorop_f16_s16816dgrad_optimized_f16_128x64_64x3_nhwc_align2,7214.04,6697.29,7109.96,6556.47
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x128_64x3_nhwc_align8,43945,39028,38636.2,39030.1
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x128_64x3_nhwc_align4,40536,36048.2,34889.7,37002.2
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x128_64x3_nhwc_align2,33131.5,32488.8,28507.3,32475
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x64_64x5_nhwc_align8,28371.5,22888.7,23848.9,23171.3
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x64_64x5_nhwc_align4,27334.6,23543.2,23209.8,23260.3
cutlass_tensorop_f16_s16816dgrad_optimized_f16_64x64_64x5_nhwc_align2,22061.7,21158.2,19387,21181.7
```

[load_store_k1024.conv2d.csv](https://github.com/NVIDIA/cutlass/files/14855264/load_store_k1024.conv2d.csv)
[loadk1024.conv2d.csv](https://github.com/NVIDIA/cutlass/files/14855265/loadk1024.conv2d.csv)
[normal_k1024.conv2d.csv](https://github.com/NVIDIA/cutlass/files/14855266/normal_k1024.conv2d.csv)
[store_k1024.conv2d.csv](https://github.com/NVIDIA/cutlass/files/14855267/store_k1024.conv2d.csv)
[the_four.csv](https://github.com/NVIDIA/cutlass/files/14855268/the_four.csv)

