### PR TITLE
Fix upper_bound assert in integer_subbyte

### DIFF
--- a/include/cutlass/integer_subbyte.h
+++ b/include/cutlass/integer_subbyte.h
@@ -93,12 +93,12 @@ struct integer_subbyte {
       [[maybe_unused]] constexpr int lower_bound = -(1 << (Bits - 1));
       [[maybe_unused]] constexpr int upper_bound = (1 << (Bits - 1)) - 1;
       assert(value >= lower_bound);
-      assert(value < upper_bound);
+      assert(value <= upper_bound);
     }
     else {
-      [[maybe_unused]] constexpr unsigned upper_bound = 1u << Bits;
+      [[maybe_unused]] constexpr unsigned upper_bound = (1u << Bits) - 1;
       assert(value >= 0);
-      assert(value < static_cast<int>(upper_bound));
+      assert(value <= static_cast<int>(upper_bound));
     }
   }
 
@@ -112,11 +112,11 @@ struct integer_subbyte {
       [[maybe_unused]] constexpr int lower_bound = -(1 << (Bits - 1));
       [[maybe_unused]] constexpr int upper_bound = (1 << (Bits - 1)) - 1;
       assert(value >= lower_bound);
-      assert(value < upper_bound);
+      assert(value <= upper_bound);
     }
     else {
-      [[maybe_unused]] constexpr unsigned upper_bound = 1u << Bits;
-      assert(value < upper_bound);
+      [[maybe_unused]] constexpr unsigned upper_bound = (1u << Bits) - 1;
+      assert(value <= upper_bound);
     }
   }
 


### PR DESCRIPTION
The assertion with a signed upper bound was incorrect. I have corrected it and, to enhance readability, uniformly used closed intervals.

This may fix the problem in #1952. 