### PR TITLE
Add ParetoQ to PUBLICATIONS.md

### DIFF
--- a/PUBLICATIONS.md
+++ b/PUBLICATIONS.md
@@ -1,5 +1,9 @@
 # Publications Using Cutlass
 
+## 2025
+
+- ["ParetoQ: Scaling Laws in Extremely Low-bit LLM Quantization"](https://arxiv.org/abs/2502.02631). Zechun Liu, Changsheng Zhao, Hanxian Huang, Sijia Chen, Jing Zhang, Jiawei Zhao, Scott Roy, Lisa Jin, Yunyang Xiong, Yangyang Shi, Lin Xiao, Yuandong Tian, Bilge Soran, Raghuraman Krishnamoorthi, Tijmen Blankevoort, Vikas Chandra. _arXiv_, February 2025.
+
 ## 2024
 
 - ["ShadowKV: KV Cache in Shadows for High-Throughput Long-Context LLM Inference"](https://arxiv.org/abs/2410.21465). Hanshi Sun, Li-Wen Chang, Wenlei Bao, Size Zheng, Ningxin Zheng, Xin Liu, Harry Dong, Yuejie Chi, Beidi Chen. _arXiv_, October 2024.


### PR DESCRIPTION
ParetoQ leverages CUTLASS mixed-precision W2A16 kernel. Special thanks to @hwu36 and @IwakuraRein for the support!