### PR TITLE
More generic interface for Group GEMM problem size

### DIFF
--- a/examples/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling.cu
+++ b/examples/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling.cu
@@ -250,7 +250,7 @@ cutlass::DeviceAllocation<ElementAccumulator> block_beta;
 /// Testbed utility types
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-using RasterOrderOptions = typename cutlass::gemm::kernel::detail::PersistentTileSchedulerSm90GroupParams<Shape<int,int,int>>::RasterOrderOptions;
+using RasterOrderOptions = typename GemmKernel::TileScheduler::RasterOrderOptions;
 
 /// Result structure
 struct Result

--- a/examples/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling_with_sparse_groups.cu
+++ b/examples/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling/68_hopper_fp8_warp_specialized_grouped_gemm_with_blockwise_scaling_with_sparse_groups.cu
@@ -253,7 +253,7 @@ cutlass::DeviceAllocation<ElementAccumulator> block_beta;
 /// Testbed utility types
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-using RasterOrderOptions = typename cutlass::gemm::kernel::detail::PersistentTileSchedulerSm90GroupParams<Shape<int,int,int>>::RasterOrderOptions;
+using RasterOrderOptions = typename GemmKernel::TileScheduler::RasterOrderOptions;
 
 /// Result structure
 struct Result

--- a/examples/75_blackwell_grouped_gemm/75_blackwell_grouped_gemm.cu
+++ b/examples/75_blackwell_grouped_gemm/75_blackwell_grouped_gemm.cu
@@ -237,7 +237,7 @@ cutlass::DeviceAllocation<ElementAccumulator> block_beta;
 /// Testbed utility types
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-using RasterOrderOptions = typename cutlass::gemm::kernel::detail::PersistentTileSchedulerSm100GroupParams<typename ProblemShape::UnderlyingProblemShape>::RasterOrderOptions;
+using RasterOrderOptions = typename GemmKernel1SM::TileScheduler::RasterOrderOptions;
 // Command line options parsing
 struct Options {
 

--- a/examples/75_blackwell_grouped_gemm/75_blackwell_grouped_gemm_block_scaled.cu
+++ b/examples/75_blackwell_grouped_gemm/75_blackwell_grouped_gemm_block_scaled.cu
@@ -300,7 +300,7 @@ auto make_iterator(T* ptr) {
 /// Testbed utility types
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-using RasterOrderOptions = typename cutlass::gemm::kernel::detail::PersistentTileSchedulerSm100GroupParams<typename ProblemShape::UnderlyingProblemShape>::RasterOrderOptions;
+using RasterOrderOptions = typename GemmKernel2SM::TileScheduler::RasterOrderOptions;
 // Command line options parsing
 struct Options {
 

--- a/include/cutlass/gemm/group_array_problem_shape.hpp
+++ b/include/cutlass/gemm/group_array_problem_shape.hpp
@@ -74,7 +74,7 @@ struct GroupProblemShape {
 
   CUTLASS_HOST_DEVICE
   bool
-  is_host_problem_shape_available() {
+  is_host_problem_shape_available() const {
     return host_problem_shapes != nullptr;
   }
 };
@@ -113,7 +113,7 @@ public:
 
   CUTLASS_HOST_DEVICE
   bool
-  is_host_problem_shape_available() {
+  is_host_problem_shape_available() const {
     return true;
   }
 private:


### PR DESCRIPTION
The problem size array of group gemm is no longer exposed on sm90/sm100 tile schedulers, allowing custom problem sizes to be plugged in, as long as they respect a generic interface.

This is done in order to be able to better integrate CUTLASS into MoE GEMM problems.