### PR TITLE
Enable implicit fallthrough

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,7 @@ if (CUTLASS_CLANG_HOST_COMPILE)
     "-Wno-error=inconsistent-missing-override"
     "-Wno-sign-conversion"
     "-Wno-unused-parameter"
+    "-Wimplicit-fallthrough"
   )
 
   foreach(FLAG ${FLAGS_TO_ADD})


### PR DESCRIPTION
`-Wimplicit-fallthrough` is a very high signal warning. In internal testing we found that 30-40% of flagged instances were bugs of some sort.

CUTLASS currently passes `-Wimplicit-fallthrough`, but doesn't enforce it.

In this diff I'm attempting to enable the flag, but I'm not sure how: I'm unable to find a place where CUTLASS enables warning flags, even basic things like `-Wall`.

I'm worried that maybe CUTLASS doesn't use warning flags at all?