### PR TITLE
Fix limitations in cutlass EVT Python Tracer

### DIFF
--- a/python/cutlass/backend/evt/frontend/frontend_base.py
+++ b/python/cutlass/backend/evt/frontend/frontend_base.py
@@ -73,6 +73,7 @@ class EVTFrontendBase:
         self.dag_ir = DAGIR(self.cc, self.element_compute)
         self.compute_cnt = 0
         self.layout_cnt = 0
+        self.imm_cnt = 0
 
         self.pass_manager = EVTPassManager(
             self.dag_ir,
@@ -106,6 +107,13 @@ class EVTFrontendBase:
     def trace(self, *args, **kwargs):
         # Parse the input
         self.parse(*args, **kwargs)
+
+        # Verify the DAG IR to ensure that "D" is the output node with out_degree = 0
+        if (self.cc >= 90):
+            if (self.dag_ir.out_degree("D") != 0):
+                raise RuntimeError(
+                    f"On SM90 or higher, D is expected to be a output node with 0 users to "
+                    f"enable smem reuse between C and D, but got {self.dag_ir.out_degree('D')}")
 
         # Run the passes
         self.pass_manager()
@@ -187,7 +195,8 @@ class EVTFrontendBase:
         except:
             raise ValueError(f"{type(value).__name__} cannot be converted to float.")
 
-        name = f"imm_{value}".replace('.', '_')
+        name = f"imm_{value}_k{self.imm_cnt}".replace('.', '_')
+        self.imm_cnt += 1
         load_node = LoadNode(name)
         load_node.tensor = {"tensor": value, "is_constant": True}
         self.add_node(load_node)

--- a/python/cutlass/backend/evt/frontend/python_ast.py
+++ b/python/cutlass/backend/evt/frontend/python_ast.py
@@ -42,7 +42,7 @@ from cutlass_library import DataType
 
 import cutlass
 from cutlass.backend.evt.frontend.frontend_base import EVTFrontendBase
-from cutlass.backend.epilogue import relu
+from cutlass.backend.epilogue import identity, relu, tanh, sigmoid, silu, hardswish, gelu
 from cutlass.backend.library import FunctionalOp
 
 
@@ -72,10 +72,17 @@ class PythonASTFrontend(EVTFrontendBase, ast.NodeVisitor):
             ast.Div: FunctionalOp.Divides,
             "maximum": FunctionalOp.Maximum,
             "minimum": FunctionalOp.Minimum,
+            "identity": identity.binding_type,
             "relu": relu.binding_type,
+            "tanh": tanh.binding_type,
+            "sigmoid": sigmoid.binding_type,
+            "silu": silu.binding_type,
+            "hardswish": hardswish.binding_type,
+            "gelu": gelu.binding_type,
             "multiply_add": FunctionalOp.MultiplyAdd,
             "sum": (FunctionalOp.Plus, FunctionalOp.AtomicAdd),
-            "max": (FunctionalOp.Maximum, FunctionalOp.AtomicMaximum)
+            "max": (FunctionalOp.Maximum, FunctionalOp.AtomicMaximum),
+            "exp": FunctionalOp.Exp
         }
         return mapping[op]
 

--- a/python/cutlass/backend/library.py
+++ b/python/cutlass/backend/library.py
@@ -118,6 +118,7 @@ class FunctionalOp(enum.Enum):
     Multiplies = enum_auto()
     MultiplyAdd = enum_auto()
     Plus = enum_auto()
+    Exp = enum_auto()
 
 
 FunctionalOpTag = {
@@ -130,6 +131,7 @@ FunctionalOpTag = {
     FunctionalOp.Multiplies: "cutlass::multiplies",
     FunctionalOp.MultiplyAdd: "cutlass::multiply_add",
     FunctionalOp.Plus: "cutlass::plus",
+    FunctionalOp.Exp: "cutlass::fast_exp_op",
 }
 
 

--- a/python/cutlass/epilogue/__init__.py
+++ b/python/cutlass/epilogue/__init__.py
@@ -52,4 +52,5 @@ from cutlass.epilogue.evt_ops import (
     reshape,
     maximum,
     minimum,
+    exp
 )

--- a/python/cutlass/epilogue/evt_ops.py
+++ b/python/cutlass/epilogue/evt_ops.py
@@ -73,6 +73,12 @@ def minimum(x, y):
     elif is_torch_tensor(x):
         return torch.minimum(x, torch.tensor(y))
 
+def exp(x):
+    if is_numpy_tensor(x):
+        return np.exp(x)
+    elif is_torch_tensor(x):
+        return torch.exp(x)
+
 
 ##############################################################################
 # Layout manipulate nodes

--- a/test/python/cutlass/evt/evt_compute_sm80_90.py
+++ b/test/python/cutlass/evt/evt_compute_sm80_90.py
@@ -117,6 +117,82 @@ class TestEVTCompute(EVTTestCaseBase):
             input_keys = ["C", "alpha", "beta"]
             result_keys = ["D"]
             launcher.verify((m, n, k), input_keys, result_keys, l)
+            
+    def test_tanh(self):
+        """
+        Test Tanh op
+        """
+        def evt_tanh(accum):
+            D = tanh(accum)
+            return D
+
+        for m, n, k, l in self.get_problem_sizes(8):
+            example_inputs = {
+                "accum": self.fake_tensor(self.element, (l, m, n)),
+                "D": self.fake_tensor(self.element, (l, m, n))
+            }
+
+            launcher = EVTTestBed(self.element, evt_tanh, example_inputs)
+            input_keys = []
+            result_keys = ["D"]
+            launcher.verify((m, n, k), input_keys, result_keys, l)
+    
+    def test_sigmoid(self):
+        """
+        Test Sigmoid op
+        """
+        def evt_sigmoid(accum):
+            D = sigmoid(accum)
+            return D
+
+        for m, n, k, l in self.get_problem_sizes(8):
+            example_inputs = {
+                "accum": self.fake_tensor(self.element, (l, m, n)),
+                "D": self.fake_tensor(self.element, (l, m, n))
+            }
+
+            launcher = EVTTestBed(self.element, evt_sigmoid, example_inputs)
+            input_keys = []
+            result_keys = ["D"]
+            launcher.verify((m, n, k), input_keys, result_keys, l)
+    
+    def test_gelu(self):
+        """
+        Test GELU op
+        """
+        def evt_gelu(accum):
+            D = gelu(accum)
+            return D
+        
+        for m, n, k, l in self.get_problem_sizes(8):
+            example_inputs = {
+                "accum": self.fake_tensor(self.element, (l, m, n)),
+                "D": self.fake_tensor(self.element, (l, m, n))
+            }
+            
+            launcher = EVTTestBed(self.element, evt_gelu, example_inputs)
+            input_keys = []
+            result_keys = ["D"]
+            launcher.verify((m, n, k), input_keys, result_keys, l)
+
+    def test_exp(self):
+        """
+        Test Exp op
+        """
+        def evt_exp(accum):
+            D = exp(accum)
+            return D
+        
+        for m, n, k, l in self.get_problem_sizes(8):
+            example_inputs = {
+                "accum": self.fake_tensor(self.element, (l, m, n)),
+                "D": self.fake_tensor(self.element, (l, m, n))
+            }
+            
+            launcher = EVTTestBed(self.element, evt_exp, example_inputs)
+            input_keys = []
+            result_keys = ["D"]
+            launcher.verify((m, n, k), input_keys, result_keys, l)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/cutlass/evt/evt_store_sm80_90.py
+++ b/test/python/cutlass/evt/evt_store_sm80_90.py
@@ -48,6 +48,30 @@ cutlass.set_log_level(logging.WARNING)
 
 @unittest.skipIf(device_cc() not in [80, 86, 89, 90], "This unittest is only supported on CC [80, 86, 89, 90]")
 class TestEVTStore(EVTTestCaseBase):
+    @unittest.skipIf(device_cc() != 90, "This test is only for CC 90")
+    def test_invalid_store(self):
+        """
+        Test invalid store
+        """
+        def evt_invalid_store(accum):
+            D = accum
+            F = D + 1 # D has users, which is not allowed on SM90 or higher
+            return D, F
+        
+        for m, n, k, l in self.get_problem_sizes(8):
+            example_inputs = {
+                "accum": self.fake_tensor(self.element, (l, m, n)),
+                "D": self.fake_tensor(self.element, (l, m, n)),
+                "F": self.fake_tensor(self.element, (l, m, n))
+            }
+            with self.assertRaisesRegex(
+                    RuntimeError, 
+                    r"On SM90 or higher, D is expected to be a output node with 0 users " 
+                    r"to enable smem reuse between C and D, but got 1"
+                ):
+                launcher = EVTTestBed(self.element, evt_invalid_store, example_inputs)
+            
+            break  # Only need to test once
 
     def test_aux_store(self):
         """


### PR DESCRIPTION
This MR fixes the following issues on GitHub:
https://github.com/NVIDIA/cutlass/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%5BInductor-EVT%5D
[[BUG][Inductor-EVT] Python EVT tracer generates incorrect code when assigning accumulator to output D #2288](https://github.com/NVIDIA/cutlass/issues/2288)
[Reason]: This error is caused by the restriction on sm90 what D must be the output node without users.
[Solution]: Add verifier for sm90 to report the invalid input
[[BUG][Inductor-EVT] Compilation error with usage of same var twice in expression #2349](https://github.com/NVIDIA/cutlass/issues/2349)
[Reason]: The graph used in the tracer doesn't support multiple parallel edges between two nodes
[Solution]: When adding an edge to the graph, if the edge already exists, add an identity compute node to avoid having multiple parallel edges.
[[FEA][Inductor-EVT] tanh, sigmoid, exp, gelu are not supported in python evt tracer #2289](https://github.com/NVIDIA/cutlass/issues/2289)
[Solution]: registered these ops to the python ast frontend
[[FEA][torchinductor-EVT] tensor construction API that takes in shape + stride directly #2245](https://github.com/NVIDIA/cutlass/issues/2245)
[Solution]: added stride to ctor
[[BUG][Inductor-EVT] EVT python tracer: No LCA found when it appears that there is an LCA #2309](https://github.com/NVIDIA/cutlass/issues/2309)
[Reason]: originally, the graph_to_tree pass creating topological-visitor nodes by finding the least common ancestor of all the uses of a node. However, there was a notImplementedError if there isn't one.
[Solution]: replace the NotImplemented Error by packing all nodes into a single topological visitor node as a fallback.