### PR TITLE
Fix: a calculation error in the example of dividing out in the 02_layout_algebra doc

### DIFF
--- a/media/docs/cpp/cute/02_layout_algebra.md
+++ b/media/docs/cpp/cute/02_layout_algebra.md
@@ -151,7 +151,7 @@ For example,
 * `(3,6,2,8) /  9 => (1,2,2,8)`
 * `(3,6,2,8) / 72 => (1,1,1,4)`
 
-To compute the strides of the strided layout, the residues of the above operation are used to scale the strides of `A`. For instance, the last example `(3,6,2,8):(w,x,y,z) / 72` with strides `(w,x,y,z)` produces `(3*w,6*x,2*x,2*z)` as the strides of the strided layout.
+To compute the strides of the strided layout, the residues of the above operation are used to scale the strides of `A`. For instance, the last example `(3,6,2,8):(w,x,y,z) / 72` with strides `(w,x,y,z)` produces `(72*w,24*x,4*y,2*z)` as the strides of the strided layout.
 
 As you may have noticed, we can only divide shapes by certain values and get a sensible result. This is called the **stride divisibility condition** and is statically checked in CuTe when possible.
 
@@ -171,7 +171,7 @@ This operation causes the result to have a shape that is compatible with `B`.
 
 Again, this operation must satisfy a **shape divisibility condition** to yield a sensible result and is statically checked in CuTe when possible.
 
-From the above examples, we can construct the composition `(3,6,2,8):(w,x,y,z) o 16:9 = (1,2,2,4):(3*w,3*x,y,z)`.
+From the above examples, we can construct the composition `(3,6,2,8):(w,x,y,z) o 16:9 = (1,2,2,4):(9*w,3*x,y,z)`.
 
 ---
 #### Example 1 -- Worked Example of Calculating a Composition


### PR DESCRIPTION
``` cpp
auto l = make_layout(make_shape(3, 6, 2, 8), make_stride(96, 16, 8, 2));
auto p = make_layout(16_c, 72_c);
auto q = composition(l, p);
print(q);
```
output: 
(3,6,2,8):(96,16,8,2)
_16:_72
(1,1,1,16):(6912,384,32,4)
`(3,6,2,8):(96,16,8,2) / 72` produces `(96*72, 16*24, 8*4, 2*2)` as the strides of the strided layout, not `(96*3, 16*6, 8*2, 2*2)`