### PR TITLE
Fix broken imports in heuristics_provider.py

### DIFF
--- a/python/cutlass_library/heuristics.py
+++ b/python/cutlass_library/heuristics.py
@@ -37,7 +37,8 @@ import json
 import csv
 
 try:
-  if CUTLASS_IGNORE_PACKAGE:
+  import builtins
+  if hasattr(builtins, "CUTLASS_IGNORE_PACKAGE") and CUTLASS_IGNORE_PACKAGE == True:
     raise ImportError("Disabling attempt to import cutlass_library")
   from cutlass_library.library import *
   from cutlass_library.generator import *

--- a/python/cutlass_library/heuristics_provider.py
+++ b/python/cutlass_library/heuristics_provider.py
@@ -41,7 +41,13 @@ import logging
 import ctypes
 import functools
 
-from library import DataType, LayoutType
+try:
+  import builtins
+  if hasattr(builtins, "CUTLASS_IGNORE_PACKAGE") and CUTLASS_IGNORE_PACKAGE == True:
+    raise ImportError("Disabling attempt to import cutlass_library")
+  from cutlass_library.library import DataType, LayoutType
+except ImportError:
+  from library import DataType, LayoutType
 
 class MatmulHeuristics:
 


### PR DESCRIPTION
There are some broken imports when installing `cutlass_library` using `setup_library.py`. This PR mirrors import logic from other files to fix this