### PR TITLE
Add Faster Neighborhood Attention to PUBLICATIONS

### DIFF
--- a/PUBLICATIONS.md
+++ b/PUBLICATIONS.md
@@ -1,5 +1,9 @@
 # Publications Using Cutlass
 
+## 2024
+
+- ["Faster Neighborhood Attention: Reducing the O(n^2) Cost of Self Attention at the Threadblock Level"](https://arxiv.org/abs/2403.04690). Ali Hassani, Wen-Mei Hwu, Humphrey Shi. _arXiv_, March 2024.
+
 ## 2023
 
 - ["A Case Study in CUDA Kernel Fusion: Implementing FlashAttention-2 on NVIDIA Hopper Architecture using the CUTLASS Library"](https://arxiv.org/abs/2312.11918). Ganesh Bikshandi, Jay Shah. _arXiv_, December 2023.


### PR DESCRIPTION
Adds "Faster Neighborhood Attention: Reducing the O(n^2) Cost of Self Attention at the Threadblock Level" to publications.

TLDR; Neighborhood attention requires treating the attention problem as two batched GETTs instead of GEMMs (row mode can be 2-D and 3-D instead of a single dimension as in NLP.)