### PR TITLE
Fix type mismatch in linear combination epilogue

### DIFF
--- a/include/cutlass/epilogue/thread/linear_combination.h
+++ b/include/cutlass/epilogue/thread/linear_combination.h
@@ -323,7 +323,7 @@ public:
     ElementCompute intermediate;
     multiplies<ElementCompute> multiply;
 
-    intermediate = multiply(alpha_, accumulator);    // D = alpha * Accum
+    intermediate = multiply(alpha_, converted_accumulator);    // D = alpha * Accum
     return destination_converter(intermediate);
   }
 };


### PR DESCRIPTION
The update ensures that the multiplication uses the properly converted accumulator value, which can help prevent type-related errors. For example, when `ElementAccumulator_ = float` and `ElementCompute_ = half_t` will cause a compilation error.

The multiplication operation now uses `converted_accumulator` instead of `accumulator` to compute the intermediate value in the `LinearCombination` class.