### PR TITLE
fix: missing argparse argument static_shape for cutedsl ampere sgemm example

### DIFF
--- a/examples/python/CuTeDSL/ampere/sgemm.py
+++ b/examples/python/CuTeDSL/ampere/sgemm.py
@@ -844,6 +844,7 @@ if __name__ == "__main__":
         default=False,
         help="Use circular buffer tensor sets to ensure L2 cold cache",
     )
+    parser.add_argument("--static_shape", action="store_true")
 
     args = parser.parse_args()
     print("Running SIMT GEMM example:")


### PR DESCRIPTION
If the example snippet is run with:

```shell
python sgemm.py --mnk 4608,3072,3072 --a_major k --b_major k --c_major n
```

an attribute not found error will be raised:

```shell
Running SIMT GEMM example:
Traceback (most recent call last):
  File "sgemm.py", line 859, in <module>
    args.static_shape,
    ^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'static_shape'
```