### PR TITLE
Avoid LDGSTS routing by changing default copy to be universalcopy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # PyCache files
 __pycache__/
 cutlass_library.egg-info/
+build/
+.vscode/

--- a/examples/50_hopper_gemm_with_epilogue_swizzle/50_hopper_gemm_with_epilogue_swizzle.cu
+++ b/examples/50_hopper_gemm_with_epilogue_swizzle/50_hopper_gemm_with_epilogue_swizzle.cu
@@ -485,7 +485,7 @@ int main(int argc, char const **args) {
   // Tiled copy from Smem to Registers
   // Note : CuTe will vectorize this copy if the tiling + swizzling above were right
   using TiledCopyS2R = TiledCopy<
-                         Copy_Atom<DefaultCopy, ElementAcc>,
+                         Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementAcc>,
                          Layout< Shape<_128,_16>, 
                                  Stride<_16,_1>>,
                          TileShapeS2R>;
@@ -496,9 +496,9 @@ int main(int argc, char const **args) {
       cutlass::gemm::TagToStrideC_t<LayoutD>,
       cutlass::epilogue::thread::LinearCombination<int32_t, 1, int32_t, int32_t>,
       SmemLayout,
-      Copy_Atom<DefaultCopy, ElementAcc>,
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementAcc>,
       TiledCopyS2R,
-      Copy_Atom<DefaultCopy, ElementOutput>>>;
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, ElementOutput>>>;
 
   //
   // Assembling the GemmKernel

--- a/include/cute/arch/copy.hpp
+++ b/include/cute/arch/copy.hpp
@@ -90,7 +90,8 @@ using AutoVectorizingCopy = AutoVectorizingCopyWithAssumedAlignment<128>;
 // DefaultCopy alias does not assume alignment of pointers or dynamic strides.
 //
 
-using DefaultCopy = AutoVectorizingCopyWithAssumedAlignment<8>;
+
+using DefaultCopy = UniversalCopy<uint_bit_t<128>>;
 
 //
 // Global memory prefetch into L2

--- a/test/unit/cute/volta/vectorization_auto.cu
+++ b/test/unit/cute/volta/vectorization_auto.cu
@@ -109,7 +109,7 @@ template <class T, class GmemLayout, class RmemTiler>
 void
 test_copy_vectorization(GmemLayout gmem_layout, RmemTiler rmem_tiler)
 {
-  test_copy_vectorization<T>(DefaultCopy{}, gmem_layout, rmem_tiler);
+  test_copy_vectorization<T>(AutoVectorizingCopyWithAssumedAlignment<128>{}, gmem_layout, rmem_tiler);
 }
 
 TEST(SM70_CuTe_Volta, SimpleVec)


### PR DESCRIPTION
https://github.com/NVIDIA/cutlass/issues/1672

This PR changes the default copy to be `UniversalCopy` so the LDGSTS instruction is avoided, and downstream users will need to specify the copy type if they want to use it which is more intuitive. 

Note: I imagine since all of the tests and examples that are configured to use `DefaultCopy` will need to now transition over to `AutoVectorizingCopyWithAssumedAlignment<128>` as that was the previous copy type. This way we can preserve behavior across benchmarks and tests. Before I make a bunch of changes across files though I'd like to get feedback now incase I'm missing anything.