### PR TITLE
Always use cudaGetDriverEntryPoint with CUDA 12

### DIFF
--- a/include/cutlass/cuda_host_adapter.hpp
+++ b/include/cutlass/cuda_host_adapter.hpp
@@ -104,8 +104,7 @@ namespace cutlass {
 
 #else // defined(CUTLASS_ENABLE_DIRECT_CUDA_DRIVER_CALL)
 
-#if ((__CUDACC_VER_MAJOR__ >= 13) ||                               \
-    ((__CUDACC_VER_MAJOR__ == 12) && (__CUDACC_VER_MINOR__ >= 5))) \
+#if (__CUDACC_VER_MAJOR__ >= 13)
 
 #define CUTLASS_CUDA_DRIVER_WRAPPER_DECL(func, ver)             \
   template <typename... Args>                                   \


### PR DESCRIPTION
`cudaGetDriverEntryPointByVersion` has been added to drivers in 12.5, but we don't know at compile time the driver version. In particular, we can build with nvcc 12.8 for a 12.2 driver for instance, and this was causing the following error:

```
undefined symbol: cudaGetDriverEntryPointByVersion,
```

Closes https://github.com/NVIDIA/cutlass/issues/2079

NOTE: I was not able to test it with CUDA driver 12.5+