### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/python/CuTeDSL/requirements.txt
+++ b/python/CuTeDSL/requirements.txt
@@ -1,3 +1,3 @@
 # Use `pip install -r requirements.txt` with the present file to install a
 # wheel consistent with the present state of the github repository
-nvidia-cutlass-dsl=4.0.0.dev1
+nvidia-cutlass-dsl==4.0.0.dev1


### PR DESCRIPTION
Needs == for pip to parse the file