### PR TITLE
DOC:  Update CUTLASS quickstart, remove FP8 GEMM link

### DIFF
--- a/media/docs/cpp/quickstart.md
+++ b/media/docs/cpp/quickstart.md
@@ -659,9 +659,7 @@ $ cmake .. -DCUTLASS_NVCC_ARCHS='70;75;80' -DCUTLASS_LIBRARY_KERNELS=tensorop*s*
 
 ## Instantiating a Blackwell SM100 GEMM kernel
 
-Blackwell SM100 kernels are instantiated very similarly to Hopper kernels. Let us start with an
-[FP8 GEMM without blockscaling](https://github.com/NVIDIA/cutlass/tree/main/test/unit/gemm/device/sm100_gemm_f8_f8_f8_tensor_op_s32_batch_alpha_beta.cu)
-as an example.
+Blackwell SM100 kernels are instantiated very similarly to Hopper kernels. Let us start with an FP8 GEMM without blockscaling as an example.
 
 The kernel starts with setting up datatypes and cluster shapes. 
 ```c++


### PR DESCRIPTION
Hi,
I am learning from the docs and found the file linked to FP8 GEMM without blockscaling (`sm100_gemm_f8_f8_f8_tensor_op_s32_batch_alpha_beta.cu`) does not exists so remove the hyperlink OR if preferred then replace it with the closed one `cutlass/test/unit/gemm/device/sm100_gemm_f8_f8_f8_tensor_op_f32_alignx.cu`