### PR TITLE
Support N={48, 80, 96, 112, ...} for SM100 EpilogueTileAuto

### DIFF
--- a/include/cutlass/epilogue/collective/builders/sm100_builder.inl
+++ b/include/cutlass/epilogue/collective/builders/sm100_builder.inl
@@ -1095,7 +1095,7 @@ private:
       constexpr int N_min_D = (detail::is_m_major<GmemStrideTypeD>()) ? 8 * WarpN
                                 : (sizeof_bits_v<ElementD> == 6) ? 128 * WarpN // TMA store only supports SW128B for FP6 data type
                                                                 : 128 / sizeof_bits_v<ElementD> * WarpN;
-      constexpr int N = cute::min(CtaN, cute::max(N_perf, N_min_C, N_min_D));
+      constexpr int N = cute::gcd(CtaN, cute::min(CtaN, cute::max(N_perf, N_min_C, N_min_D)));
       static_assert(CtaN >= N_min_C && CtaN >= N_min_D, "CTA tile too small");
 
       // stride by tmem warp layout and return a by-mode tiler


### PR DESCRIPTION
This partially addresses #2268

I'm still figuring out how I can support ctaNs that are multiples of 8 but not multiple of 16, e.g. N={8, 24, 56, 72, ...}. 

 