### PR TITLE
Support identity op in epilogue custom EVT.

### DIFF
--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -103,6 +103,14 @@ namespace detail {
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
+struct identity_value_op {
+  CUTLASS_HOST_DEVICE
+  T operator()(T lhs) const {
+    return lhs;
+  }
+};
+
+template <typename T>
 struct absolute_value_op {
   CUTLASS_HOST_DEVICE
   T operator()(T lhs) const {


### PR DESCRIPTION
In many GEMM application scenarios, we only need C = A \* B instead of D= alpha  \* A  \* B + beta  \* C. Therefore, in CUTLASS, we usually set alpha=1.0 and beta=0.0. 
This method may have performance issues when the K dimension is small. This is because when the K dimension is small, Epilogue is executed frequently, and each time Epilogue is executed, many unnecessary operations are performed, such as FMUL, FFMA, etc. 
Therefore, we support identity op to avoid unnecessary calculations in Epilogue. We slightly modify [example 49](https://github.com/NVIDIA/cutlass/blob/main/examples/49_hopper_gemm_with_collective_builder/49_collective_builder.cu) to show the use of the identity op.
When performing GEMM calculations with a problem size of (8192, 8192, 128), we can observe that the CUDA kernel using the identity op has better performance:
![image](https://github.com/user-attachments/assets/00a4cfd6-ab11-4cdd-b96b-dc33b5fbb27e)
The profile results of ncu also show that the number of unnecessary FMUL instructions can be significantly reduced when using identity op:
![image](https://github.com/user-attachments/assets/45bfe7d7-7f9a-471c-b362-27b8585eb614)
