### PR TITLE
cache procedural_name in GemmOperation

### DIFF
--- a/python/cutlass_library/gemm_operation.py
+++ b/python/cutlass_library/gemm_operation.py
@@ -355,6 +355,10 @@ class GemmOperation:
 
   # Generates the full kernel function name
   def procedural_name(self):
+    return self._procedural_name
+
+  @functools.cached_property
+  def _procedural_name(self):
     ''' The full procedural name indicates architecture, extended name, tile size, and layout. '''
     opcode_class_name = OpcodeClassNames[self.tile_description.math_instruction.opcode_class]
     if self.arch >= 90:


### PR DESCRIPTION
See https://github.com/NVIDIA/cutlass/issues/2316

~40% speed-up by caching procedural_name()

### Repro
https://gist.github.com/ColinPeppler/228f37cec854edc9581ed32f282a6d98

```
$ python cutlass_enum.py 9999
Instantiation level: 9999
arch: 90, cuda_version: 12.4
CUTLASS library manifested 7,141,570 operations in 606.73 seconds
                                                                                                                                                              
$ python cutlass_enum.py 9999
Instantiation level: 9999
arch: 90, cuda_version: 12.4
CUTLASS library manifested 7,141,570 operations in 367.58 seconds
```