### PR TITLE
Liberate runtime check in example 13

### DIFF
--- a/examples/13_two_tensor_op_fusion/test_run.h
+++ b/examples/13_two_tensor_op_fusion/test_run.h
@@ -66,7 +66,7 @@ int testRun(int arch, std::vector<bool (*)()> & test_funcs, const std::string & 
     return -1;
   }
 
-  if (!(props.major == arch_major && props.minor == arch_minor)) {
+  if ((props.major < arch_major) || (props.major == arch_major && props.minor < arch_minor)) {
     supported = false;
   }
 


### PR DESCRIPTION
Example 13 runs currently only if the arch version match exactly the cuda device version but I believe the example should run if device capabilities weakly exceeds arch requirements. 