### PR TITLE
fix-left-inverse-for-nvcc114

### DIFF
--- a/include/cute/layout.hpp
+++ b/include/cute/layout.hpp
@@ -1346,7 +1346,7 @@ left_inverse(Layout<Shape,Stride> const& layout)
       }
     });
 
-  return coalesce(make_layout(append(result_shape, get<back(sorted_seq)>(lshape)),
+  return coalesce(make_layout(append(result_shape, get<decltype(back(sorted_seq))::value>(lshape)),
                               result_stride));
 }
 


### PR DESCRIPTION
During compilation of a complex left-inverse kernel, NVCC 11.4 failed to build the implementation. I resolved the compiler-specific issues to improve the code robustness, then verified the fixes with NVCC 12.1.

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/4b914155-99c2-421b-8af1-d3058f139c2b" />
