### PR TITLE
Fix C++17 version detection in helper_macros.hpp

### DIFF
--- a/include/cutlass/detail/helper_macros.hpp
+++ b/include/cutlass/detail/helper_macros.hpp
@@ -146,7 +146,13 @@ namespace cutlass {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if (201700L <= __cplusplus)
+#ifndef _MSVC_LANG  
+#define MSCV_LANG _MSVC_LANG
+#else
+#define MSCV_LANG 0
+#endif
+
+#if (201700L <= __cplusplus || 201700L <= MSVC_LANG)
 #define CUTLASS_CONSTEXPR_IF_CXX17 constexpr
 #define CUTLASS_CXX17_OR_LATER 1
 #else

--- a/include/cutlass/detail/helper_macros.hpp
+++ b/include/cutlass/detail/helper_macros.hpp
@@ -152,7 +152,7 @@ namespace cutlass {
 #define MSCV_LANG 0
 #endif
 
-#if (201700L <= __cplusplus || 201700L <= MSVC_LANG)
+#if (201700L <= __cplusplus || 201700L <= MSCV_LANG)
 #define CUTLASS_CONSTEXPR_IF_CXX17 constexpr
 #define CUTLASS_CXX17_OR_LATER 1
 #else

--- a/include/cutlass/detail/helper_macros.hpp
+++ b/include/cutlass/detail/helper_macros.hpp
@@ -147,12 +147,12 @@ namespace cutlass {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #ifndef _MSVC_LANG  
-#define MSCV_LANG _MSVC_LANG
+#define MSVC_LANG _MSVC_LANG
 #else
-#define MSCV_LANG 0
+#define MSVC_LANG 0
 #endif
 
-#if (201700L <= __cplusplus || 201700L <= MSCV_LANG)
+#if (201700L <= __cplusplus || 201700L <= MSVC_LANG)
 #define CUTLASS_CONSTEXPR_IF_CXX17 constexpr
 #define CUTLASS_CXX17_OR_LATER 1
 #else


### PR DESCRIPTION
It seems that __cplusplus can be inconsistent with _MSVC_LANG when discerning C++17 version in some cases.
See https://github.com/NVIDIA/cutlass/issues/1474. 
Added switch to check _MSVC_LANG in addition to __cplusplus.