### PR TITLE
Fix device thread `gemm.h` constructor

### DIFF
--- a/tools/util/include/cutlass/util/reference/device/thread/gemm.h
+++ b/tools/util/include/cutlass/util/reference/device/thread/gemm.h
@@ -91,7 +91,7 @@ struct Gemm {
       A_tile[i] = ElementA(0);
     }
 
-    for (int j = 0; j < OutputTile::kColumn; ++j) {
+    for (int j = 0; j < OutputTile::kRow; ++j) {
       B_tile[j] = ElementB(0);
     }
 


### PR DESCRIPTION
Traversing the length of array B_tile is incorrect.