### PR TITLE
feat: allow print_latex(TiledMMA) to colorize sliced thread and add print_latex(ThrMMA)

### DIFF
--- a/include/cute/atom/mma_atom.hpp
+++ b/include/cute/atom/mma_atom.hpp
@@ -753,7 +753,7 @@ print_latex(MMA_Atom<Args...> const& mma_atom)
 template <class... Args>
 CUTE_HOST_DEVICE
 void
-print_latex(TiledMMA<Args...> const& mma)
+print_latex(TiledMMA<Args...> const& mma, int thr_idx)
 {
   auto layout_and_thrid_C = mma.get_layoutC_MN();
   auto layoutC_MN = get<0>(layout_and_thrid_C);
@@ -769,7 +769,24 @@ print_latex(TiledMMA<Args...> const& mma)
 
   print_latex_mma(layoutC_MN, thrID_C,
                   layoutA_MK, thrID_A,
-                  layoutB_NK, thrID_B);
+                  layoutB_NK, thrID_B,
+                  thr_idx);
+}
+
+template <class... Args>
+CUTE_HOST_DEVICE
+void
+print_latex(TiledMMA<Args...> const& mma)
+{
+  print_latex(mma, -1);
+}
+
+template <class TiledMMA, class ThrVMNK>
+CUTE_HOST_DEVICE
+void
+print_latex(ThrMMA<TiledMMA, ThrVMNK> const& thr_mma)
+{
+  print_latex(static_cast<TiledMMA const&>(thr_mma), get<0>(thr_mma.thr_vmnk_));
 }
 
 // MNK MMA Layout to console printer
@@ -836,7 +853,8 @@ CUTE_HOST_DEVICE
 void
 print_latex_mma(LayoutC const& C, ThrIDC const& TC,  // (m,n) -> (tid,vid)  and  tid -> thr_idx
                 LayoutA const& A, ThrIDA const& TA,  // (m,k) -> (tid,vid)  and  tid -> thr_idx
-                LayoutB const& B, ThrIDB const& TB)  // (n,k) -> (tid,vid)  and  tid -> thr_idx
+                LayoutB const& B, ThrIDB const& TB,  // (n,k) -> (tid,vid)  and  tid -> thr_idx
+                int slice_thr_idx = -1)
 {
   CUTE_STATIC_ASSERT_V(rank(C) == Int<2>{});
   CUTE_STATIC_ASSERT_V(rank(A) == Int<2>{});
@@ -883,10 +901,16 @@ print_latex_mma(LayoutC const& C, ThrIDC const& TC,  // (m,n) -> (tid,vid)  and 
       int val_idx = C(m,n) / size(TC);
       int thr_idx = TC(thrid);
 
-      printf("\\node[box,fill=%s] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
-             color_map[thr_idx % 8],
-             m, n,
-             thr_idx, val_idx);
+      if (slice_thr_idx < 0 || slice_thr_idx == thr_idx) {
+        printf("\\node[box,fill=%s] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
+              color_map[thr_idx % 8],
+              m, n,
+              thr_idx, val_idx);
+      } else {
+        printf("\\node[box] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
+              m, n,
+              thr_idx, val_idx);
+      }
     }
   }
 
@@ -897,10 +921,16 @@ print_latex_mma(LayoutC const& C, ThrIDC const& TC,  // (m,n) -> (tid,vid)  and 
       int val_idx = A(m,k) / size(TA);
       int thr_idx = TA(thrid);
 
-      printf("\\node[box,fill=%s] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
-             color_map[thr_idx % 8],
-             m, k-1-size<1>(A),
-             thr_idx, val_idx);
+      if (slice_thr_idx < 0 || slice_thr_idx == thr_idx) {
+        printf("\\node[box,fill=%s] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
+              color_map[thr_idx % 8],
+              m, k-1-size<1>(A),
+              thr_idx, val_idx);
+      } else {
+        printf("\\node[box] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
+              m, k-1-size<1>(A),
+              thr_idx, val_idx);
+      }
     }
   }
 
@@ -911,10 +941,16 @@ print_latex_mma(LayoutC const& C, ThrIDC const& TC,  // (m,n) -> (tid,vid)  and 
       int val_idx = B(n,k) / size(TB);
       int thr_idx = TB(thrid);
 
-      printf("\\node[box,fill=%s] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
-             color_map[thr_idx % 8],
-             k-1-size<1>(B), n,
-             thr_idx, val_idx);
+      if (slice_thr_idx < 0 || slice_thr_idx == thr_idx) {
+        printf("\\node[box,fill=%s] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
+              color_map[thr_idx % 8],
+              k-1-size<1>(B), n,
+              thr_idx, val_idx);
+      } else {
+        printf("\\node[box] at (%d,%d) {\\shortstack{T%d \\\\ V%d}};\n",
+              k-1-size<1>(B), n,
+              thr_idx, val_idx);
+      }
     }
   }
 


### PR DESCRIPTION
Allow colorize only one thread of `print_latex`, to make mma pattern obvious and reduce eye strain.

For example,

```cpp
#include "cute/tensor.hpp"
using namespace cute;
int main() {
  auto tiled_mma = make_tiled_mma(SM80_16x8x8_F32F16F16F32_TN{});
  auto thr_mma = tiled_mma.get_thread_slice(11);
  // print_latex(tiled_mma, 11);
  print_latex(thr_mma);  // the same as above
  return 0;
}
```

produces

![latex](https://github.com/user-attachments/assets/095529a8-86a0-42f7-bd3e-8e1fb2501844)

