### PR TITLE
Make CuTe and PyCuTe idx2crd Behaviors The Same

### DIFF
--- a/python/pycute/int_tuple.py
+++ b/python/pycute/int_tuple.py
@@ -144,7 +144,25 @@ def prefix_product(a, init=1):
       return init
 
 
-def idx2crd(idx, shape, stride=None):
+def idx2crd(idx, shape):
+
+  if is_tuple(idx):
+    if is_tuple(shape):                # tuple tuple tuple
+      assert len(idx) == len(shape)
+      return tuple(idx2crd(i, s) for i, s in zip(idx,shape))
+    else:                              # tuple "int" "int"
+      assert False           # Error
+  else:
+    if is_tuple(shape):                # "int" tuple tuple
+      tuple_idx = []
+      for i in range(len(shape)):
+        tuple_idx.append(idx2crd(idx // product(shape[:i]), shape[i]))
+      return tuple(tuple_idx)
+    else:                              # "int" "int" "int"
+      return idx % shape
+
+
+def idx2crd(idx, shape, stride):
   if stride is None:
     stride = prefix_product(shape)
 


### PR DESCRIPTION
CuTe C++ has two function overloadings for `idx2crd`:
* [crd2idx(Coord const& coord, Shape const& shape)](https://github.com/NVIDIA/cutlass/blob/f7b19de32c5d1f3cedfc735c2849f12b537522ee/include/cute/stride.hpp#L146)
* [idx2crd(Index  const& idx, Shape  const& shape, Stride const& stride)](https://github.com/NVIDIA/cutlass/blob/f7b19de32c5d1f3cedfc735c2849f12b537522ee/include/cute/stride.hpp#L179)

However, PyCuTe only has one function for `idx2crd`:
* [idx2crd(idx, shape, stride=None)](https://github.com/NVIDIA/cutlass/blob/f7b19de32c5d1f3cedfc735c2849f12b537522ee/python/pycute/int_tuple.py#L147)

If default value `None` if used for the `idx2crd(idx, shape, stride=None)` in PyCuTe, the function behavior is different from the `crd2idx(Coord const& coord, Shape const& shape)` in CuTe C++.

Therefore, a new function `idx2crd(idx, shape)` was added to PyCuTe, and the default value was removed from `idx2crd(idx, shape, stride=None)`.