### PR TITLE
Fix typo in comment

### DIFF
--- a/include/cutlass/epilogue/fusion/sm90_visitor_compute_tma_warpspecialized.hpp
+++ b/include/cutlass/epilogue/fusion/sm90_visitor_compute_tma_warpspecialized.hpp
@@ -78,7 +78,7 @@ using namespace detail;
 // the template argument.
 //
 // template<class A>
-// struct FooHomogeneous : public Foo<A, B> {};
+// struct FooHomogeneous : public Foo<A, A> {};
 //
 template<
   template <class> class ComputeFn,


### PR DESCRIPTION
According to the previous comment, `FooHomogeneous` should inherit from `Foo<A, A>`, which has the same effect as the type template param `B` has a default template argument `A`.