### PR TITLE
Fix: print subbyte<T> compilation error

### DIFF
--- a/include/cute/container/array_subbyte.hpp
+++ b/include/cute/container/array_subbyte.hpp
@@ -195,7 +195,7 @@ public:
 template <class T>
 CUTE_HOST_DEVICE
 void
-print(subbyte_reference<T>&& ref) {
+print(subbyte_reference<T> ref) {
   cute::print(ref.get());
 }
 
@@ -363,12 +363,6 @@ template <class T>
 CUTE_HOST_DEVICE void
 print(subbyte_iterator<T> const& x) {
   printf("subptr[%db](%p.%u)", int(sizeof_bits_v<T>), x.ptr_, x.idx_);
-}
-
-template <class T>
-CUTE_HOST_DEVICE void
-print(subbyte_reference<T> const& x) {
-  print(x.get());
 }
 
 //


### PR DESCRIPTION
# Bug Fix

## Which component has the problem?
**CuTe C++**

## Describe the bug
When printing a tensor of subbyte `<cutlass::float_e2m1_t>` created by `make_fragment_like`, a compilation error occurs.

## Steps/Code to reproduce bug
With repo at commit: `a2439551c765c5393aebe557ee75d3a0412d2211`

```cpp
#include <cuda.h>
#include <cute/tensor.hpp>
#include <cutlass/numeric_types.h>  // cutlass::float_e4m3_t

using namespace cute;

__global__ void print_nvfp4_kernel(const __half *Aptr) {

  auto A_tensor = make_tensor(make_gmem_ptr((__half *)Aptr), make_shape(Int<16>{}, Int<16>{}), make_stride(16, Int<1>{}));

  Tensor glm_A_tensor_fp4 = make_tensor(make_gmem_ptr((cutlass::float_e2m1_t *)Aptr), make_shape(Int<16>{}, Int<16>{}), make_stride(16, Int<1>{}));

  Tensor A_tensor_fp4 = make_fragment_like<cutlass::float_e2m1_t>(A_tensor);
  
  if (cute::thread0()) {
    print("nvfp4: \n");
    print(glm_A_tensor_fp4(0)); print("\n"); // pass, result correct
    print(A_tensor_fp4(0)); print("\n"); // compilation error
  }
}
```
## Outputs
**Compilation error:**

error: more than one instance of overloaded function "cuda_kernel::print" matches the argument list:
function template "void cute::print(const cute::subbyte_reference<T> &)" (declared at line 370 of ../third_party/cutlass/include/cute/container/array_subbyte.hpp)
function template "void cute::print(cute::subbyte_reference<T>)" (declared at line 198 of ../third_party/cutlass/include/cute/container/array_subbyte.hpp)
argument types are: (cute::subbyte_reference<cutlass::float_e2m1_t>)
print(A_tensor_fp4(0)); print("\n");

## Expected behavior
compile pass & result correct.

## Environment details
- **Compiler:** g++ (Debian 12.2.0-14+deb12u1) 12.2.0
- **CUDA:** Cuda compilation tools, release 12.8, V12.8.93
- **Build:** cuda_12.8.r12.8/compiler.35583870_0

## Additional context
The two overloads are indistinguishable at the "pass-by-value / pass-by-const-reference" level. Changing one of them to "accept only rvalues" allows the compiler to make a unique distinction: "passing an lvalue invokes the const& version, while passing an rvalue invokes the && version." 

With the rvalue overload added, the code now compiles successfully and produces the expected results.
Could you please take a look and let me know your thoughts?

Thanks!

@ccecka @thakkarV 
