### PR TITLE
ex77 backward varlen

### DIFF
--- a/examples/77_blackwell_fmha/77_blackwell_fmha_bwd.cu
+++ b/examples/77_blackwell_fmha/77_blackwell_fmha_bwd.cu
@@ -114,12 +114,16 @@ struct Options {
   int h_k = 1;
   int q = 1024;
   int k = 1024;
+  std::vector<int> varlen_q;
+  std::vector<int> varlen_k;
   int d = 128;
   int iterations = 3;
   bool verify = false;
   bool verbose = false;
 
   bool causal = false;
+  bool residual = false;
+  bool varlen = false;
   int sm_count = 0;
 
   std::string kernel_filter;
@@ -177,13 +181,75 @@ struct Options {
     cmd.get_cmd_line_argument("h", h, -1);
     if (h == -1) h = 2048 / d;
 
+    varlen = cmd.check_cmd_line_flag("varlen");
+
     cmd.get_cmd_line_argument("q", q, -1);
     cmd.get_cmd_line_argument("k", k, -1);
+    cmd.get_cmd_line_argument("b", b, -1);
+    std::string varlen_q_str;
+    cmd.get_cmd_line_argument("varlen-q", varlen_q_str);
+    std::string varlen_k_str;
+    cmd.get_cmd_line_argument("varlen-k", varlen_k_str);
+
+    if (varlen && ! varlen_q_str.empty()) {
+      varlen_q.clear();
+      while (! varlen_q_str.empty()) {
+        size_t pos = varlen_q_str.find(':');
+        varlen_q.push_back(std::stoi(varlen_q_str.substr(0, pos)));
+        if (pos == std::string::npos) {
+          break;
+        }
+        varlen_q_str = varlen_q_str.substr(pos + 1);
+      }
+      if (b == -1) {
+        b = static_cast<int>(varlen_q.size());
+      }
+      if (b != static_cast<int>(varlen_q.size())) {
+        std::cout << "Error: Invalid --varlen-q length\n";
+        std::exit(-1);
+      }
+      int new_q = 0;
+      for (auto elem : varlen_q) {
+        new_q += elem;
+      }
+      if (q != -1) {
+        std::cout << "Error: Can't provide --q and --varlen-q\n";
+        std::exit(-1);
+      }
+      q = new_q;
+    }
+
+    if (varlen && ! varlen_k_str.empty()) {
+      varlen_k.clear();
+      while (! varlen_k_str.empty()) {
+        size_t pos = varlen_k_str.find(':');
+        varlen_k.push_back(std::stoi(varlen_k_str.substr(0, pos)));
+        if (pos == std::string::npos) {
+          break;
+        }
+        varlen_k_str = varlen_k_str.substr(pos + 1);
+      }
+      if (b == -1) {
+        b = static_cast<int>(varlen_k.size());
+      }
+      if (b != static_cast<int>(varlen_k.size())) {
+        std::cout << " Error: Invalid --varlen-k length\n";
+        std::exit(-1);
+      }
+      int new_k = 0;
+      for (auto elem : varlen_k) {
+        new_k += elem;
+      }
+      if (k != -1) {
+        std::cout << "Error: Can't provide --k and --varlen-k\n";
+        std::exit(-1);
+      }
+      k = new_k;
+    }
+
     if (q == -1) q = k;
     if (k == -1) k = q;
     if (q == -1 && k == -1) q = k = defaults.q;
-
-    cmd.get_cmd_line_argument("b", b, -1);
     if (b == -1) b = 16384 / k;
     if (b == 0) b = 1;
 
@@ -195,8 +261,14 @@ struct Options {
     if (mask == "causal") {
       causal = true;
     }
+    else if (mask == "residual") {
+      residual = true;
+    }
     else {
       causal = defaults.causal;
+    }
+    if (varlen) {
+      residual = true;
     }
 
     skip_reference = cmd.check_cmd_line_flag("skip-reference");
@@ -226,11 +298,18 @@ struct Options {
       << "  --h=<int>                   Sets the H extent\n"
       << "  --q=<int>                   Sets the Q extent\n"
       << "  --k=<int>                   Sets the K extent\n"
-      << "  --d=<int>                   Sets the D extentn"
+      << "  --varlen-q=<int>:<int...>   Sets the variable Q extent per batch (colon separated)\n"
+      << "  --varlen-k=<int>:<int...>   Sets the variable K extent per batch (colon separated)\n"
+      << "  --d=<int>                   Sets the D extent\n"
       << "  --iterations=<int>          Benchmarking iterations\n"
       << "  --verify                    Verify results\n"
       << "  --verbose                   Print smem and execution time per kernel\n"
-      << "  --mask=<no|causal>          Enables masking\n"
+      << "  --mask=<no|residual|causal> Enables masking\n"
+      << "  --varlen                    Enables variable sequence length\n"
+      << "                              B*Q and B*K become the total sequence length\n"
+      << "                              and are split B-ways, alternatingly +10% and -10%\n"
+      << "                              with the last batch sized to make it fit\n"
+      << "                              implies at least residual masking for correctness\n"
       << "  --sm-count                  Sets SM count rather than querying it\n"
       << "  --kernel-filter=<filter>    Sets regexp to match kernel against\n"
       << "\n";
@@ -307,6 +386,7 @@ struct ExampleResult {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<
+  bool kIsVarlen,
   class TileShape,
   class DispatchPolicy,
   class ActiveMask,
@@ -322,9 +402,11 @@ struct BwdRunner {
   using ElementAccumulator = float;
 
   // Q K D (H B)
-  using ProblemShapeType = cute::tuple<int, int, int, cute::tuple<int, int>>;
-
-  using Operation = cutlass::fmha::device::Sm100FmhaBwd<Element, ElementAccumulator, TileShape, ActiveMask>;
+  using ProblemShape = std::conditional_t<
+      kIsVarlen,
+      cute::tuple<VariableLength, VariableLength, int, cute::tuple<int, int>>,
+      cute::tuple<int, int, int, cute::tuple<int, int>>
+  >;
   
   using TensorStride = Stride<int, _1, Stride<int, int>>; // Seq D (H B)
   using StrideQ = TensorStride;
@@ -363,6 +445,9 @@ struct BwdRunner {
   DeviceAllocation<Element> block_O;
   DeviceAllocation<ElementAccumulator> block_LSE;
 
+  DeviceAllocation<int> block_cumulative_seqlen_q;
+  DeviceAllocation<int> block_cumulative_seqlen_kv;
+
   DeviceAllocation<Element> block_dQ;
   DeviceAllocation<Element> block_dK;
   DeviceAllocation<Element> block_dV;
@@ -375,7 +460,7 @@ struct BwdRunner {
   //
   // Methods
   //
-  bool verify(const ProblemShapeType& problem_shape) {
+  bool verify(const ProblemShape& problem_shape) {
     auto [Q, K, D, HB] = problem_shape;
     auto [H, B] = HB;
 
@@ -459,22 +544,89 @@ struct BwdRunner {
     return passed_dQ && passed_dK && passed_dV;
   }
 
+  auto initialize_problem_shape(Options const& options) {
+    if constexpr (kIsVarlen) {
+      int num_batches = options.b;
+
+      // generate Q as --b times
+      //    gaussian (--Q, --Q / 2) sampled positive
+      //    track cumulative 
+      std::mt19937 rng(0x202305151552ull);
+      std::normal_distribution<double> dist_q(options.q, options.q / 2);
+      std::normal_distribution<double> dist_kv(options.k, options.k / 2);
+
+      auto generate_positive_int = [](auto& dist, auto& gen) {
+        // "0" is a valid value we test here
+        return std::max(0, static_cast<int>(dist(gen)));
+      };
+
+      std::vector<int> cumulative_seqlen_q = {0};
+      std::vector<int> cumulative_seqlen_kv = {0};
+
+      int total_seqlen_q = 0;
+      int total_seqlen_kv = 0;
+      int max_seqlen_q = 0;
+      int max_seqlen_kv = 0;
+
+      const bool kVarlenSame = false;
+      for (int i = 0; i < num_batches; i++) {
+        int seqlen_q = (! options.varlen_q.empty()) ? options.varlen_q.at(i) : 
+                kVarlenSame ? options.q :
+                generate_positive_int(dist_q, rng);
+        int seqlen_kv = (! options.varlen_k.empty()) ? options.varlen_k.at(i) :
+                kVarlenSame ? options.k :
+                generate_positive_int(dist_kv, rng);
+
+        total_seqlen_q += seqlen_q;
+        total_seqlen_kv += seqlen_kv;
+
+        max_seqlen_q = std::max(max_seqlen_q, seqlen_q);
+        max_seqlen_kv = std::max(max_seqlen_kv, seqlen_kv);
+
+        cumulative_seqlen_q.push_back(cumulative_seqlen_q.back() + seqlen_q);
+        cumulative_seqlen_kv.push_back(cumulative_seqlen_kv.back() + seqlen_kv);
+      }
+
+      block_cumulative_seqlen_q.reset(cumulative_seqlen_q.size());
+      block_cumulative_seqlen_q.copy_from_host(cumulative_seqlen_q.data(), cumulative_seqlen_q.size());
+      block_cumulative_seqlen_kv.reset(cumulative_seqlen_kv.size());
+      block_cumulative_seqlen_kv.copy_from_host(cumulative_seqlen_kv.data(), cumulative_seqlen_kv.size());
+
+      ProblemShape problem_shape{
+          {max_seqlen_q, block_cumulative_seqlen_q.get(), total_seqlen_q},
+          {max_seqlen_kv, block_cumulative_seqlen_kv.get(), total_seqlen_kv},
+          options.d, {options.h, options.b}
+      };
+      auto tensor_shape = make_shape(total_seqlen_q, total_seqlen_kv, options.d, make_shape(options.h, 1));
+
+      return cute::make_tuple(problem_shape, tensor_shape);
+    }
+    else {
+      ProblemShape problem_shape{options.q, options.k, options.d, {options.h, options.b}};
+      return cute::make_tuple(problem_shape, problem_shape);
+    }
+  }
+
   /// Initialize operands to be used in the GEMM and reference GEMM
-  void initialize(const ProblemShapeType& problem_shape, Options const& options) {
-    auto [Q, K, D, HB] = problem_shape;
+  ProblemShape initialize(Options const& options) {
+    auto [problem_shape, tensor_shape] = initialize_problem_shape(options);
+    auto [Q, K, D, HB] = tensor_shape;
     auto [H, B] = HB;
     D = cutlass::round_up(D, 8);  // Alignment
-    Q = cutlass::round_up(Q, 8);  // Alignment
 
-    auto shape_QO = select<0,2,3>(problem_shape);
-    auto shape_KV = select<1,2,3>(problem_shape);
-    auto shape_LSE = select<0,3>(problem_shape);
+    // for varlen, Q == total_Q, K == total_K, B = 1
+    // but in problem_shape, they've got to be max_Q/max_K, and B = B
 
-    stride_Q = make_stride(D, _1{}, make_stride(D*Q, D*Q*H));
-    stride_K = make_stride(D, _1{}, make_stride(D*K, D*K*H));
+    auto shape_QO = make_shape(Q, D, make_shape(H, B));
+    auto shape_KV = make_shape(K, D, make_shape(H, B));
+    auto shape_LSE = make_shape(Q, make_shape(H, B));
+
+    stride_Q = make_stride(D, _1{}, make_stride(D*Q, B == 1 ? 0 : D*Q*H));
+    stride_K = make_stride(D, _1{}, make_stride(D*K, B == 1 ? 0 : D*K*H));
+    stride_LSE = make_stride(_1{}, make_stride(Q, B == 1 ? 0 : Q*H));
+
     stride_V = stride_K;
     stride_O = stride_Q;
-    stride_LSE = make_stride(_1{}, make_stride(Q, Q*H));
 
     stride_dQ = stride_Q;
     stride_dK = stride_K;
@@ -505,6 +657,13 @@ struct BwdRunner {
     initialize_block(block_V, seed + 2021, options.init_style_v);
     initialize_block(block_dO, seed + 2020, options.init_style_do);
 
+    initialize_block(block_dQ, seed + 2030, InitStyle::kOne);
+    initialize_block(block_dK, seed + 2031, InitStyle::kOne);
+    initialize_block(block_dV, seed + 2032, InitStyle::kOne);
+    initialize_block(block_ref_dQ, seed + 2033);
+    initialize_block(block_ref_dK, seed + 2034);
+    initialize_block(block_ref_dV, seed + 2035);
+
     Tensor mQ = make_tensor(make_gmem_ptr(block_Q.get()),
       select<0,2,3>(problem_shape),
       stride_Q);
@@ -528,14 +687,18 @@ struct BwdRunner {
     if (! options.skip_reference) {
       fmha_reference(problem_shape, mQ, mK, mV, mO, mLSE, ActiveMask{});
     }
+
+    return problem_shape;
   }
 
   ExampleResult run(const Options& options, const cutlass::KernelHardwareInfo& hw_info) {
-    auto problem_shape = make_shape(options.q, options.k, options.d, make_shape(options.h, options.b));
-
-    initialize(problem_shape, options);
+    auto problem_shape = initialize(options);
 
     ElementAccumulator softmax_scale = 1.0f / sqrtf(options.d);
+
+    ExampleResult example_result;
+
+    using Operation = cutlass::fmha::device::Sm100FmhaBwd<ProblemShape, Element, ElementAccumulator, TileShape, ActiveMask>;
 
     typename Operation::Arguments arguments{
       problem_shape,
@@ -553,8 +716,6 @@ struct BwdRunner {
     };
 
     Operation op;
-
-    ExampleResult example_result;
 
     example_result.smem_size = Operation::Kernel::SharedStorageSize;
 
@@ -650,7 +811,7 @@ struct BwdRunner {
 
     runtime_ms /= static_cast<float>(options.iterations);
 
-    double flops = 10.0 * (std::is_same_v<ActiveMask, CausalMask> ? 0.5 : 1.0);
+    double flops = 10.0 * (std::is_same_v<ActiveMask, CausalForBackwardMask> ? 0.5 : 1.0);
     flops *= static_cast<double>(get<0>(problem_shape));
     flops *= static_cast<double>(get<1>(problem_shape));
     flops *= static_cast<double>(get<2>(problem_shape));
@@ -688,11 +849,18 @@ struct BwdRunner {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+int main_result = 0;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
 /// Helper to print a description of the example run and its result
 void print_result(const std::string& description, ExampleResult result, bool verbose) {
   std::ios fmt(nullptr);
   fmt.copyfmt(std::cout);
   std::cout << (result.passed ? (result.verified ? " [OK]  " : " [--] ") : "[FAIL] ");
+  if (! result.passed) {
+    main_result = -1;
+  }
   std::cout << std::setw(32) << std::left << description;
   std::cout.copyfmt(fmt);
   std::cout << " : " << result.tflops_tc_s << " TFLOPS/s" << std::endl;
@@ -706,14 +874,28 @@ void print_result(const std::string& description, ExampleResult result, bool ver
 
 struct KernelCoop {};
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template<class Fn>
+auto dispatch_bool(bool value, Fn fn) {
+  if (value) {
+    return fn(std::true_type{});
+  }
+  else {
+    return fn(std::false_type{});
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<class Mask>
 void run_bwd_64(Mask fusion, Options const & options, cutlass::KernelHardwareInfo const& hw_info) {
   auto run = [&](auto shape, auto kernel, const char* name, auto... kernel_options) {
-    BwdRunner<decltype(shape), decltype(kernel), Mask, decltype(kernel_options)...> runner;
-    auto result = runner.run(options, hw_info);
-    print_result(name, result, options.verbose);
+    dispatch_bool(options.varlen, [&](auto is_varlen) {
+      BwdRunner<decltype(is_varlen)::value, decltype(shape), decltype(kernel), Mask, decltype(kernel_options)...> runner;
+      auto result = runner.run(options, hw_info);
+      print_result(name, result, options.verbose);
+    });
   };
 
   using HeadDim = _64;
@@ -726,9 +908,11 @@ void run_bwd_64(Mask fusion, Options const & options, cutlass::KernelHardwareInf
 template<class Mask>
 void run_bwd_128(Mask fusion, Options const & options, cutlass::KernelHardwareInfo const& hw_info) {
   auto run = [&](auto shape, auto kernel, const char* name, auto... kernel_options) {
-    BwdRunner<decltype(shape), decltype(kernel), Mask, decltype(kernel_options)...> runner;
-    auto result = runner.run(options, hw_info);
-    print_result(name, result, options.verbose);
+    dispatch_bool(options.varlen, [&](auto is_varlen) {
+      BwdRunner<decltype(is_varlen)::value, decltype(shape), decltype(kernel), Mask, decltype(kernel_options)...> runner;
+      auto result = runner.run(options, hw_info);
+      print_result(name, result, options.verbose);
+    });
   };
 
   using HeadDim = _128;
@@ -803,7 +987,10 @@ int main_single(int argc, char const **args) {
 
   auto with_causal = [&](auto fn) {
     if (options.causal) {
-      fn(CausalMask{});
+      fn(CausalForBackwardMask{});
+    }
+    else if (options.residual) {
+      fn(ResidualMaskForBackward{});
     }
     else {
       fn(NoMask{});
@@ -823,15 +1010,13 @@ int main_single(int argc, char const **args) {
   });
 #endif
 
-  return 0;
+  return main_result;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char const **args) {
   std::vector<std::string> full_arguments(args, args + argc);
-
-  int result = 0;
 
   bool recursed = false;
   for (size_t i = 1; i < full_arguments.size(); i++) {
@@ -859,7 +1044,7 @@ int main(int argc, char const **args) {
     main_single(argc, args);
   }
 
-  return result;
+  return main_result;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/examples/77_blackwell_fmha/CMakeLists.txt
+++ b/examples/77_blackwell_fmha/CMakeLists.txt
@@ -141,25 +141,26 @@ if(NOT WIN32 AND (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang")) AND (CUTLASS_NVCC
         TEST_COMMAND_OPTIONS
         TEST_BASIC
         TEST_VARLEN
+        # NOTE: bwd doesn't support GQA yet, --h_k will just get ignored in these tests
+        TEST_VARLEN_00
+        TEST_VARLEN_01
+        TEST_VARLEN_02
+        TEST_VARLEN_03
+        TEST_VARLEN_04
+        TEST_VARLEN_05
+        TEST_VARLEN_06
+        TEST_VARLEN_07
+        TEST_VARLEN_08
+        TEST_VARLEN_09
+        TEST_VARLEN_10
+        TEST_VARLEN_11
+        TEST_VARLEN_12
+        TEST_VARLEN_13
+        TEST_VARLEN_14
         )
     target_include_directories(77_blackwell_fmha_bwd_${PREC} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_compile_definitions(77_blackwell_fmha_bwd_${PREC} PRIVATE ${PREC_MACRO})
     target_compile_options(77_blackwell_fmha_bwd_${PREC} PRIVATE -Xptxas -v)
-
-    cutlass_example_add_executable(
-        77_blackwell_fmha_bwd_sat_${PREC}
-        77_blackwell_fmha_bwd.cu
-        TEST_COMMAND_OPTIONS
-        TEST_BASIC
-        # TEST_GEN_VARLEN
-        TEST_GEN_HDIM64
-        # TEST_GEN_GQA
-        # TEST_GEN_REMAP
-        # TEST_GEN_CACHEONLY)
-        )
-    target_include_directories(77_blackwell_fmha_bwd_sat_${PREC} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    target_compile_definitions(77_blackwell_fmha_bwd_sat_${PREC} PRIVATE ${PREC_MACRO} SKIP_ATOMIC)
-    target_compile_options(77_blackwell_fmha_bwd_sat_${PREC} PRIVATE -Xptxas -v)
   endforeach()
 
   # Add a target that builds all examples

--- a/examples/77_blackwell_fmha/collective/fmha_fusion.hpp
+++ b/examples/77_blackwell_fmha/collective/fmha_fusion.hpp
@@ -132,6 +132,58 @@ struct ResidualMask : NoMask {
   }
 };
 
+struct ResidualMaskForBackward : NoMask {
+
+  using Base = NoMask;
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(
+      BlkCoord const& blk_coord,
+      TileShape const& tile_shape,
+      ProblemSize const& problem_size) {
+
+    if (get<1>(problem_size) % get<1>(tile_shape) != 0) {
+      return 1;
+    }
+    return 0;
+  }
+
+  template<class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE
+  int get_unmasked_trip_count(
+      BlkCoord const& blk_coord,
+      TileShape const& tile_shape,
+      ProblemSize const& problem_size) {
+
+    // if the sequence length does not divide the tile size evenly
+    if (get<1>(problem_size) % get<1>(tile_shape) != 0) {
+      return get_trip_count(blk_coord, tile_shape, problem_size) - 1;
+    }
+    return get_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template<class AccQK, class IndexQK, class ProblemSize>
+  CUTLASS_DEVICE
+  void apply_mask(
+      AccQK& acc_qk,
+      IndexQK const& index_qk,
+      ProblemSize const& problem_size) {
+
+    // This is useful is seqlen_k % kBlockN != 0 since it masks
+    // the remaining elements out from softmax.
+    // d % kHeadDim != 0 or seqlen_q % kBlockM do not suffer from similar
+    // issues as they are transparently taken care of by TMA and the
+    // epilogue, if it is instantiated with predication support.
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < size(acc_qk); i++) {
+      auto pos = index_qk(i);
+      if (! elem_less(pos, select<0,1>(problem_size))) {
+        acc_qk(i) = -INFINITY;
+      }
+    }
+  }
+};
+
 struct CausalMask : NoMask {
 
   using Base = NoMask;
@@ -197,25 +249,57 @@ struct CausalMask : NoMask {
 
 };
 
+struct CausalForBackwardMask : CausalMask, ResidualMaskForBackward {
+
+  using Base = CausalMask;
+
+  template<class AccQK, class IndexQK, class ProblemSize>
+  CUTLASS_DEVICE
+  void apply_mask(
+      AccQK& acc_qk,
+      IndexQK const& index_qk,
+      ProblemSize const& problem_size) {
+
+    // There are two ways to do causal if N_Q != N_K
+    // (1) is to assume that the Q is at the beginning of the matrix
+    //    - this is what we demonstrate here
+    // (2) is that it is at the end of the matrix
+    //    - this is usually what we want for inference settings
+    //      where we only compute the next row and use cache for the rest
+    //    - if you'd like this, you only need to add an offset like so:
+    //      get<0>(pos) + offset_q < get<1>(pos)
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < size(acc_qk); i++) {
+      auto pos = index_qk(i);
+      bool masked = (get<0>(pos) < get<1>(pos)) || !elem_less(pos, problem_size);
+      if (masked) {
+        acc_qk(i) = -INFINITY;
+      }
+    }
+  }
+
+};
+
 struct VariableLength {
   int max_length;
   int* cumulative_length = nullptr;
+  int total_length = -1;
 
   CUTE_HOST_DEVICE operator int() const {
     return max_length;
   }
 };
 
-template<class T> struct is_variable_length : std::false_type {};
-template<> struct is_variable_length<VariableLength> : std::true_type {};
-template<class T> constexpr bool is_variable_length_v = is_variable_length<T>::value;
+template<class T> struct is_variable_length_impl : std::false_type {};
+template<> struct is_variable_length_impl<VariableLength> : std::true_type {};
+template<class T> constexpr bool is_variable_length_v = is_variable_length_impl<remove_cvref_t<T>>::value;
 
 template<class Shape, class Idx>
 CUTE_HOST_DEVICE
 constexpr auto
 apply_variable_length(Shape const& shape, Idx const& idx) {
   return transform_leaf(shape, [&](auto const& s) {
-    if constexpr (is_variable_length_v<remove_cvref_t<decltype(s)>>) {
+    if constexpr (is_variable_length_v<decltype(s)>) {
       return s.cumulative_length[idx+1] - s.cumulative_length[idx];
     }
     else {
@@ -230,7 +314,7 @@ constexpr auto
 apply_variable_length(Shape const& shape, Coord const& coord, Idx const& idx) {
   auto new_shape = apply_variable_length(shape, idx);
   auto new_coord = transform_leaf(shape, coord, [&](auto const& s, auto const& c) {
-    if constexpr (is_variable_length_v<remove_cvref_t<decltype(s)>>) {
+    if constexpr (is_variable_length_v<decltype(s)>) {
       return cute::make_tuple(c, s.cumulative_length[idx]);
     }
     else {
@@ -238,6 +322,30 @@ apply_variable_length(Shape const& shape, Coord const& coord, Idx const& idx) {
     }
   });
   return cute::make_tuple(new_shape, new_coord);
+}
+
+template<class Shape, class Coord>
+CUTE_HOST_DEVICE
+constexpr auto
+apply_variable_length_offset(Shape const& shape, Coord const& coord) {
+  auto idx = back(back(coord));
+  auto result_shape = transform_leaf(shape, [&](auto const& s) {
+    if constexpr (is_variable_length_v<decltype(s)>) {
+      return s.cumulative_length[idx+1] - s.cumulative_length[idx];
+    }
+    else {
+      return s;
+    }
+  });
+  auto result_offset = transform_leaf(coord, shape, [&](auto const& c, auto const& s) {
+    if constexpr (is_variable_length_v<decltype(s)>) {
+      return s.cumulative_length[idx];
+    }
+    else {
+      return _0{};
+    }
+  });
+  return cute::make_tuple(result_shape, result_offset);
 }
 
 }  // namespace cutlass::fmha::collective

--- a/examples/77_blackwell_fmha/kernel/fmha_kernel_bwd_sum_OdO.hpp
+++ b/examples/77_blackwell_fmha/kernel/fmha_kernel_bwd_sum_OdO.hpp
@@ -39,11 +39,11 @@ namespace cutlass::fmha::kernel {
 
 using namespace cute;
 
-template<class Element, class ElementAcc>
+template<class ProblemShape, class Element, class ElementAcc>
 struct FmhaKernelBwdSumOdO {
 
   struct Arguments {
-    cute::tuple<int, int, int, cute::tuple<int, int>> problem_size;
+    ProblemShape problem_shape;
 
     const Element* ptr_O;
     cute::tuple<int, cute::_1, cute::tuple<int, int>> stride_O;
@@ -86,11 +86,11 @@ struct FmhaKernelBwdSumOdO {
   static const int kIterationsQ = kBlockQ / kNumThreadsQ;
 
   static bool can_implement(Arguments const& args) {
-    return get<2>(args.problem_size) % kElementsPerLoad == 0;
+    return get<2>(args.problem_shape) % kElementsPerLoad == 0;
   }
 
   static dim3 get_grid_shape(Params const& params) {
-    dim3 grid(ceil_div(size<0>(params.problem_size), kBlockQ), size<3,0>(params.problem_size), size<3,1>(params.problem_size));
+    dim3 grid(ceil_div(size<0>(params.problem_shape), kBlockQ), size<3,0>(params.problem_shape), size<3,1>(params.problem_shape));
     return grid;
   }
 
@@ -110,10 +110,20 @@ struct FmhaKernelBwdSumOdO {
     auto ptr_lse_bh = params.ptr_lse + blockIdx.y * get<1,0>(params.stride_lse) + blockIdx.z * get<1,1>(params.stride_lse);
     auto ptr_scaled_lse_bh = params.ptr_scaled_lse + blockIdx.y * get<1,0>(params.stride_scaled_lse) + blockIdx.z * get<1,1>(params.stride_scaled_lse);
 
+    auto problem_q = get<0>(params.problem_shape);
+    int seqlen_q = problem_q;
+    if constexpr (is_variable_length_v<decltype(problem_q)>) {
+      int offset = problem_q.cumulative_length[blockIdx.z];
+      ptr_O_bh += offset * get<0>(params.stride_O);
+      ptr_dO_bh += offset * get<0>(params.stride_dO);
+      ptr_lse_bh += offset * get<0>(params.stride_lse);
+      seqlen_q = problem_q.cumulative_length[blockIdx.z + 1] - offset;
+    }
+
     CUTLASS_PRAGMA_UNROLL
     for (int idx_q_t = threadIdx.y; idx_q_t < kBlockQ; idx_q_t += kNumThreadsQ) {
       int idx_q = idx_q_t + kBlockQ * blockIdx.x;
-      if (idx_q >= get<0>(params.problem_size)) continue;
+      if (idx_q >= seqlen_q) continue;
       ElementAcc acc = 0;
       auto ptr_O_bhq = ptr_O_bh + idx_q * get<0>(params.stride_O);
       auto ptr_dO_bhq = ptr_dO_bh + idx_q * get<0>(params.stride_dO);
@@ -121,7 +131,7 @@ struct FmhaKernelBwdSumOdO {
       auto ptr_lse_bhq = ptr_lse_bh + idx_q * get<0>(params.stride_lse);
       auto ptr_scaled_lse_bhq = ptr_scaled_lse_bh + idx_q * get<0>(params.stride_scaled_lse);
 
-      for (int idx_d = threadIdx.x * kElementsPerLoad; idx_d < get<2>(params.problem_size); idx_d += kElementsPerLoad * kNumThreadsD) {
+      for (int idx_d = threadIdx.x * kElementsPerLoad; idx_d < get<2>(params.problem_shape); idx_d += kElementsPerLoad * kNumThreadsD) {
         Element value_O[kElementsPerLoad];
         Element value_dO[kElementsPerLoad];
         

--- a/examples/77_blackwell_fmha/reference/fmha_bwd_reference.hpp
+++ b/examples/77_blackwell_fmha/reference/fmha_bwd_reference.hpp
@@ -44,29 +44,43 @@ template<
     class Fusion
 >
 void __global__ fmha_bwd_reference_dQ_kernel(
-    ProblemShape problem_shape,
-    TensorQ mQ, TensorK mK, TensorV mV,
-    TensorO mO, TensorLSE mLSE, TensorDO mDO,
-    TensorDQ mDQ, /* TensorDK mDK, TensorDV mDV, */
+    ProblemShape problem_shape_in,
+    TensorQ mQ_in, TensorK mK_in, TensorV mV_in,
+    TensorO mO_in, TensorLSE mLSE_in, TensorDO mDO_in,
+    TensorDQ mDQ_in, /* TensorDK mDK, TensorDV mDV, */
     Fusion fusion) {
 
   using namespace cute;
+  using namespace cutlass::fmha::collective;
 
   using Element = typename TensorO::value_type;
   using ElementAccumulator = typename TensorLSE::value_type;
   
   extern __shared__ char mS_mem[];
-  Element* mS = reinterpret_cast<Element*>(mS_mem);
+  ElementAccumulator* mS = reinterpret_cast<ElementAccumulator*>(mS_mem);
 
-  Element softmax_scale = static_cast<Element>(1.0 / sqrt(1.0 * size<1>(mO)));
+  ElementAccumulator softmax_scale = 1.0 / sqrt(ElementAccumulator(size<2>(problem_shape_in)));
 
-  for (int idx_L = blockIdx.y; idx_L < size<2>(mDQ); idx_L += gridDim.y) {
-    for (int idx_Q = blockIdx.x; idx_Q < size<0>(mDQ); idx_Q += gridDim.x) {
-      for (int idx_K = threadIdx.x; idx_K < size<0>(mK); idx_K += blockDim.x) {
+  for (int idx_L = blockIdx.y; idx_L < size<3>(problem_shape_in); idx_L += gridDim.y) {
+    auto [problem_shape, offset] = apply_variable_length_offset(
+        problem_shape_in,
+        make_coord(_0{}, _0{}, _0{}, idx2crd(idx_L, get<3>(problem_shape_in)))
+    );
+    // problem_shape = problem_shape_in;
+    // offset = repeat_like(problem_shape_in, _0{});
+    auto mQ = domain_offset(select<0,2,3>(offset), mQ_in);
+    auto mK = domain_offset(select<1,2,3>(offset), mK_in);
+    auto mV = domain_offset(select<1,2,3>(offset), mV_in);
+    auto mO = domain_offset(select<0,2,3>(offset), mO_in);
+    auto mLSE = domain_offset(select<0,3>(offset), mLSE_in);
+    auto mDO = domain_offset(select<0,2,3>(offset), mDO_in);
+    auto mDQ = domain_offset(select<0,2,3>(offset), mDQ_in);
+    for (int idx_Q = blockIdx.x; idx_Q < size<0>(problem_shape); idx_Q += gridDim.x) {
+      for (int idx_K = threadIdx.x; idx_K < size<1>(problem_shape); idx_K += blockDim.x) {
         ElementAccumulator acc_qk = 0;
         ElementAccumulator acc_dov = 0;
         ElementAccumulator acc_doo = 0;
-        for (int idx_D0 = 0; idx_D0 < size<1>(mK); idx_D0++) {
+        for (int idx_D0 = 0; idx_D0 < size<2>(problem_shape); idx_D0++) {
           acc_qk += mQ(idx_Q, idx_D0, idx_L) * mK(idx_K, idx_D0, idx_L);
           acc_dov += mDO(idx_Q, idx_D0, idx_L) * mV(idx_K, idx_D0, idx_L);
           acc_doo += mDO(idx_Q, idx_D0, idx_L) * mO(idx_Q, idx_D0, idx_L);
@@ -78,15 +92,15 @@ void __global__ fmha_bwd_reference_dQ_kernel(
         fusion.apply_mask(frag, make_tensor(id.data() + make_arithmetic_tuple(idx_Q, idx_K), id.layout()), problem_shape);
         acc_qk = frag(0);
 
-        mS[idx_K] = static_cast<Element>(exp(softmax_scale * acc_qk - mLSE(idx_Q, idx_L)) * softmax_scale * (acc_dov - acc_doo));
+        mS[idx_K] = static_cast<ElementAccumulator>(exp(softmax_scale * acc_qk - mLSE(idx_Q, idx_L)) * softmax_scale * (acc_dov - acc_doo));
       }  // for idx_K
 
       __syncthreads();
 
-      for (int idx_D = threadIdx.x; idx_D < size<1>(mDQ); idx_D += blockDim.x) {
+      for (int idx_D = threadIdx.x; idx_D < size<2>(problem_shape); idx_D += blockDim.x) {
         ElementAccumulator acc = 0;
-        for (int idx_K = 0; idx_K < size<0>(mK); idx_K++) {
-          acc += mS[idx_K] * mK(idx_K, idx_D, idx_L);
+        for (int idx_K = 0; idx_K < size<1>(problem_shape); idx_K++) {
+          acc += mS[idx_K] * ElementAccumulator(mK(idx_K, idx_D, idx_L));
         }
         mDQ(idx_Q, idx_D, idx_L) = static_cast<typename TensorDQ::value_type>(acc);
       }  // for idx_D
@@ -104,29 +118,43 @@ template<
     class Fusion
 >
 void __global__ fmha_bwd_reference_dK_kernel(
-    ProblemShape problem_shape,
-    TensorQ mQ, TensorK mK, TensorV mV,
-    TensorO mO, TensorLSE mLSE, TensorDO mDO,
-    /* TensorDQ mDQ, */ TensorDK mDK, /* TensorDV mDV, */
+    ProblemShape problem_shape_in,
+    TensorQ mQ_in, TensorK mK_in, TensorV mV_in,
+    TensorO mO_in, TensorLSE mLSE_in, TensorDO mDO_in,
+    /* TensorDQ mDQ_in, */ TensorDK mDK_in, /* TensorDV mDV_in, */
     Fusion fusion) {
 
   using namespace cute;
+  using namespace cutlass::fmha::collective;
 
   using Element = typename TensorO::value_type;
   using ElementAccumulator = typename TensorLSE::value_type;
   
   extern __shared__ char mS_mem[];
-  Element* mS = reinterpret_cast<Element*>(mS_mem);
+  ElementAccumulator* mS = reinterpret_cast<ElementAccumulator*>(mS_mem);
 
-  Element softmax_scale = static_cast<Element>(1.0 / sqrt(1.0 * size<1>(mO)));
+  ElementAccumulator softmax_scale = 1.0 / sqrt(ElementAccumulator(size<2>(problem_shape_in)));
 
-  for (int idx_L = blockIdx.y; idx_L < size<2>(mDK); idx_L += gridDim.y) {
-    for (int idx_K = blockIdx.x; idx_K < size<0>(mDK); idx_K += gridDim.x) {
-      for (int idx_Q = threadIdx.x; idx_Q < size<0>(mDO); idx_Q += blockDim.x) {
+  for (int idx_L = blockIdx.y; idx_L < size<3>(problem_shape_in); idx_L += gridDim.y) {
+    auto [problem_shape, offset] = apply_variable_length_offset(
+        problem_shape_in,
+        make_coord(_0{}, _0{}, _0{}, idx2crd(idx_L, get<3>(problem_shape_in)))
+    );
+    // problem_shape = problem_shape_in;
+    // offset = repeat_like(problem_shape_in, _0{});
+    auto mQ = domain_offset(select<0,2,3>(offset), mQ_in);
+    auto mK = domain_offset(select<1,2,3>(offset), mK_in);
+    auto mV = domain_offset(select<1,2,3>(offset), mV_in);
+    auto mO = domain_offset(select<0,2,3>(offset), mO_in);
+    auto mLSE = domain_offset(select<0,3>(offset), mLSE_in);
+    auto mDO = domain_offset(select<0,2,3>(offset), mDO_in);
+    auto mDK = domain_offset(select<1,2,3>(offset), mDK_in);
+    for (int idx_K = blockIdx.x; idx_K < size<1>(problem_shape); idx_K += gridDim.x) {
+      for (int idx_Q = threadIdx.x; idx_Q < size<0>(problem_shape); idx_Q += blockDim.x) {
         ElementAccumulator acc_qk = 0;
         ElementAccumulator acc_dov = 0;
         ElementAccumulator acc_doo = 0;
-        for (int idx_D0 = 0; idx_D0 < size<1>(mK); idx_D0++) {
+        for (int idx_D0 = 0; idx_D0 < size<2>(problem_shape); idx_D0++) {
           acc_qk += mQ(idx_Q, idx_D0, idx_L) * mK(idx_K, idx_D0, idx_L);
           acc_dov += mDO(idx_Q, idx_D0, idx_L) * mV(idx_K, idx_D0, idx_L);
           acc_doo += mDO(idx_Q, idx_D0, idx_L) * mO(idx_Q, idx_D0, idx_L);
@@ -138,15 +166,15 @@ void __global__ fmha_bwd_reference_dK_kernel(
         fusion.apply_mask(frag, make_tensor(id.data() + make_arithmetic_tuple(idx_Q, idx_K), id.layout()), problem_shape);
         acc_qk = frag(0);
 
-        mS[idx_Q] = static_cast<Element>(exp(softmax_scale * acc_qk - mLSE(idx_Q, idx_L)) * softmax_scale * (acc_dov - acc_doo));
+        mS[idx_Q] = static_cast<ElementAccumulator>(exp(softmax_scale * acc_qk - mLSE(idx_Q, idx_L)) * softmax_scale * (acc_dov - acc_doo));
       }  // for idx_Q
 
       __syncthreads();
 
-      for (int idx_D = threadIdx.x; idx_D < size<1>(mDK); idx_D += blockDim.x) {
+      for (int idx_D = threadIdx.x; idx_D < size<2>(problem_shape); idx_D += blockDim.x) {
         ElementAccumulator acc = 0;
-        for (int idx_Q = 0; idx_Q < size<0>(mDO); idx_Q++) {
-          acc += mS[idx_Q] * mQ(idx_Q, idx_D, idx_L);
+        for (int idx_Q = 0; idx_Q < size<0>(problem_shape); idx_Q++) {
+          acc += mS[idx_Q] * ElementAccumulator(mQ(idx_Q, idx_D, idx_L));
         }
         mDK(idx_K, idx_D, idx_L) = static_cast<typename TensorDK::value_type>(acc);
       }  // for idx_D
@@ -164,28 +192,42 @@ template<
     class Fusion
 >
 void __global__ fmha_bwd_reference_dV_kernel(
-    ProblemShape problem_shape,
-    TensorQ mQ, TensorK mK, TensorV mV,
-    TensorO mO, TensorLSE mLSE, TensorDO mDO,
-    /* TensorDQ mDQ, TensorDK mDK, */ TensorDV mDV,
+    ProblemShape problem_shape_in,
+    TensorQ mQ_in, TensorK mK_in, TensorV mV_in,
+    TensorO mO_in, TensorLSE mLSE_in, TensorDO mDO_in,
+    /* TensorDQ mDQ_in, TensorDK mDK_in, */ TensorDV mDV_in,
     Fusion fusion) {
 
   using namespace cute;
+  using namespace cutlass::fmha::collective;
 
   using Element = typename TensorO::value_type;
   using ElementAcc = typename TensorLSE::value_type;
   
   extern __shared__ char mS_mem[];
-  Element* mS = reinterpret_cast<Element*>(mS_mem);
+  ElementAcc* mS = reinterpret_cast<ElementAcc*>(mS_mem);
 
-  ElementAcc softmax_scale = static_cast<ElementAcc>(1.0 / sqrt(1.0 * size<1>(mO)));
+  ElementAcc softmax_scale = 1.0 / sqrt(ElementAcc(size<2>(problem_shape_in)));
 
-  for (int idx_L = blockIdx.y; idx_L < size<2>(mDV); idx_L += gridDim.y) {
-    for (int idx_K = blockIdx.x; idx_K < size<0>(mDV); idx_K += gridDim.x) {
-      for (int idx_Q = threadIdx.x; idx_Q < size<0>(mDO); idx_Q += blockDim.x) {
+  for (int idx_L = blockIdx.y; idx_L < size<3>(problem_shape_in); idx_L += gridDim.y) {
+    auto [problem_shape, offset] = apply_variable_length_offset(
+        problem_shape_in,
+        make_coord(_0{}, _0{}, _0{}, idx2crd(idx_L, get<3>(problem_shape_in)))
+    );
+    // problem_shape = problem_shape_in;
+    // offset = repeat_like(problem_shape_in, _0{});
+    auto mQ = domain_offset(select<0,2,3>(offset), mQ_in);
+    auto mK = domain_offset(select<1,2,3>(offset), mK_in);
+    auto mV = domain_offset(select<1,2,3>(offset), mV_in);
+    auto mO = domain_offset(select<0,2,3>(offset), mO_in);
+    auto mLSE = domain_offset(select<0,3>(offset), mLSE_in);
+    auto mDO = domain_offset(select<0,2,3>(offset), mDO_in);
+    auto mDV = domain_offset(select<1,2,3>(offset), mDV_in);
+    for (int idx_K = blockIdx.x; idx_K < size<1>(problem_shape); idx_K += gridDim.x) {
+      for (int idx_Q = threadIdx.x; idx_Q < size<0>(problem_shape); idx_Q += blockDim.x) {
         ElementAcc acc_qk = 0;
 
-        for (int idx_D0 = 0; idx_D0 < size<1>(mK); idx_D0++) {
+        for (int idx_D0 = 0; idx_D0 < size<2>(problem_shape); idx_D0++) {
           ElementAcc rQ = mQ(idx_Q, idx_D0, idx_L);
           ElementAcc rK = mK(idx_K, idx_D0, idx_L);
           acc_qk += rQ * rK;
@@ -197,15 +239,15 @@ void __global__ fmha_bwd_reference_dV_kernel(
         fusion.apply_mask(frag, make_tensor(id.data() + make_arithmetic_tuple(idx_Q, idx_K), id.layout()), problem_shape);
         acc_qk = frag(0);
 
-        mS[idx_Q] = static_cast<Element>(exp(softmax_scale * acc_qk - mLSE(idx_Q, idx_L)));
+        mS[idx_Q] = expf(softmax_scale * acc_qk - mLSE(idx_Q, idx_L));
       }  // for idx_Q
 
       __syncthreads();
 
-      for (int idx_D = threadIdx.x; idx_D < size<1>(mDV); idx_D += blockDim.x) {
+      for (int idx_D = threadIdx.x; idx_D < size<2>(problem_shape); idx_D += blockDim.x) {
         ElementAcc acc = 0;
-        for (int idx_Q = 0; idx_Q < size<0>(mDO); idx_Q++) {
-          ElementAcc rS = mS[idx_Q];
+        for (int idx_Q = 0; idx_Q < size<0>(problem_shape); idx_Q++) {
+          ElementAcc rS = static_cast<Element>(mS[idx_Q]);
           ElementAcc rDO = mDO(idx_Q, idx_D, idx_L);
           acc += rS * rDO;
         }
@@ -235,7 +277,7 @@ void fmha_bwd_reference_dQ(
 
   dim3 grid(size<0>(mDQ), size<2>(mDQ), 1);
   dim3 block(256);
-  int shared_mem = size<0>(mK) * sizeof(typename TensorO::value_type);
+  int shared_mem = size<0>(mK) * sizeof(typename TensorLSE::value_type);
   fmha_bwd_reference_dQ_kernel<<<grid, block, shared_mem>>>(problem_shape, mQ, mK, mV, mO, mLSE, mDO, mDQ, fusion);
 }
 
@@ -259,7 +301,7 @@ void fmha_bwd_reference_dK(
 
   dim3 grid(size<0>(mDK), size<2>(mDK), 1);
   dim3 block(256);
-  int shared_mem = size<0>(mDO) * sizeof(typename TensorO::value_type);
+  int shared_mem = size<0>(mDO) * sizeof(typename TensorLSE::value_type);
   fmha_bwd_reference_dK_kernel<<<grid, block, shared_mem>>>(problem_shape, mQ, mK, mV, mO, mLSE, mDO, mDK, fusion);
 }
 
@@ -283,7 +325,7 @@ void fmha_bwd_reference_dV(
 
   dim3 grid(size<0>(mDV), size<2>(mDV), 1);
   dim3 block(256);
-  int shared_mem = size<0>(mDO) * sizeof(typename TensorO::value_type);
+  int shared_mem = size<0>(mDO) * sizeof(typename TensorLSE::value_type);
   fmha_bwd_reference_dV_kernel<<<grid, block, shared_mem>>>(problem_shape, mQ, mK, mV, mO, mLSE, mDO, mDV, fusion);
 }
 


### PR DESCRIPTION
Re-applies the bwd varlen changes from https://github.com/NVIDIA/cutlass/pull/2366 , which were reverted due to test breakages. Adds additional test coverage and various fixes.

#### Known Limitations
* GQA is not yet supported. `--h_k` will be ignored in test commands