### PR TITLE
Fix epilogue::thread::Convert cannot be used with DefaultEpilogue

### DIFF
--- a/include/cutlass/epilogue/thread/conversion_op.h
+++ b/include/cutlass/epilogue/thread/conversion_op.h
@@ -62,6 +62,7 @@ public:
   using ElementOutput = ElementOutput_;
   using ElementAccumulator = ElementAccumulator_;
   using ElementCompute = ElementAccumulator_;
+  using ElementD = ElementOutput;                     // for use with cute::collective::DefaultEpilogue
 
   static int const kCount = Count;
 
@@ -121,6 +122,21 @@ public:
     // Convert to destination numeric type
     NumericArrayConverter<ElementOutput, ElementAccumulator, kCount, Round> destination_converter;
 
+    return destination_converter(accumulator);
+  }
+
+  //
+  // Specializations for scalar (for use with cute::collective::DefaultEpilogue)
+  //
+  CUTLASS_HOST_DEVICE
+  ElementD operator()(ElementAccumulator const accumulator, ElementAccumulator const source) const {
+    NumericConverter<ElementD, ElementAccumulator, Round> destination_converter;
+    return destination_converter(source);
+  }
+
+  CUTLASS_HOST_DEVICE
+  ElementD operator()(ElementAccumulator const accumulator) const {
+    NumericConverter<ElementD, ElementAccumulator, Round> destination_converter;
     return destination_converter(accumulator);
   }
 };


### PR DESCRIPTION
Add the interface types and functions to template class `epilogue::thread::Convert` which is required by `DefaultEpilogue`.

Testing code:

```c++
  using CollectiveEpilogue = cutlass::epilogue::collective::DefaultEpilogue<
      ElementD,
      cutlass::detail::TagToStrideC_t<LayoutC>,
      cutlass::detail::TagToStrideC_t<LayoutD>,
      cutlass::epilogue::thread::Convert<ElementD, AlignmentD, ElementAccumulator>,
      cutlass::gemm::EpilogueDefault>;
```