### PR TITLE
Add missing 60_cutlass_import to CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -140,6 +140,7 @@ foreach(EXAMPLE
   57_hopper_grouped_gemm
   58_ada_fp8_gemm
   59_ampere_gather_scatter_conv
+  60_cutlass_import
   )
 
   add_subdirectory(${EXAMPLE})


### PR DESCRIPTION
It turns out that `60_cutlass_import` has never been built as an example since it was introduced. 