### PR TITLE
[EVT] Fix Row/Col broadcast with array arguments

### DIFF
--- a/include/cutlass/epilogue/fusion/sm90_visitor_load_tma_warpspecialized.hpp
+++ b/include/cutlass/epilogue/fusion/sm90_visitor_load_tma_warpspecialized.hpp
@@ -1042,8 +1042,10 @@ struct Sm90RowBroadcast {
       is_zero_ = params.null_default == ElementCompute(0);
     }
     // Dynamic non-batched scalar broadcast
-    else if (IsDynamicBroadcast && stride_N == bool(0) && stride_L == repeat_like(stride_L, 0) && !IsArrayOfPointers) {
-      is_zero_ = params.ptr_row[0] == ElementInput(0);
+    if constexpr (!IsArrayOfPointers) {
+      if (IsDynamicBroadcast && stride_N == bool(0) && stride_L == repeat_like(stride_L, 0)) {
+        is_zero_ = params.ptr_row[0] == ElementInput(0);
+      }
     }
   }
 
@@ -1319,8 +1321,10 @@ struct Sm90ColBroadcast {
       is_zero_ = params.null_default == ElementCompute(0);
     }
     // Dynamic non-batched scalar broadcast
-    else if (IsDynamicBroadcast && stride_M == bool(0) && stride_L == repeat_like(stride_L, 0) && !IsArrayOfPointers) {
-      is_zero_ = params.ptr_col[0] == ElementInput(0);
+    if constexpr (!IsArrayOfPointers) {
+      if (IsDynamicBroadcast && stride_M == bool(0) && stride_L == repeat_like(stride_L, 0)) {
+        is_zero_ = params.ptr_col[0] == ElementInput(0);
+      }
     }
   }
 

--- a/include/cutlass/epilogue/fusion/sm90_visitor_load_tma_warpspecialized.hpp
+++ b/include/cutlass/epilogue/fusion/sm90_visitor_load_tma_warpspecialized.hpp
@@ -1042,8 +1042,8 @@ struct Sm90RowBroadcast {
       is_zero_ = params.null_default == ElementCompute(0);
     }
     // Dynamic non-batched scalar broadcast
-    if constexpr (!IsArrayOfPointers) {
-      if (IsDynamicBroadcast && stride_N == bool(0) && stride_L == repeat_like(stride_L, 0)) {
+    else if (IsDynamicBroadcast && stride_N == bool(0) && stride_L == repeat_like(stride_L, 0)) {
+      if constexpr (!IsArrayOfPointers) {
         is_zero_ = params.ptr_row[0] == ElementInput(0);
       }
     }
@@ -1321,8 +1321,8 @@ struct Sm90ColBroadcast {
       is_zero_ = params.null_default == ElementCompute(0);
     }
     // Dynamic non-batched scalar broadcast
-    if constexpr (!IsArrayOfPointers) {
-      if (IsDynamicBroadcast && stride_M == bool(0) && stride_L == repeat_like(stride_L, 0)) {
+    else if (IsDynamicBroadcast && stride_M == bool(0) && stride_L == repeat_like(stride_L, 0)) {
+      if constexpr (!IsArrayOfPointers) {
         is_zero_ = params.ptr_col[0] == ElementInput(0);
       }
     }


### PR DESCRIPTION
#2033 added the ability for row/col broadcast nodes to accept ptr array arguments, however, during some followup refactoring it was broken. Specifically, there is an invalid type comparison that was added. This small PR fixes the issue by using a constexpr if to avoid the comparison if ptrarray is being used.