### PR TITLE
Add BF16 dtype mapping for python EVT

### DIFF
--- a/python/cutlass/backend/epilogue.py
+++ b/python/cutlass/backend/epilogue.py
@@ -44,6 +44,7 @@ from cutlass.utils.datatypes import is_numpy_tensor, is_torch_available, is_torc
 
 dtype2ctype = {
     DataType.f16: ctypes.c_uint16,
+    DataType.bf16: ctypes.c_uint16,
     DataType.f32: ctypes.c_float,
     DataType.f64: ctypes.c_double,
     DataType.s8: ctypes.c_int8,


### PR DESCRIPTION
Fixes #1824

I was thinking of adding a test case for this, but currently the dtype is hard-coded to FP16

https://github.com/NVIDIA/cutlass/blob/44dae8b90ef232ea663727470dfbbe9daff6972d/test/python/cutlass/evt/utils/evt_testbed.py#L206

Would take some refactoring to test multiple dtypes at the same time. Lmk if you want to add any tests, or don't add anything is fine.

@jackkosaian 