### PR TITLE
Restore "make_ordered_layout" method removed in 3.5

### DIFF
--- a/include/cute/layout.hpp
+++ b/include/cute/layout.hpp
@@ -398,6 +398,14 @@ make_ordered_layout(Shape const& shape, Order const& order)
   return make_layout(shape, compact_order(shape, order));
 }
 
+template <class Shape, class Stride>
+CUTE_HOST_DEVICE constexpr
+auto
+make_ordered_layout(Layout<Shape,Stride> const& layout)
+{
+  return make_ordered_layout(layout.shape(), layout.stride());
+}
+
 // Make a compact layout with the same shape as @a layout
 //   and strides following the order induced by @a layout.stride().
 // Static-0 strides in the input @a layout are preserved in the output.


### PR DESCRIPTION
From CUTLASS 3.4.1 to 3.5, one of the `make_ordered_layout` methods in `cute/layout.hpp` was removed, which breaks compatibility with the colfax FA-2 implementation. This PR restores that method.