### PR TITLE
Modify the debug printing in the sm70 example code of the CuTe examples.

### DIFF
--- a/examples/cute/tutorial/sgemm_sm70.cu
+++ b/examples/cute/tutorial/sgemm_sm70.cu
@@ -173,7 +173,7 @@ gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
     print("  sB : "); print(  sB); print("\n");
     print("tBgB : "); print(tBgB); print("\n");
     print("tBsB : "); print(tBsB); print("\n");
-    print("tArA : "); print(tArA); print("\n");
+    print("tBrB : "); print(tBrB); print("\n");
   }
 #endif
 


### PR DESCRIPTION
I think it should print **tBrB** here.