### PR TITLE
Update half.h - typo at line 138(unnecessary space before '1')

### DIFF
--- a/include/cutlass/half.h
+++ b/include/cutlass/half.h
@@ -135,7 +135,7 @@ class CpuId {
     // GCC / Clang
        int eax, ebx, ecx, edx;
 
-      __cpuid (1 , eax, ebx, ecx, edx); 
+      __cpuid (1, eax, ebx, ecx, edx); 
       f16c_enabled = ecx & 0x20000000;
     #endif
   #else 


### PR DESCRIPTION
In line 138, there is an unnecessary space before '1'. I removed it to make it look a little cooler.