### PR TITLE
Fix Copy_Atom type mismatch in sgemm_sm80.cu

### DIFF
--- a/examples/cute/tutorial/sgemm_sm80.cu
+++ b/examples/cute/tutorial/sgemm_sm80.cu
@@ -496,8 +496,8 @@ gemm_nt(int m, int n, int k,
                size(ceil_div(N, bN)));
   gemm_device<<<dimGrid, dimBlock, smem_size, stream>>>
       (prob_shape, cta_tiler,
-       A, dA, sA, copyA, AutoVectorizingCopy{},
-       B, dB, sB, copyB, AutoVectorizingCopy{},
+       A, dA, sA, copyA, Copy_Atom<AutoVectorizingCopy, TA>{},
+       B, dB, sB, copyB, Copy_Atom<AutoVectorizingCopy, TB>{},
        C, dC, sC, mmaC,
        alpha, beta);
 }
@@ -573,8 +573,8 @@ gemm_tn(int m, int n, int k,
                size(ceil_div(N, bN)));
   gemm_device<<<dimGrid, dimBlock, smem_size, stream>>>
       (prob_shape, cta_tiler,
-       A, dA, sA, copyA, AutoVectorizingCopy{},
-       B, dB, sB, copyB, AutoVectorizingCopy{},
+       A, dA, sA, copyA, Copy_Atom<AutoVectorizingCopy, TA>{},
+       B, dB, sB, copyB, Copy_Atom<AutoVectorizingCopy, TB>{},
        C, dC, sC, mmaC,
        alpha, beta);
 }


### PR DESCRIPTION
Original code failed with compilation error when the generic `gemm_nt`, `gemm_tn` are compiled. (by default, only the `half_t` specialization is built). 