### PR TITLE
Add missing CUDA_ARCH guard for `__nanosleep` in example

### DIFF
--- a/examples/common/dist_gemm_helpers.h
+++ b/examples/common/dist_gemm_helpers.h
@@ -60,7 +60,9 @@ using AtomicBoolean = cuda::atomic<bool>;
 
 __global__ void delay_kernel(const AtomicBoolean* atomic_flag_ptr) {
   while (not atomic_flag_ptr->load()) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
     __nanosleep(40);
+#endif
   }
 }
 


### PR DESCRIPTION
Without this (similary done for other instances) compilation on pre-7.0 CCCs fill fail as the function is not defined.