### PR TITLE
Fix bfloat16 epsilon

### DIFF
--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -362,8 +362,7 @@ struct numeric_limits<cutlass::bfloat16_t> {
 
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
-  static cutlass::bfloat16_t epsilon() { return (cutlass::bfloat16_t)(cutlass::bfloat16_t::bitcast(0x3f81) - cutlass::bfloat16_t::bitcast(0x3f80)); }
-
+  static cutlass::bfloat16_t epsilon() { return cutlass::bfloat16_t::bitcast(0x3c00); }
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
   static cutlass::bfloat16_t round_error() { return cutlass::bfloat16_t(0.5f); }
@@ -431,8 +430,7 @@ struct numeric_limits<cutlass::bfloat16_t> {
 
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
-  static cutlass::bfloat16_t epsilon() { return (cutlass::bfloat16_t)(cutlass::bfloat16_t::bitcast(0x3f81) - cutlass::bfloat16_t::bitcast(0x3f80)); }
-
+  static cutlass::bfloat16_t epsilon() { return cutlass::bfloat16_t::bitcast(0x3c00); }
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
   static cutlass::bfloat16_t round_error() { return cutlass::bfloat16_t(0.5f); }

--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -362,7 +362,7 @@ struct numeric_limits<cutlass::bfloat16_t> {
 
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
-  static cutlass::bfloat16_t epsilon() { return cutlass::bfloat16_t::bitcast(0x1000); }
+  static cutlass::bfloat16_t epsilon() { return (cutlass::bfloat16_t)(cutlass::bfloat16_t::bitcast(0x3f81) - cutlass::bfloat16_t::bitcast(0x3f80)); }
 
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
@@ -431,7 +431,7 @@ struct numeric_limits<cutlass::bfloat16_t> {
 
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE
-  static cutlass::bfloat16_t epsilon() { return cutlass::bfloat16_t::bitcast(0x1000); }
+  static cutlass::bfloat16_t epsilon() { return (cutlass::bfloat16_t)(cutlass::bfloat16_t::bitcast(0x3f81) - cutlass::bfloat16_t::bitcast(0x3f80)); }
 
   /// Returns smallest finite value
   CUTLASS_HOST_DEVICE


### PR DESCRIPTION
How described at https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon.html
numeric_limits::epsilon should return machine epsilon, and for bfloat16 might be represented as committed.

Current constant 0x1000 has nothing in common with this machine epsilon.