### PR TITLE
feat: support kFactor 8 used in mma tensor op tile iterator

### DIFF
--- a/include/cutlass/gemm/warp/mma_tensor_op_tile_iterator.h
+++ b/include/cutlass/gemm/warp/mma_tensor_op_tile_iterator.h
@@ -2292,7 +2292,17 @@ class MmaTensorOpMultiplicandTileIterator<
     int access_contiguous_idx = -1;
     int access_strided_idx = -1;
 
-    if (Layout::kFactor == 4) {
+    if (Layout::kFactor == 8) {
+      int factor_in_partition =
+          (Layout::PartitionShape::kContiguous * Layout::kFactor /
+           Layout::TileShape::kContiguous);
+
+      if (Policy::LdsmShape::kStrided == Policy::LdsmShape::kCount) {
+        partition_contiguous_idx = lane_in_quad_pair / factor_in_partition;
+        access_contiguous_idx = ((lane_in_quad) ^ (lane_id / Layout::kFactor));
+        access_strided_idx = lane_id / Layout::kFactor;
+      }
+    } else if (Layout::kFactor == 4) {
       // Super Integer matrix multiply Interleaved-32
 
       int factor_in_partition =


### PR DESCRIPTION
support Layout::kFactor with 8
loading data from shared memory:
|0 | 16 | 32 | 48 | 64 | 80 | 96 | 112|
|-- | -- | -- | -- | -- | -- | -- | --|
|T0 | T1 | T2 | T3 | T4 | T5 | T6 | T7|
|T9 | T8 | T11 | T10 | T13 | T12 | T15 | T14|
|T18 | T19 | T16 | T17 | T22 | T23 | T20 | T21|
|T27 | T26 | T25 | T24 | T31 | T30 | T29 | T28|
