### PR TITLE
Check Epilogue Alignment for TMA in CUTLASS 3.x Hopper Grouped GEMM

### DIFF
--- a/include/cutlass/epilogue/collective/builders/sm90_builder.inl
+++ b/include/cutlass/epilogue/collective/builders/sm90_builder.inl
@@ -300,6 +300,11 @@ struct Sm90TmaBuilderImpl {
   using ElementC = cute::conditional_t<cute::is_void_v<ElementC_>,ElementD,ElementC_>; // prevents void ref breakages
   using GmemLayoutTagC = cute::conditional_t<cute::is_void_v<ElementC_>,GmemLayoutTagD,GmemLayoutTagC_>;
 
+  // C/D should meet TMA alignment requirement if not void
+  static_assert(detail::is_aligned<
+    ElementC, AlignmentC, ElementD, AlignmentD, cutlass::gemm::collective::detail::tma_alignment_bytes,
+    cute::is_void_v<ElementC_>, cute::is_void_v<ElementD_>>(), "C/D Should meet TMA alignment requirement");
+
   using GmemStrideTypeC = cutlass::detail::TagToStrideC_t<GmemLayoutTagC>;
   using GmemStrideTypeD = cutlass::detail::TagToStrideC_t<GmemLayoutTagD>;
   

--- a/include/cutlass/epilogue/collective/builders/sm90_common.inl
+++ b/include/cutlass/epilogue/collective/builders/sm90_common.inl
@@ -75,6 +75,13 @@ sm90_get_smem_load_op_for_source() {
   }
 }
 
+template <class ElementC, int AlignmentC, class ElementD, int AlignmentD, int RequiredAlignment, bool IsVoidC, bool IsVoidD>
+constexpr bool
+is_aligned() {
+  return (IsVoidC || (sizeof(ElementC) * AlignmentC) % RequiredAlignment == 0) &&
+         (IsVoidD || (sizeof(ElementD) * AlignmentD) % RequiredAlignment == 0);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 } // namespace cutlass::epilogue::collective::detail


### PR DESCRIPTION
Recently, we implemented a Grouped GEMM on the Hopper GPU using the CUTLASS 3.x API. We use bfloat16 as the datatype. In the GEMM problem size, **M** and **K** are divisible by 8, but **N** is not divisible by 8. Since the C/D matrix is Row-Major, we have to set the C/D Alignment to a value less than 8, usually 2. Based on previous experience, we use `KernelPtrArrayTmaWarpSpecializedPingpong` and `PtrArrayTmaWarpSpecializedPingpong` as scheduling strategies for Mainloop and Epilogue.
The above configuration can be compiled successfully, but when we launch Grouped GEMM, we find some precision issues, some results are not stored correctly, and no CUDA Error is reported.
We further found that if we use the [can_implement API](https://github.com/NVIDIA/cutlass/blob/ad7b2f5e84fcfa124cb02b91d5bd26d238c0459e/include/cutlass/epilogue/collective/sm90_epilogue_array_tma_warpspecialized.hpp#L398) to perform additional checks, CUTLASS will tell us that the current problem size does not meet the requirements of TMA. can_implement requires a copy of the problem size in Host Memory, which is **NOT** always available in some business scenarios. Here, the correct approach should be to use `PtrArrayNoSmemWarpSpecialized` as the scheduling strategy for Epilogue.
In fact, based on the Alignment of the C/D matrix, it can be inferred that the Load/Store of the C/D matrix cannot meet the Alignment requirements of the TMA, but CUTLASS currently does not check this during compilation. However, for the A/B matrix, CUTLASS does check this: https://github.com/NVIDIA/cutlass/blob/ad7b2f5e84fcfa124cb02b91d5bd26d238c0459e/include/cutlass/gemm/collective/builders/sm90_gmma_builder.inl#L230
Therefore, in this PR, we add this compile-time check to CUTLASS, so that we can find problems as early as possible and avoid spending extra effort on debugging.