### PR TITLE
Fixing std::numeric_limits<half_t>::digits to include the implicit one

### DIFF
--- a/include/cutlass/half.h
+++ b/include/cutlass/half.h
@@ -599,7 +599,7 @@ struct numeric_limits<cutlass::half_t> {
   static bool const is_iec559 = true;
   static bool const is_bounded = true;
   static bool const is_modulo = false;
-  static int const digits = 10;
+  static int const digits = 11;
 
   /// Least positive value
   static cutlass::half_t min() { return cutlass::half_t::bitcast(0x0001); }
@@ -658,7 +658,7 @@ struct numeric_limits<cutlass::half_t> {
   static bool const is_iec559 = true;
   static bool const is_bounded = true;
   static bool const is_modulo = false;
-  static int const digits = 10;
+  static int const digits = 11;
 
   /// Least positive value
   CUTLASS_HOST_DEVICE


### PR DESCRIPTION
Small pull request to fix the issue #1701 