### PR TITLE
Fix: Remove redundant parameters of update function in device GemmUniversal

### DIFF
--- a/include/cutlass/gemm/device/gemm_universal.h
+++ b/include/cutlass/gemm/device/gemm_universal.h
@@ -401,9 +401,9 @@ public:
   }
 
   /// Lightweight update given a subset of arguments
-  Status update(Arguments const &args, void *workspace = nullptr) {
+  Status update(Arguments const &args) {
 
-    return underlying_operator_.update(to_underlying_arguments(args), workspace);
+    return underlying_operator_.update(to_underlying_arguments(args));
   }
 
   /// Runs the kernel using initialized state.


### PR DESCRIPTION
The `udpate` function of device GemmUniversal's column-major specialization has a `workspace` parameter, and it's passed to `underlying_operator_`:
https://github.com/NVIDIA/cutlass/blob/a2439551c765c5393aebe557ee75d3a0412d2211/include/cutlass/gemm/device/gemm_universal.h#L404-L407
But the `update` function of the `underlying_operator_`, that is, `GemmUniversalBase`, don't have this paramerter:
https://github.com/NVIDIA/cutlass/blob/a2439551c765c5393aebe557ee75d3a0412d2211/include/cutlass/gemm/device/gemm_universal_base.h#L423-L428
This leads to compile error when using the column-major specialization, so I removed it.