### PR TITLE
fix_missing_stdint

### DIFF
--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -147,9 +147,9 @@
 //
 
 #if defined(__CUDACC_RTC__)
-#include <cuda/std/cstdint>
+#  include <cuda/std/cstdint>
 #else
-#include <cstdint>
+#  include <cstdint>
 #endif
 
 //

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -143,6 +143,12 @@
 #endif
 
 //
+// Type
+//
+
+#include <cstdint>
+
+//
 // Debugging utilities
 //
 

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -146,7 +146,11 @@
 // Type
 //
 
+#if defined(__CUDACC_RTC__)
+#include <cuda/std/cstdint>
+#else
 #include <cstdint>
+#endif
 
 //
 // Debugging utilities


### PR DESCRIPTION
I encountered a compile error when compiling cutlass@3.8.0. It seems to be a missing header <cstdint>. See also #2148.

```plain_text
...
[ 52%] Generating nvrtc/cute/atom/mma_traits_sm90.hpp
cd /tmp/mizuno-ai/spack-stage/spack-stage-cutlass-3.8.0-taomxjkncofl27l4ed6y4azkxfgb2yll/spack-build-taomxjk/test/unit/nvrtc && /mnt/sda/2022-0526/public/wuk/v0.23.0.12.3.0.12.20241120/spack/opt/spack/linux-debian11-zen2/gcc-13.2.0/cmake-3.30.5-a4w5ckchyi3ih7t4slujnfrhr4vsc64s/bin/cmake -DFILE_IN="/tmp/mizuno-ai/spack-stage/spack-stage-cutlass-3.8.0-taomxjkncofl27l4ed6y4azkxfgb2yll/spack-src/include/cute/atom/mma_traits_sm90.hpp" -DFILE_OUT="/tmp/mizuno-ai/spack-stage/spack-stage-cutlass-3.8.0-taomxjkncofl27l4ed6y4azkxfgb2yll/spack-build-taomxjk/test/unit/nvrtc/nvrtc/cute/atom/mma_traits_sm90.hpp" -DVARIABLE_NAME="cute_atom_mma_traits_sm90_hpp" -P /tmp/mizuno-ai/spack-stage/spack-stage-cutlass-3.8.0-taomxjkncofl27l4ed6y4azkxfgb2yll/spack-src/bin2hex.cmake
/mnt/sda/2022-0526/public/wuk/v0.23.0.12.3.0.12.20241120/spack/opt/spack/linux-debian11-zen2/gcc-13.2.0/gmake-4.4.1-3ncebplrwxrbfxmcxvansf4cxl52gl6f/bin/make  -f tools/library/CMakeFiles/cutlass_library_gemm_sm80_f16_s16816gemm_u8_f16.dir/build.make tools/library/CMakeFiles/cutlass_library_gemm_sm80_f16_s16816gemm_u8_f16.dir/depend
/tmp/mizuno-ai/spack-stage/spack-stage-cutlass-3.8.0-taomxjkncofl27l4ed6y4azkxfgb2yll/spack-src/include/cute/arch/cluster_sm90.hpp(153): error: identifier "uint32_t" is undefined
             uint32_t block_rank_in_cluster()
...
```