### PR TITLE
Add missing #include <memory> for definition of std::addressof.

### DIFF
--- a/include/cutlass/cluster_launch.hpp
+++ b/include/cutlass/cluster_launch.hpp
@@ -36,6 +36,9 @@
 #pragma once
 
 #include <cuda_runtime_api.h>
+
+#include <memory>
+
 #include "cutlass/cutlass.h"
 #include "cutlass/trace.h"
 #if defined(__CUDACC_RTC__)


### PR DESCRIPTION
`detail::checked_addressof` uses `std::addressof`; failing to `#include` this header results in a compiler error if it didn't happen to be `#include`d already.