### PR TITLE
Import cuda, cudart, nvrtc lazily

### DIFF
--- a/python/cutlass/backend/arguments.py
+++ b/python/cutlass/backend/arguments.py
@@ -33,7 +33,10 @@
 from math import prod
 from typing import Union
 
-from cuda import cuda, cudart
+from cutlass.utils.lazy_import import lazy_import
+
+cuda = lazy_import("cuda.cuda")
+cudart = lazy_import("cuda.cudart")
 import numpy as np
 
 import cutlass

--- a/python/cutlass/backend/compiler.py
+++ b/python/cutlass/backend/compiler.py
@@ -37,7 +37,10 @@ import sqlite3
 import subprocess
 import tempfile
 
-from cuda import cuda, nvrtc
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
+cudart = lazy_import("cuda.cudart")
+nvrtc = lazy_import("cuda.nvrtc")
 from cutlass_library import SubstituteTemplate
 
 import cutlass

--- a/python/cutlass/backend/conv2d_operation.py
+++ b/python/cutlass/backend/conv2d_operation.py
@@ -29,11 +29,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #################################################################################################
+from __future__ import annotations
 
 import ctypes
 from typing import Union
 
-from cuda import cuda
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
 from cutlass_library import SubstituteTemplate
 import numpy as np
 

--- a/python/cutlass/backend/evt/epilogue.py
+++ b/python/cutlass/backend/evt/epilogue.py
@@ -36,7 +36,8 @@ Epilogue Visitor interface for compiling, and running visitor-based epilogue.
 
 import ctypes
 
-from cuda import cuda
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
 from cutlass_library import DataType
 import numpy as np
 

--- a/python/cutlass/backend/frontend.py
+++ b/python/cutlass/backend/frontend.py
@@ -29,8 +29,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #################################################################################################
+from __future__ import annotations
 
-from cuda import cuda
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
 import numpy as np
 
 from cutlass.backend.memory_manager import device_mem_alloc, todevice

--- a/python/cutlass/backend/gemm_operation.py
+++ b/python/cutlass/backend/gemm_operation.py
@@ -29,12 +29,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #################################################################################################
+from __future__ import annotations
 
 import copy
 import ctypes
 import enum
 
-from cuda import cuda, cudart
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
+cudart = lazy_import("cuda.cudart")
 from cutlass_library import SubstituteTemplate
 import numpy as np
 

--- a/python/cutlass/backend/memory_manager.py
+++ b/python/cutlass/backend/memory_manager.py
@@ -34,11 +34,12 @@ import numpy as np
 
 import cutlass
 from cutlass.utils.datatypes import is_numpy_tensor
+from cutlass.utils.lazy_import import lazy_import
 
 if cutlass.use_rmm:
     import rmm
 else:
-    from cuda import cudart
+    cudart = lazy_import("cuda.cudart")
 
 
 class PoolMemoryManager:

--- a/python/cutlass/backend/reduction_operation.py
+++ b/python/cutlass/backend/reduction_operation.py
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ################################################################################
+from __future__ import annotations
 
 import ctypes
 from typing import Union

--- a/python/cutlass/backend/reduction_operation.py
+++ b/python/cutlass/backend/reduction_operation.py
@@ -33,7 +33,9 @@
 import ctypes
 from typing import Union
 
-from cuda import cuda, cudart
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
+cudart =  lazy_import("cuda.cudart")
 import numpy as np
 
 from cutlass_library import (

--- a/python/cutlass/backend/utils/device.py
+++ b/python/cutlass/backend/utils/device.py
@@ -33,8 +33,11 @@
 """
 Utility functions for interacting with the device
 """
+from __future__ import annotations
 
-from cuda import cuda, cudart
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
+cudart =  lazy_import("cuda.cudart")
 
 import cutlass
 from cutlass.utils.datatypes import is_cupy_tensor, is_numpy_tensor, is_torch_tensor

--- a/python/cutlass/library_defaults.py
+++ b/python/cutlass/library_defaults.py
@@ -37,7 +37,6 @@ Classes containing valid operations for a given compute capability and data type
 from itertools import combinations_with_replacement
 import logging
 
-from cuda import __version__
 import cutlass_library
 from cutlass_library.library import ConvKind, IteratorAlgorithm, StrideSupport, GroupMode
 
@@ -48,22 +47,8 @@ from cutlass.utils.datatypes import td_from_profiler_td, td_from_profiler_op
 
 _generator_ccs = [50, 60, 61, 70, 75, 80, 90]
 
-# Strip any additional information from the CUDA version
-_cuda_version = __version__.split("rc")[0]
 
-# Check that Python CUDA version exceeds NVCC version
-_nvcc_version = cutlass.nvcc_version()
-_cuda_list = _cuda_version.split('.')
-_nvcc_list = _nvcc_version.split('.')
-for val_cuda, val_nvcc in zip(_cuda_list, _nvcc_list):
-    if int(val_cuda) < int(val_nvcc):
-        raise Exception(f"Python CUDA version of {_cuda_version} must be greater than or equal to NVCC version of {_nvcc_version}")
 
-if len(_nvcc_list) > len(_cuda_list):
-    if len(_nvcc_list) != len(_cuda_list) + 1:
-        raise Exception(f"Malformatted NVCC version of {_nvcc_version}")
-    if _nvcc_list[:-1] == _cuda_list and int(_nvcc_list[-1]) != 0:
-        raise Exception(f"Python CUDA version of {_cuda_version} must be greater than or equal to NVCC version of {_nvcc_version}")
 
 
 class KernelsForDataType:

--- a/python/cutlass/library_defaults.py
+++ b/python/cutlass/library_defaults.py
@@ -48,9 +48,6 @@ from cutlass.utils.datatypes import td_from_profiler_td, td_from_profiler_op
 _generator_ccs = [50, 60, 61, 70, 75, 80, 90]
 
 
-
-
-
 class KernelsForDataType:
     """
     Container class for keeping track of kernels that correspond to a particular combination
@@ -277,7 +274,7 @@ class ArchOptions:
         ]
         manifest_args = cutlass_library.generator.define_parser().parse_args(args)
         manifest = cutlass_library.manifest.Manifest(manifest_args)
-        generate_function(manifest, _nvcc_version)
+        generate_function(manifest, cutlass._nvcc_version)
 
         if operation_kind not in manifest.operations:
             # No kernels generated for this architecture, this could be because the CUDA
@@ -552,6 +549,9 @@ class OptionRegistry:
 
     def __init__(self, target_cc: int):
         self.registry = {}
+
+        if target_cc > 90:
+            raise Exception(f"Unsupported compute capability {target_cc}. The CUTLASS Python interface only supports compute capabilities up to 90.")
 
         gemm_kinds = [cutlass_library.GemmKind.Universal, cutlass_library.GemmKind.Universal3x]
         operation_kinds = [cutlass_library.OperationKind.Gemm, cutlass_library.OperationKind.Conv2d]

--- a/python/cutlass/op/conv.py
+++ b/python/cutlass/op/conv.py
@@ -112,7 +112,9 @@
         args.sync()
 """
 
-from cuda import cuda
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
+cudart =  lazy_import("cuda.cudart")
 from cutlass_library import (
     ConvKind,
     ConvMode,

--- a/python/cutlass/op/conv.py
+++ b/python/cutlass/op/conv.py
@@ -111,7 +111,8 @@
 
         args.sync()
 """
-
+from __future__ import annotations
+from typing import Optional
 from cutlass.utils.lazy_import import lazy_import
 cuda = lazy_import("cuda.cuda")
 cudart =  lazy_import("cuda.cudart")
@@ -737,7 +738,7 @@ class Conv2d(OperationBase):
             alpha=None, beta=None,
             split_k=("serial", 1), sync: bool = True,
             print_module: bool = False,
-            stream: cuda.CUstream = cuda.CUstream(0)) -> Conv2dArguments:
+            stream: Optional[cuda.CUstream] = None) -> Conv2dArguments:
         """
         Runs the kernel currently specified. If it has not already been, the kernel is emitted and
         compiled. Tensors holding operands and outputs of the kernel are sourced either from the
@@ -770,6 +771,8 @@ class Conv2d(OperationBase):
         :return: arguments passed in to the kernel
         :rtype: cutlass.backend.Conv2dArguments
         """
+        if not stream:
+            stream = cuda.CUstream(0)
         super().run_setup()
 
         A = self._verify_tensor(A, self.A, self._element_a, self._layout_a, "A")
@@ -928,7 +931,10 @@ class Conv2dFprop(Conv2d):
         self, input=None, weight=None, C=None, output=None, alpha=None, beta=None,
         stride=(1, 1), padding=(0, 0), dilation=(1, 1), split_k=("serial", 1),
         sync: bool = True, print_module: bool = False,
-        stream: cuda.CUstream = cuda.CUstream(0)) -> Conv2dArguments:
+        stream: Optional[cuda.CUstream] = None) -> Conv2dArguments:
+
+        if not stream:
+            stream = cuda.CUstream(0)
 
         A, B, D = input, weight, output
         return super().run(
@@ -953,8 +959,11 @@ class Conv2dDgrad(Conv2d):
     def run(self, grad_output=None, weight=None, C=None, grad_input=None, alpha=None, beta=None,
         stride=(1, 1), padding=(0, 0), dilation=(1, 1), split_k=("serial", 1),
         sync: bool = True, print_module: bool = False,
-        stream: cuda.CUstream = cuda.CUstream(0)) -> Conv2dArguments:
+        stream: Optional[cuda.CUstream] = None) -> Conv2dArguments:
         #
+        if not stream:
+            stream = cuda.CUstream(0)
+
         A, B, D = grad_output, weight, grad_input
         return super().run(
             A, B, C, D, alpha, beta, stride, padding, dilation, split_k, sync, print_module, stream)
@@ -978,8 +987,10 @@ class Conv2dWgrad(Conv2d):
     def run(self, grad_output=None, input=None, C=None, grad_weight=None, alpha=None, beta=None,
         stride=(1, 1), padding=(0, 0), dilation=(1, 1), split_k=("serial", 1),
         sync: bool = True, print_module: bool = False,
-        stream: cuda.CUstream = cuda.CUstream(0)) -> Conv2dArguments:
-        #
+        stream: Optional[cuda.CUstream] = None) -> Conv2dArguments:
+        if not stream:
+            stream = cuda.CUstream(0)
+
         A, B, D = grad_output, input, grad_weight
         return super().run(
             A, B, C, D, alpha, beta, stride, padding, dilation, split_k, sync, print_module, stream)

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -113,7 +113,8 @@
 
         args.sync()
 """
-
+from __future__ import annotations
+from typing import Optional
 from math import prod
 
 from cutlass.utils.lazy_import import lazy_import
@@ -624,7 +625,7 @@ class Gemm(OperationBase):
 
     def run(self, A=None, B=None, C=None, D=None,
             alpha=None, beta=None, sync: bool = True, print_module: bool = False, visitor_args: dict = None,
-            stream: cuda.CUstream = cuda.CUstream(0)) -> GemmArguments:
+            stream: Optional[cuda.CUstream] = None) -> GemmArguments:
         """
         Runs the kernel currently specified. If it has not already been, the kernel is emitted and
         compiled. Tensors holding operands and outputs of the kernel are sourced either from the
@@ -653,6 +654,8 @@ class Gemm(OperationBase):
         :return: arguments passed in to the kernel
         :rtype: cutlass.backend.GemmArguments
         """
+        if not stream:
+            stream = cuda.CUStream(0)
         super().run_setup()
         A = self._verify_tensor(A, self.A, self._element_a, self._layout_a, "A")
         B = self._verify_tensor(B, self.B, self._element_b, self._layout_b, "B")

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -655,7 +655,7 @@ class Gemm(OperationBase):
         :rtype: cutlass.backend.GemmArguments
         """
         if not stream:
-            stream = cuda.CUStream(0)
+            stream = cuda.CUstream(0)
         super().run_setup()
         A = self._verify_tensor(A, self.A, self._element_a, self._layout_a, "A")
         B = self._verify_tensor(B, self.B, self._element_b, self._layout_b, "B")

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -116,7 +116,8 @@
 
 from math import prod
 
-from cuda import cuda
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
 from cutlass_library import (
     DataType,
     DataTypeSize,

--- a/python/cutlass/op/gemm_grouped.py
+++ b/python/cutlass/op/gemm_grouped.py
@@ -50,7 +50,8 @@
         plan = cutlass.op.GroupedGemm(element=cutlass.DataType.f16, layout=cutlass.LayoutType.RowMajor)
         plan.run([A0, A1], [B0, B1], [C0, C1], [D0, D1])
 """
-
+from __future__ import annotations
+from typing import Optional
 from cutlass_library import DataTypeSize
 
 from cutlass.utils.lazy_import import lazy_import
@@ -197,7 +198,7 @@ class GroupedGemm(Gemm):
     def run(self, A, B, C, D,
             alpha=None, beta=None, sync: bool = True,
             print_module: bool = False,
-            stream: cuda.CUstream = cuda.CUstream(0)) -> GemmGroupedArguments:
+            stream: Optional[cuda.CUstream] = None) -> GemmGroupedArguments:
         """
         Runs the kernel currently specified.
 
@@ -226,6 +227,9 @@ class GroupedGemm(Gemm):
         :return: arguments passed in to the kernel
         :rtype: cutlass.backend.GemmGroupedArguments
         """
+        if not stream:
+            stream = cuda.CUstream(0)
+
         super().run_setup()
 
         if len(A) != len(B) or len(A) != len(C) or len(A) != len(D):

--- a/python/cutlass/op/gemm_grouped.py
+++ b/python/cutlass/op/gemm_grouped.py
@@ -53,7 +53,8 @@
 
 from cutlass_library import DataTypeSize
 
-from cuda import cuda
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
 from cutlass.backend.gemm_operation import (
     GemmGroupedArguments,
     GemmOperationGrouped,

--- a/python/cutlass/utils/lazy_import.py
+++ b/python/cutlass/utils/lazy_import.py
@@ -1,0 +1,11 @@
+import importlib
+from typing import Any
+
+def lazy_import(mod_name: str) -> Any:
+    class Lazy:
+        def __getattr__(self, name:str) -> Any:
+            module = importlib.import_module(mod_name)
+            return getattr(module, name)
+    
+    return Lazy()
+            

--- a/python/cutlass/utils/profiler.py
+++ b/python/cutlass/utils/profiler.py
@@ -37,7 +37,9 @@ Profiler based on the cuda events
 import re
 import subprocess
 
-from cuda import cuda, cudart
+from cutlass.utils.lazy_import import lazy_import
+cuda = lazy_import("cuda.cuda")
+cudart =  lazy_import("cuda.cudart")
 import numpy as np
 
 from cutlass import CUTLASS_PATH
@@ -54,18 +56,27 @@ class GpuTimer:
             cuda.cuEventCreate(cuda.CUevent_flags.CU_EVENT_DEFAULT)[1],
         ]
 
-    def start(self, stream=cuda.CUstream(0)):
+    def start(self, stream=None):
+        if not stream:
+            stream = cuda.CUstream(0)
+
         (err,) = cuda.cuEventRecord(self.events[0], stream)
         if err != cuda.CUresult.CUDA_SUCCESS:
             raise RuntimeError(f"CUDA Error {str(err)}")
 
-    def stop(self, stream=cuda.CUstream(0)):
+    def stop(self, stream=None):
+        if not stream:
+            stream = cuda.CUstream(0)
+
         (err,) = cuda.cuEventRecord(self.events[1], stream)
         if err != cuda.CUresult.CUDA_SUCCESS:
             raise RuntimeError(f"CUDA Error {str(err)}")
         pass
 
-    def stop_and_wait(self, stream=cuda.CUstream(0)):
+    def stop_and_wait(self, stream=None):
+        if not stream:
+            stream = cuda.CUstream(0)
+
         self.stop(stream)
         if stream:
             (err,) = cuda.cuStreamSynchronize(stream)
@@ -182,4 +193,3 @@ class CUDAEventProfiler:
             flops_ += m * n * batch_count * 2
 
         return flops_
-


### PR DESCRIPTION
Towards https://github.com/NVIDIA/cutlass/issues/2243

This PR adds a util to import the above cuda.* modules lazily.

Other changes:
* import annotation to remove imports for type annotations unless type checking is running
* removing cuda.* types from default args to not eagerly import