### PR TITLE
Fix `cutlass` python library with cuda `12.6.2.post1`

### DIFF
--- a/python/cutlass/backend/operation.py
+++ b/python/cutlass/backend/operation.py
@@ -36,7 +36,7 @@ from cuda import __version__, cuda
 
 from cutlass.backend.utils.device import device_cc
 
-_version_splits = [int(x) for x in __version__.split("rc")[0].split(".")]
+_version_splits = [int(x) for x in __version__.split("rc")[0].split(".post")[0].split(".")]
 _supports_cluster_launch = None
 
 

--- a/python/cutlass_library/generator.py
+++ b/python/cutlass_library/generator.py
@@ -103,7 +103,7 @@ def CudaToolkitVersionSatisfies(semantic_ver_string, major, minor, patch = 0):
 
   # Update cuda_version based on parsed string
   if semantic_ver_string != '':
-    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')]):
+    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')[:3]):
       if i < len(cuda_version):
         cuda_version[i] = x
       else:

--- a/python/cutlass_library/generator.py
+++ b/python/cutlass_library/generator.py
@@ -103,7 +103,7 @@ def CudaToolkitVersionSatisfies(semantic_ver_string, major, minor, patch = 0):
 
   # Update cuda_version based on parsed string
   if semantic_ver_string != '':
-    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')[:3]):
+    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')[:3]]):
       if i < len(cuda_version):
         cuda_version[i] = x
       else:

--- a/python/cutlass_library/sm90_utils.py
+++ b/python/cutlass_library/sm90_utils.py
@@ -61,7 +61,7 @@ def CudaToolkitVersionSatisfies(semantic_ver_string, major, minor, patch = 0):
 
   # Update cuda_version based on parsed string
   if semantic_ver_string != '':
-    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')]):
+    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')[:3]):
       if i < len(cuda_version):
         cuda_version[i] = x
       else:

--- a/python/cutlass_library/sm90_utils.py
+++ b/python/cutlass_library/sm90_utils.py
@@ -61,7 +61,7 @@ def CudaToolkitVersionSatisfies(semantic_ver_string, major, minor, patch = 0):
 
   # Update cuda_version based on parsed string
   if semantic_ver_string != '':
-    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')[:3]):
+    for i, x in enumerate([int(x) for x in semantic_ver_string.split('.')[:3]]):
       if i < len(cuda_version):
         cuda_version[i] = x
       else:


### PR DESCRIPTION
Previously we had this error upon import:
```
  File "/storage/home/cutlass/python/cutlass/backend/operation.py", line 39, in <listcomp>
    _version_splits = [int(x) for x in __version__.split("rc")[0].split(".")]
                       ^^^^^^
ValueError: invalid literal for int() with base 10: 'post1'
```