### PR TITLE
Add Line Break for Print SVG

### DIFF
--- a/include/cute/atom/mma_atom.hpp
+++ b/include/cute/atom/mma_atom.hpp
@@ -1070,7 +1070,7 @@ print_svg_mma(LayoutC const& C, ThrIDC const& TC,  // (m,n) -> (tid,vid)  and  t
   }
 
   // footer
-  printf("</svg>");
+  printf("</svg>\n");
 }
 
 template <class... Args>


### PR DESCRIPTION
Print SVG footer deserves a line break because print LaTeX has one.