### PR TITLE
Fix dimension comments in TiledMMA thrfrg functions

### DIFF
--- a/include/cute/atom/mma_atom.hpp
+++ b/include/cute/atom/mma_atom.hpp
@@ -262,7 +262,7 @@ struct TiledMMA : MMA_Atom
                             make_layout(size<1>(AtomShape_MNK{})));
     auto c_tensor = zipped_divide(t_tensor, c_tile);                 // ((AtomM,AtomN),(RestM,RestN))
 
-    // Transform the Atom mode from (M,K) to (Thr,Val)
+    // Transform the Atom mode from (M,N) to (Thr,Val)
     auto tv_tensor = c_tensor.compose(AtomLayoutC_TV{},_);           // ((ThrV,FrgV),(RestM,RestN))
 
     // Tile the tensor for the C-threads
@@ -340,7 +340,7 @@ struct TiledMMA : MMA_Atom
                             make_layout(size<2>(AtomShape_MNK{})));
     auto b_tensor = zipped_divide(t_tensor, b_tile);                 // ((AtomN,AtomK),(RestN,RestK))
 
-    // Transform the Atom mode from (M,K) to (Thr,Val)
+    // Transform the Atom mode from (N,K) to (Thr,Val)
     auto tv_tensor = b_tensor.compose(AtomLayoutB_TV{},_);           // ((ThrV,FrgV),(RestN,RestK))
 
     // Tile the tensor for the Thread


### PR DESCRIPTION
Correct the dimension descriptions in comments for tensor transformations:
- Line 265: Fix comment from (M,K) to (M,N) for C tensor transformation
- Line 343: Fix comment from (M,K) to (N,K) for B tensor transformation

These changes align the comments with the actual tensor dimensions being processed in the respective functions.