### PR TITLE
Enabled examples/45_dual_gemm for GPUs with capability 80 or higher.

### DIFF
--- a/examples/45_dual_gemm/test_run.h
+++ b/examples/45_dual_gemm/test_run.h
@@ -66,7 +66,7 @@ int testRun(int arch, std::vector<bool (*)()> & test_funcs, const std::string & 
     return -1;
   }
 
-  if (!(props.major == arch_major && props.minor == arch_minor)) {
+  if (props.major<arch_major || (props.major==arch_major && props.minor<arch_minor) ) {
     supported = false;
   }
 


### PR DESCRIPTION
Enabled examples/45_dual_gemm for GPUs with capability 80 or higher.