### PR TITLE
bwl1289/fix/cmake-build-fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,8 +703,8 @@ target_include_directories(
 
 install(
   DIRECTORY
-  ${CUTLASS_INCLUDE_DIR}/
-  ${CMAKE_CURRENT_BINARY_DIR}/include/
+  ${CUTLASS_INCLUDE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}/include
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,9 +745,9 @@ if(NOT WIN32)
   # Add common library search paths so executables and libraries can load and run
   # without LD_LIBRARY_PATH being set.
   link_libraries(
-    "-Wl,-rpath,'$ORIGIN'"
-    "-Wl,-rpath,'$ORIGIN/../lib64'"
-    "-Wl,-rpath,'$ORIGIN/../lib'"
+    "-Wl,-rpath,'$$ORIGIN'"
+    "-Wl,-rpath,'$$ORIGIN/../lib64'"
+    "-Wl,-rpath,'$$ORIGIN/../lib'"
     "-Wl,-rpath,'${CUDA_TOOLKIT_ROOT_DIR}/lib64'"
     "-Wl,-rpath,'${CUDA_TOOLKIT_ROOT_DIR}/lib'"
     ${CMAKE_DL_LIBS}

--- a/tools/library/CMakeLists.txt
+++ b/tools/library/CMakeLists.txt
@@ -35,6 +35,9 @@ include(GNUInstallDirs)
 set(CUTLASS_BUILD_MONO_LIBRARY OFF CACHE BOOL 
   "Determines whether the cutlass library is generated as a single file or multiple files.")
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(BUILD_STATIC_LIBS "Build static libraries" OFF)
+
 ################################################################################
 
 add_library(cutlass_library_includes INTERFACE)
@@ -123,88 +126,98 @@ function(cutlass_add_cutlass_library)
   if (CUTLASS_BUILD_MONO_LIBRARY AND __SUFFIX)
 
     # If we're only building a single monolithic library then we
-    # simply link the generated object files to the default library. 
+    # simply link the generated object files to the default library.
+    if(BUILD_SHARED_LIBS)
+      target_link_libraries(${DEFAULT_NAME} PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>)
+    endif()
 
-    target_link_libraries(${DEFAULT_NAME} PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>)
-    target_link_libraries(${DEFAULT_NAME}_static PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>)
+    if(BUILD_STATIC_LIBS)
+      target_link_libraries(${DEFAULT_NAME}_static PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>)
+    endif()
 
   else()
 
-    cutlass_add_library(
-      ${__NAME} 
-      SHARED
-      EXPORT_NAME ${__EXPORT_NAME}
-      ""
+    # Shared library (honors CMake's standard BUILD_SHARED_LIBS)
+    if(BUILD_SHARED_LIBS)
+      cutlass_add_library(
+        ${__NAME}
+        SHARED
+        EXPORT_NAME ${__EXPORT_NAME}
+        ""
       )
 
-    target_compile_features(${__NAME} INTERFACE cxx_std_17)
-    
-    set_target_properties(
-      ${__NAME}
-      PROPERTIES
-      OUTPUT_NAME ${__OUTPUT_NAME}
-      WINDOWS_EXPORT_ALL_SYMBOLS 1
-      )
-    
-    target_link_libraries(
-      ${__NAME}
-      PUBLIC cutlass_library_includes
-      PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>
-      cuda_driver
-      )
-    
-    set_target_properties(${__NAME} PROPERTIES DEBUG_POSTFIX "${CUTLASS_LIBRARY_DEBUG_POSTFIX}")
-    
-    cutlass_add_library(
-      ${__NAME}_static
-      STATIC
-      EXPORT_NAME ${__EXPORT_NAME}_static
-      ""
+      target_compile_features(${__NAME} INTERFACE cxx_std_17)
+
+      set_target_properties(${__NAME}
+        PROPERTIES
+        OUTPUT_NAME ${__OUTPUT_NAME}
+        WINDOWS_EXPORT_ALL_SYMBOLS 1
+        DEBUG_POSTFIX "${CUTLASS_LIBRARY_DEBUG_POSTFIX}"
       )
 
-    target_compile_features(${__NAME}_static INTERFACE cxx_std_17)
-    
-    if (WIN32)
-      set(STATIC_OUTPUT_NAME ${__OUTPUT_NAME}.static)
-    else()
-      set(STATIC_OUTPUT_NAME ${__OUTPUT_NAME})
-    endif()
-    
-    set_target_properties(
-      ${__NAME}_static
-      PROPERTIES
-      OUTPUT_NAME ${STATIC_OUTPUT_NAME}
-      WINDOWS_EXPORT_ALL_SYMBOLS 1
+      target_link_libraries(${__NAME}
+        PUBLIC cutlass_library_includes
+        PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>
+        cuda_driver
       )
-    
-    target_link_libraries(
-      ${__NAME}_static
-      PUBLIC cutlass_library_includes
-      PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>
-      cuda_driver
+
+      install(
+        TARGETS ${__NAME}
+        EXPORT NvidiaCutlass
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       )
-    
-    set_target_properties(${__NAME}_static PROPERTIES DEBUG_POSTFIX "${CUTLASS_LIBRARY_DEBUG_POSTFIX}")
-    
-    install(
-      TARGETS ${__NAME} ${__NAME}_static
-      EXPORT NvidiaCutlass
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      )
-    
-    if (__SUFFIX)
-    
-      # The partial libraries generated will be registered as linked libraries
-      # to the main cutlass library so users automatically get the necessary link
-      # commands to pull in all kernels by default.
-    
-      target_link_libraries(${DEFAULT_NAME} PUBLIC ${__NAME})
-      target_link_libraries(${DEFAULT_NAME}_static PUBLIC ${__NAME}_static)
-    
+
+      if (__SUFFIX)
+        target_link_libraries(${DEFAULT_NAME} PUBLIC ${__NAME})
+      endif()
     endif()
 
+    # Static library
+    if(BUILD_STATIC_LIBS)
+      cutlass_add_library(
+        ${__NAME}_static
+        STATIC
+        EXPORT_NAME ${__EXPORT_NAME}_static
+        ""
+      )
+
+      target_compile_features(${__NAME}_static INTERFACE cxx_std_17)
+
+      if (WIN32)
+        set(STATIC_OUTPUT_NAME ${__OUTPUT_NAME}.static)
+      else()
+        set(STATIC_OUTPUT_NAME ${__OUTPUT_NAME})
+      endif()
+
+      set_target_properties(
+        ${__NAME}_static
+        PROPERTIES
+        OUTPUT_NAME ${STATIC_OUTPUT_NAME}
+        WINDOWS_EXPORT_ALL_SYMBOLS 1
+        DEBUG_POSTFIX "${CUTLASS_LIBRARY_DEBUG_POSTFIX}"
+      )
+
+      target_link_libraries(
+        ${__NAME}_static
+        PUBLIC cutlass_library_includes
+        PRIVATE $<BUILD_INTERFACE:${__NAME}_objs>
+        cuda_driver
+      )
+
+      install(
+        TARGETS ${__NAME}_static
+        EXPORT NvidiaCutlass
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      )
+
+      if (__SUFFIX)
+        target_link_libraries(${DEFAULT_NAME}_static PUBLIC ${__NAME}_static)
+      endif()
+    endif()
   endif()
 
 endfunction()
@@ -268,8 +281,13 @@ cutlass_add_cutlass_library(
   )
 
 # For backward compatibility with the old name
-add_library(cutlass_lib ALIAS cutlass_library)
-add_library(cutlass_lib_static ALIAS cutlass_library_static)
+if(BUILD_SHARED_LIBS)
+  add_library(cutlass_lib ALIAS cutlass_library)
+endif()
+
+if(BUILD_STATIC_LIBS)
+  add_library(cutlass_lib_static ALIAS cutlass_library_static)
+endif()
 
 ################################################################################
 


### PR DESCRIPTION
This PR fixes CMake rpath escaping, conditional static/shared builds, and include path with an additional `/`

1. Bad rpath escaping for `$ORIGIN` 
	•	The existing `link_libraries()` block was incorrectly quoting rpath entries, which causes broken paths like `/../lib64 when linking with lld`. I.e. `ld.lld: error: cannot open /../lib64: Is a directory`

2.	Unconditional shared + static library builds. This adds support for opting into building just shared or just static or both, instead of always both. Also combines multiple `set_target_properties`.

3.	Include path install bug
	•	The install rule for the headers was appending an extra slash resulting in installation in paths like `/usr/local/include//cutlass`