### PR TITLE
remove invalid template parameters

### DIFF
--- a/include/cutlass/exmy_base.h
+++ b/include/cutlass/exmy_base.h
@@ -1021,18 +1021,18 @@ struct float_exmy_base
 
   /// Floating point conversion
   CUTLASS_HOST_DEVICE
-  explicit float_exmy_base<T, Derived>(float x) {
+  explicit float_exmy_base(float x) {
     storage = static_cast<Derived*>(this)->convert_from_float(x).storage;
   }
 
   // Integer conversion
   CUTLASS_HOST_DEVICE
-  explicit float_exmy_base<T, Derived>(int x) {
+  explicit float_exmy_base(int x) {
     storage = static_cast<Derived*>(this)->convert_from_float(float(x)).storage;
   }
 
   CUTLASS_HOST_DEVICE
-  explicit float_exmy_base<T, Derived>(unsigned x) {
+  explicit float_exmy_base(unsigned x) {
     storage = static_cast<Derived*>(this)->convert_from_float(float(x)).storage;
   }
 


### PR DESCRIPTION
this change removes template parameters that should not be present; with gcc 14 and -Wall I get these warnings:
```
/git/mine/cutlass/include/cutlass/exmy_base.h:1024:39: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
 1024 |   explicit float_exmy_base<T, Derived>(float x) {
      |                                       ^
/git/mine/cutlass/include/cutlass/exmy_base.h:1024:39: note: remove the ‘< >’
/git/mine/cutlass/include/cutlass/exmy_base.h:1030:39: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
 1030 |   explicit float_exmy_base<T, Derived>(int x) {
      |                                       ^
/git/mine/cutlass/include/cutlass/exmy_base.h:1030:39: note: remove the ‘< >’
/git/mine/cutlass/include/cutlass/exmy_base.h:1035:39: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
 1035 |   explicit float_exmy_base<T, Derived>(unsigned x) {
      |                                       ^
/git/mine/cutlass/include/cutlass/exmy_base.h:1035:39: note: remove the ‘< >’
```