### PR TITLE
Fix EVT for cutlass::gemm::kernel::DefaultGemmWithVisitor's behavior when constructing GemmUniversalAdapter

### DIFF
--- a/include/cutlass/gemm/kernel/gemm_universal_with_visitor.h
+++ b/include/cutlass/gemm/kernel/gemm_universal_with_visitor.h
@@ -52,12 +52,12 @@ template <
   typename Epilogue,             ///! Epilogue
   typename ThreadblockSwizzle_   ///! Threadblock swizzling function
 >
-class GemmWithEpilogueVisitor: GemmUniversal<Mma,Epilogue, ThreadblockSwizzle_> {
+class GemmWithEpilogueVisitor: public GemmUniversal<Mma, Epilogue, ThreadblockSwizzle_> {
 public:
 
   using ThreadblockSwizzle = ThreadblockSwizzle_;
 
-  using Base = GemmUniversal<Mma,Epilogue, ThreadblockSwizzle>;
+  using Base = GemmUniversal<Mma, Epilogue, ThreadblockSwizzle>;
   using Base::Base;
 
   using FusionCallbacks = typename Epilogue::FusionCallbacks;


### PR DESCRIPTION
The phenomenon I encountered while using the epilogue visitor tree in C++ is quite strange...
In `examples/47_ampere_gemm_universal_streamk/ampere_gemm_universal_streamk_broadcast.cu`:
```cpp
using EVTKernelStreamK =
    typename cutlass::gemm::kernel::DefaultGemmWithVisitor<
    ElementA, LayoutA, cutlass::ComplexTransform::kNone, AlignmentA,
    ElementB, LayoutB, cutlass::ComplexTransform::kNone, AlignmentB,
    ElementC, LayoutC, AlignmentC,
    ElementAccumulator,
    ElementCompute,
    cutlass::arch::OpClassTensorOp,
    cutlass::arch::Sm80,
    ThreadblockShape,
    WarpShape,
    InstructionShape,
    EVTD,
    cutlass::gemm::threadblock::ThreadblockSwizzleStreamK,
    NumStages,
    cutlass::arch::OpMultiplyAdd,
    EVTEpilogueStages
>::GemmKernel;

using DeviceGemmStreamK = cutlass::gemm::device::GemmUniversalAdapter<EVTKernelStreamK>;
```
I didn't want to use `cutlass::gemm::threadblock::ThreadblockSwizzleStreamK`, so I replaced it with `cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<1>`.
When I construct DeviceGemmStreamK::Arguments, it errors like this:
```
type "cutlass::gemm::kernel::GemmUniversal<Mma_, Epilogue_, ThreadblockSwizzle_, void, std::enable_if_t<<expression>, void>>::WarpShape ...
/workspace/cutlass/python/cutlass_library/../../include/cutlass/gemm/kernel/gemm_universal.h(94): here is inaccessible
```
I think it is because when if we don't use `ThreadblockSwizzleStreamK`, `DefaultGemmWithVisitor ` will choose `GemmWithEpilogueVisitor` as the type of `GemmKernel`. So `EVTKernelStreamK` will be a subclass of `GemmWithEpilogueVisitor` in include/cutlass/gemm/kernel/gemm_universal_with_visitor.h. 

The `GemmWithEpilogueVisitor` is a subclass of `GemmUniversal`, `GemmUniversal` has all the types we need to help us construct `GemmUniversalAdapter`, but when `GemmWithEpilogueVisitor` inherits from `GemmUniversal`, it doesn't use public inheritance, which means that the required types like `Mma, WarpShape` are not accessible in `GemmWithEpilogueVisitor`.

So, I changed the inheritance relationship to public to ensure the consistency of `DefaultGemmWithVisitor` behavior. Besides this, I also need to modify the `GemmWithEpilogueVisitor` class. 

I would like to hear your suggestions on this issue.