### PR TITLE
Add coord member function for ArithmeticTupleIterator

### DIFF
--- a/include/cute/atom/copy_traits_sm90_tma.hpp
+++ b/include/cute/atom/copy_traits_sm90_tma.hpp
@@ -70,7 +70,7 @@ struct TMA_LOAD_Unpack
   {
     static_assert(is_smem<TD>::value, "SM90_TMA_LOAD requires the destination be shared memory.");
 
-    auto src_coord = src.data().coord_;
+    auto src_coord = src.data().coord();
     void* dst_ptr = cute::raw_pointer_cast(dst.data());
 #if 0
     auto [c0,c1,c2,c3,c4] = append<5>(src_coord, 0);
@@ -211,7 +211,7 @@ struct Copy_Traits<SM90_TMA_LOAD::PREFETCH, NumBitsPerTMA, Args...>
               Tensor<TS,SLayout> const& src,
               Tensor<TD,DLayout>      & dst)
   {
-    auto src_coord = src.data().coord_;
+    auto src_coord = src.data().coord();
     return detail::explode_tuple(detail::CallCOPY<SM90_TMA_LOAD::PREFETCH>{},
                                  traits.opargs_, tuple_seq<decltype(traits.opargs_)>{},
                                  src_coord, tuple_seq<decltype(src_coord)>{});
@@ -372,7 +372,7 @@ struct Copy_Traits<SM90_TMA_STORE, NumBitsPerTMA, AuxParams_>
 
     void const* const desc_ptr = &(traits.tma_desc_);
     void const* const src_ptr  = cute::raw_pointer_cast(src.data());
-    auto dst_coord = dst.data().coord_;
+    auto dst_coord = dst.data().coord();
 #if 0
     auto [c0,c1,c2,c3,c4] = append<5>(dst_coord, 0);
     printf("THR (%d,%d,%d) BLK (%d,%d,%d) TMACRD (%d,%d,%d,%d,%d) SMEMADDR (%p)\n",
@@ -413,7 +413,7 @@ struct Copy_Traits<SM90_TMA_STORE_PTR, NumBitsPerTMA>
 
     void const* const desc_ptr = traits.tma_desc_;
     void const* const src_ptr  = cute::raw_pointer_cast(src.data());
-    auto dst_coord = dst.data().coord_;
+    auto dst_coord = dst.data().coord();
 #if 0
     auto [c0,c1,c2,c3,c4] = append<5>(dst_coord, 0);
     printf("THR (%d,%d,%d) BLK (%d,%d,%d) TMACRD (%d,%d,%d,%d,%d) SMEMADDR (%p)\n",
@@ -497,8 +497,8 @@ struct Copy_Traits<SM90_TMA_REDUCE_ADD, NumBitsPerTMA, AuxParams_>
   {
     static_assert(is_smem<TS>::value, "Expected smem src for SM90_TMA_REDUCE_ADD");
     //static_assert(is_gmem<TD>::value, "Expected gmem dst for SM90_TMA_REDUCE_ADD");  // TMA spoofed src tensor
-
-    traits.copy_unpack_(cute::raw_pointer_cast(src.data()), dst.data().coord_, tuple_seq<decltype(dst.data().coord_)>{});
+    auto dst_coord = dst.data().coord();
+    traits.copy_unpack_(cute::raw_pointer_cast(src.data()), dst_coord, tuple_seq<decltype(dst_coord)>{});
   }
 };
 

--- a/include/cute/numeric/arithmetic_tuple.hpp
+++ b/include/cute/numeric/arithmetic_tuple.hpp
@@ -194,6 +194,9 @@ struct ArithmeticTupleIterator
   CUTE_HOST_DEVICE constexpr
   ArithTuple operator*() const { return coord_; }
 
+  CUTE_HOST_DEVICE constexpr
+  ArithTuple coord() const { return coord_; }
+
   template <class Coord>
   CUTE_HOST_DEVICE constexpr
   auto operator[](Coord const& c) const { return *(*this + c); }
@@ -463,7 +466,7 @@ operator+(ScaledBasis<T,Ns...> const& t, C<u>) {
 template <class ArithTuple>
 CUTE_HOST_DEVICE void print(ArithmeticTupleIterator<ArithTuple> const& iter)
 {
-  printf("ArithTuple"); print(iter.coord_);
+  printf("ArithTuple"); print(iter.coord());
 }
 
 template <class T, int... Ns>
@@ -476,7 +479,7 @@ CUTE_HOST_DEVICE void print(ScaledBasis<T,Ns...> const& e)
 template <class ArithTuple>
 CUTE_HOST std::ostream& operator<<(std::ostream& os, ArithmeticTupleIterator<ArithTuple> const& iter)
 {
-  return os << "ArithTuple" << iter.coord_;
+  return os << "ArithTuple" << iter.coord();
 }
 
 template <class T, int... Ns>


### PR DESCRIPTION
Using member function instead of private member to allow users to customize ArithmeticTupleIterator behavior in extension.