### PR TITLE
[DOC] Remove unrendering latex

### DIFF
--- a/media/docs/cpp/cute/02_layout_algebra.md
+++ b/media/docs/cpp/cute/02_layout_algebra.md
@@ -332,7 +332,7 @@ Informally, `logical_divide(A, B)` splits a layout `A` into two modes -- in the 
 
 Formally, this can be written as
 
-$A \oslash B := A \circ (B,B^*)$
+```A ⊘ B := A ∘ (B, B*)```
 
 and implemented as
 ```cpp
@@ -431,7 +431,7 @@ Informally, `logical_product(A, B)` results in a two mode layout where the first
 
 Formally, this can be written as
 
-$A \otimes B := (A, A^* \circ B)$
+```A ⊗ B := (A, A* ∘ B)```
 
 and implemented in CuTe as
 ```cpp


### PR DESCRIPTION
There are some latex equations that are not rendering, and out of style with the rest of the document - changed to utf in line with the rest of the document.