### PR TITLE
Fix CUTE_DEVICE for cast_smem_ptr_to_unit

### DIFF
--- a/include/cute/arch/util.hpp
+++ b/include/cute/arch/util.hpp
@@ -88,7 +88,7 @@ namespace cute
 {
 
 /// CUTE helper to cast SMEM pointer to unsigned
-CUTE_DEVICE
+CUTE_HOST_DEVICE
 uint32_t
 cast_smem_ptr_to_uint(void const* const ptr)
 {


### PR DESCRIPTION
make_gmma_desc (with CUTE_HOST_DEVICE) calls cast_smem_ptr_to_unit. So we need to mark it CUTE_HOST_DEVICE as well. #1997 