### PR TITLE
remove restriction of stride == kernel in nhwc_pooling

### DIFF
--- a/tools/util/include/cutlass/util/device_nhwc_pooling.h
+++ b/tools/util/include/cutlass/util/device_nhwc_pooling.h
@@ -361,9 +361,6 @@ void pooling_nhwc(cutlass::Tensor4DCoord input_tensor_size,
   assert(input_tensor_size.n() == output_tensor_size.n() &&
          input_tensor_size.c() == output_tensor_size.c());
 
-  assert(filter_tensor_size.h() == stride.row() &&
-         filter_tensor_size.w() == stride.column());
-
   const int N = input_tensor_size.n();
   const int H = input_tensor_size.h();
   const int W = input_tensor_size.w();


### PR DESCRIPTION
Currently in nhwc_pooling, it is code on assumption of stride == kernel_size:
```
  assert(filter_tensor_size.h() == stride.row() &&
         filter_tensor_size.w() == stride.column());
```
In this PR,  I remove such restriction so that nhwc_pooling could work on general cases.