### PR TITLE
Build hotfix for SM 5.2 on 3.5.1

### DIFF
--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -234,7 +234,7 @@ template <>
 struct inverse_square_root<half_t> {
   CUTLASS_HOST_DEVICE
   half_t operator()(half_t const &lhs) const {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ > 520
     auto result = hrsqrt(reinterpret_cast<__half const &>(lhs));
     return reinterpret_cast<half_t const &>(result);
 #else


### PR DESCRIPTION
`hrsqrt` doesn't seem to be defined for SM 5.2