### PR TITLE
  Support use of external/system GTest installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ set(CUTLASS_ENABLE_PERFORMANCE ${CUTLASS_ENABLE_PROFILER} CACHE BOOL "Enable CUT
 
 set(CUTLASS_ENABLE_TESTS ${CUTLASS_ENABLE_TESTS_INIT} CACHE BOOL "Enable CUTLASS Tests")
 set(CUTLASS_ENABLE_GTEST_UNIT_TESTS ${CUTLASS_ENABLE_TESTS} CACHE BOOL "Enable CUTLASS GTest-based Unit Tests")
+set(CUTLASS_USE_SYSTEM_GOOGLETEST OFF CACHE BOOL "Use system/external installation of GTest")
 ################################################################################
 
 set(CUTLASS_NVCC_ARCHS_SUPPORTED "")
@@ -689,7 +690,11 @@ include(CTest)
 enable_testing()
 
 if (CUTLASS_ENABLE_GTEST_UNIT_TESTS)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/googletest.cmake)
+  if (CUTLASS_USE_SYSTEM_GOOGLETEST)
+    find_package(GTest REQUIRED)
+  else()
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/googletest.cmake)
+  endif()
 endif()
 
 if (NOT TARGET test_all)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,6 +739,7 @@ set(CUTLASS_DEFAULT_ACTIVE_TEST_SETS "default" CACHE STRING "Default
   with CUTLASS_TEST_SETS environment variable when running the ctest
   executable.")
 
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CUTLASS_CTEST_TEMPLATE_FILE ${CMAKE_CURRENT_LIST_DIR}/cmake/CTestTestfile.configure.cmake)
 set(CUTLASS_CTEST_GENERATED_FILES "" CACHE INTERNAL "")
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(
   CUTLASS
   cutlass_tools_util_includes
   $<$<BOOL:${CUTLASS_ENABLE_CUBLAS}>:nvidia::cublas>
-  gtest
+  GTest::gtest
   cudart
   cuda_driver
   )
@@ -84,7 +84,7 @@ function(cutlass_test_unit_add_executable NAME)
     target_link_libraries(
       ${NAME}
       PUBLIC
-      gtest
+      GTest::gtest
     )
   else()
     target_link_libraries(


### PR DESCRIPTION
(Re-push of #1384)

I am building the project in a restricted environment that does not allow network access (so FetchContent is not usable), and already have a pre-compiled build of GTest ready to go. With this change, I can pass `-DCUTLASS_USE_SYSTEM_GOOGLETEST=ON -DGTest_ROOT=/path/to/gtest-install` to CMake, and the tests will build using the specified install. A system install of GTest can also be picked up.

The second commit fixes a related issue: the test suite breaks when the `bin/` subdirectory is missing from the build tree, but it's the bundled-googletest logic that creates it. So we create that dir explicitly/unconditionally.