### PR TITLE
Make swizzle in pycute work

### DIFF
--- a/python/pycute/swizzle.py
+++ b/python/pycute/swizzle.py
@@ -75,7 +75,7 @@ class Swizzle:
 
   # Size of the domain
   def size(self):
-    return 1 << (bits + base + abs(shift))
+    return 1 << (self.bits + self.base + abs(self.shift))
 
   # Size of the codomain
   def cosize(self):


### PR DESCRIPTION
`self.` is missing in the implementation of Swizzle.