### PR TITLE
[docs] Specify `nvidia-cutlass-dsl` version

### DIFF
--- a/media/docs/pythonDSL/quick_start.rst
+++ b/media/docs/pythonDSL/quick_start.rst
@@ -12,7 +12,7 @@ To install the CUTLASS DSL, run:
 
 .. code-block:: bash
 
-   pip install nvidia-cutlass-dsl
+   pip install nvidia-cutlass-dsl==4.0.0.dev1
 
 The ``nvidia-cutlass-dsl`` wheel includes everything needed to generate GPU kernels. It requires 
 the same NVIDIA driver version as the 


### PR DESCRIPTION
By default `pip install nvidia-cutlass-dsl` downloads version `0.0.0a0` instead of `4.0.0.dev1`. However, to the best of my knowledge, version `0.0.0a0` doesn't contain any functional code.

Thus, I'd like to suggest updating the documentation to point to the version of `nvidia-cutlass-dsl` that can be used to reproduce examples in the documentation. 