### PR TITLE
add `CUTLASS_HOST_DEVICE` to `std::numeric_limits<cutlass::half_t>` functions

### DIFF
--- a/include/cutlass/half.h
+++ b/include/cutlass/half.h
@@ -602,30 +602,39 @@ struct numeric_limits<cutlass::half_t> {
   static int const digits = 10;
 
   /// Least positive value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t min() { return cutlass::half_t::bitcast(0x0001); }
 
   /// Minimum finite value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t lowest() { return cutlass::half_t::bitcast(0xfbff); }
 
   /// Maximum finite value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t max() { return cutlass::half_t::bitcast(0x7bff); }
 
   /// Returns smallest finite value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t epsilon() { return cutlass::half_t::bitcast(0x1800); }
 
   /// Returns maximum rounding error
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t round_error() { return cutlass::half_t(0.5f); }
 
   /// Returns positive infinity value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t infinity() { return cutlass::half_t::bitcast(0x7c00); }
 
   /// Returns quiet NaN value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t quiet_NaN() { return cutlass::half_t::bitcast(0x7fff); }
 
   /// Returns signaling NaN value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t signaling_NaN() { return cutlass::half_t::bitcast(0x7fff); }
 
   /// Returns smallest positive subnormal value
+  CUTLASS_HOST_DEVICE
   static cutlass::half_t denorm_min() { return cutlass::half_t::bitcast(0x0001); }
 };
 }  // namespace std


### PR DESCRIPTION
CC @thakkarV @Skylion007

Might be the easiest way to resolve PyTorch build failures like 
```
2024-08-12T22:44:12.1177715Z /var/lib/jenkins/workspace/aten/src/ATen/native/sparse/cuda/ComputeSparseTile.h(61): error: calling a __host__ function("std::numeric_limits< ::cutlass::half_t> ::infinity()") from a __device__ function("at::native::LargestValuesGreedy< ::at::native::IdentityOp> ::outOfBoundsFillValue< ::cutlass::half_t> ") is not allowed
2024-08-12T22:44:12.1179632Z 
2024-08-12T22:44:12.1181932Z /var/lib/jenkins/workspace/aten/src/ATen/native/sparse/cuda/ComputeSparseTile.h(61): error: identifier "std::numeric_limits< ::cutlass::half_t> ::infinity" is undefined in device code
2024-08-12T22:44:12.1183740Z 
2024-08-12T22:44:12.1185714Z /var/lib/jenkins/workspace/aten/src/ATen/native/sparse/cuda/ComputeSparseTile.h(121): error: calling a __host__ function("std::numeric_limits< ::cutlass::half_t> ::infinity()") from a __device__ function("at::native::Causal1122< ::at::native::IdentityOp> ::outOfBoundsFillValue< ::cutlass::half_t> ") is not allowed
2024-08-12T22:44:12.1187551Z 
2024-08-12T22:44:12.1188601Z /var/lib/jenkins/workspace/aten/src/ATen/native/sparse/cuda/ComputeSparseTile.h(121): error: identifier "std::numeric_limits< ::cutlass::half_t> ::infinity" is undefined in device code
2024-08-12T22:44:12.1189820Z 
2024-08-12T22:44:12.1191743Z /var/lib/jenkins/workspace/aten/src/ATen/native/sparse/cuda/ComputeSparseTile.h(61): error: calling a __host__ function("std::numeric_limits< ::cutlass::half_t> ::infinity()") from a __device__ function("at::native::LargestValuesGreedy< ::at::native::AbsOp> ::outOfBoundsFillValue< ::cutlass::half_t> ") is not allowed
2024-08-12T22:44:12.1193710Z 
2024-08-12T22:44:12.1194761Z /var/lib/jenkins/workspace/aten/src/ATen/native/sparse/cuda/ComputeSparseTile.h(61): error: identifier "std::numeric_limits< ::cutlass::half_t> ::infinity" is undefined in device code
2024-08-12T22:44:12.1195978Z 
``` in PyTorch