### PR TITLE
Request to remove annoyingly high number of warning

### DIFF
--- a/include/cutlass/integer_subbyte.h
+++ b/include/cutlass/integer_subbyte.h
@@ -74,7 +74,6 @@ struct integer_subbyte {
   template<class T,
     class Enable = cutlass::platform::enable_if_t<cutlass::platform::is_convertible_v<T, int>>
   >
-  [[deprecated("Implicit conversion is deprecated; please use explicit construction instead")]]
   CUTLASS_HOST_DEVICE
   integer_subbyte(T value)
       : integer_subbyte(static_cast<xint_t>(value)) {}


### PR DESCRIPTION
Removed the line that generates annoyingly high number of warnings in the CUTLASS compilation that makes it hard and easy to miss real CUTLASS/CuTe already very verbose template errors. If we want to keep this line, please remove the warnings and deprecated usage from the existing CUTLASS codebase. 

See the [build.logs](https://github.com/user-attachments/files/18998985/build.txt) file or the 1/100 of the warning snippet below:


```bash
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h:220:11: warning: ‘cutlass::integer_subbyte<Bits, Signed>::integer_subbyte(T) [with T = double; Enable = void; int Bits = 4; bool Signed = false]’ is deprecated: Implicit conversion is deprecated; please use explicit construction instead [-Wdeprecated-declarations]
  220 |       result = Element(rnd);
      |          ~^~~~~~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/include/cutlass/integer_subbyte.h:79:1: note: declared here
   79 |   integer_subbyte(T value)
      | ^ ~~~~~~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h: In instantiation of ‘Element cutlass::reference::host::detail::RandomUniformFunc<Element>::operator()() [with Element = cutlass::integer_subbyte<4, false>]’:
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h:1123:55:   required from ‘void cutlass::reference::host::BlockFillRandomUniform(Element*, size_t, uint64_t, double, double, int, double) [with Element = cutlass::integer_subbyte<4, false>; size_t = long unsigned int; uint64_t = long unsigned int]’
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h:1501:34:   required from ‘void cutlass::reference::host::BlockFillRandom(Element*, size_t, uint64_t, cutlass::Distribution) [with Element = cutlass::integer_subbyte<4, false>; size_t = long unsigned int; uint64_t = long unsigned int]’
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/profiler/src/device_allocation.cu:1001:73:   required from here
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h:642:33: warning: ‘cutlass::integer_subbyte<Bits, Signed>::integer_subbyte(T) [with T = double; Enable = void; int Bits = 4; bool Signed = false]’ is deprecated: Implicit conversion is deprecated; please use explicit construction instead [-Wdeprecated-declarations]
  642 |       result = static_cast<Element>(Real(rnd));
      |                                 ^~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/include/cutlass/integer_subbyte.h:79:1: note: declared here
   79 |   integer_subbyte(T value)
      | ^ ~~~~~~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h:645:33: warning: ‘cutlass::integer_subbyte<Bits, Signed>::integer_subbyte(T) [with T = double; Enable = void; int Bits = 4; bool Signed = false]’ is deprecated: Implicit conversion is deprecated; please use explicit construction instead [-Wdeprecated-declarations]
  645 |       result = static_cast<Element>(Real(rnd));
      |                                 ^~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/include/cutlass/integer_subbyte.h:79:1: note: declared here
   79 |   integer_subbyte(T value)
      | ^ ~~~~~~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/tools/util/include/cutlass/util/reference/host/tensor_fill.h:654:33: warning: ‘cutlass::integer_subbyte<Bits, Signed>::integer_subbyte(T) [with T = double; Enable = void; int Bits = 4; bool Signed = false]’ is deprecated: Implicit conversion is deprecated; please use explicit construction instead [-Wdeprecated-declarations]
  654 |       result = static_cast<Element>(Real(rnd));
      |                                 ^~~~~~~~~
/home/manish_magic_dev/repos/cutlass/cutlass_tree_2/cutlass/include/cutlass/integer_subbyte.h:79:1: note: declared here
   79 |   integer_subbyte(T value)
      | ^ ~~~~~~~~~~~~~
```