### PR TITLE
Fix sm100 gemm wrong static constexpr that breaks compilation on Windows

### DIFF
--- a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized.hpp
@@ -461,8 +461,7 @@ public:
     return grid_shape;
   }
 
-  static constexpr
-  dim3
+  static dim3
   get_block_shape() {
     return dim3(MaxThreadsPerBlock, 1, 1);
   }

--- a/include/cutlass/gemm/kernel/sm100_gemm_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_tma_warpspecialized.hpp
@@ -399,8 +399,7 @@ public:
         params.hw_info);
   }
 
-  static constexpr
-  dim3
+  static dim3
   get_block_shape() {
     return dim3(MaxThreadsPerBlock, 1, 1);
   }

--- a/include/cutlass/gemm/kernel/sm100_gemm_tma_warpspecialized_mma_transform.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_tma_warpspecialized_mma_transform.hpp
@@ -387,8 +387,7 @@ public:
         params.hw_info);
   }
 
-  static constexpr
-  dim3
+  static dim3
   get_block_shape() {
     return dim3(MaxThreadsPerBlock, 1, 1);
   }

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -523,7 +523,7 @@ using std::is_trivially_copyable;
 
 #endif
 
-#if defined(_MSC_VER) || (201703L <=__cplusplus)
+#if (201703L <=__cplusplus)
 
 /// std::is_unsigned_v
 using CUTLASS_STL_NAMESPACE::is_integral_v;

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -523,7 +523,7 @@ using std::is_trivially_copyable;
 
 #endif
 
-#if (201703L <=__cplusplus)
+#if defined(_MSC_VER) || (201703L <=__cplusplus)
 
 /// std::is_unsigned_v
 using CUTLASS_STL_NAMESPACE::is_integral_v;


### PR DESCRIPTION
`constexpr` was incorrectly added to the function definition only for this architecture, breaking the compilation of Cutlass on Windows.