### PR TITLE
Fix incorrect description about the value of e2m1 in comment

### DIFF
--- a/include/cutlass/float_subbyte.h
+++ b/include/cutlass/float_subbyte.h
@@ -70,7 +70,7 @@ struct float_e2m1_t;
 struct float_e3m2_t;
 // E2M1:
 //   2 Exponent bits with 1 Mantissa bit
-//   Range: +-[0,0.5,1,1.5,2,3,4,5,6]
+//   Range: +-[0,0.5,1,1.5,2,3,4,6]
 //   has_Inf: false
 //   has_NaN: false
 //   has_denorm: true


### PR DESCRIPTION
E2M1 value range should not cover value '5'.
There are 2*8 = 16 values, listed in range +-[0, 0.5, 1, 1.5, 2, 3, 4, 6].