### PR TITLE
DOC: Fixing fundamental types codeblock

### DIFF
--- a/media/docs/cpp/fundamental_types.md
+++ b/media/docs/cpp/fundamental_types.md
@@ -224,7 +224,7 @@ int const kN = 16;
 Array<int8_t, kN> destination;
 Array<int,    kN> source;
 
-NumericConverter<descltype(destination), decltype(source)> convert;
+NumericArrayConverter<int8_t, int, kN> convert;
 
 destination = convert(source);
 ```


### PR DESCRIPTION
`cutlass/core_io.h` is required to use the IO overloads on `cutlass::half_t`