### PR TITLE
Add Blackwell to the list of architectures in quickstart.md

### DIFF
--- a/media/docs/quickstart.md
+++ b/media/docs/quickstart.md
@@ -180,6 +180,11 @@ $ make test_unit_gemm_warp -j
 To minimize compilation time, specific GPU architectures can be enabled via the CMake command,
 selected by [CUDA Compute Capability.](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities)
 
+**NVIDIA Blackwell Architecture.**
+```bash
+$ cmake .. -DCUTLASS_NVCC_ARCHS=100a              # compiles for NVIDIA Blackwell GPU architecture
+```
+
 **NVIDIA Hopper Architecture.**
 ```bash
 $ cmake .. -DCUTLASS_NVCC_ARCHS=90a              # compiles for NVIDIA Hopper GPU architecture


### PR DESCRIPTION
As the title implies, I added the Blackwell architecture to the list of supported architectures. Since it was already mentioned at the beginning, I simply included it in the list.