### PR TITLE
Enable setuptools_scm-based versioning and update build configuration

### DIFF
--- a/python/CuTeDSL/pyproject.toml
+++ b/python/CuTeDSL/pyproject.toml
@@ -10,7 +10,7 @@
 
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools_scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,8 +25,9 @@ authors = [
 packages = ["cutlass"]
 include-package-data = true
 
-[tool.setuptools.dynamic]
-version = {file = "VERSION.EDITABLE"}
+[tool.setuptools_scm]
+root = "../.."
 
 [tool.setuptools.package-data]
 nvidia_cutlass_dsl = ["lib/**/*"]
+


### PR DESCRIPTION
### Summary
This PR updates the build configuration to use `setuptools_scm` for automated
version management and ensures proper inclusion of package data for the CUTLASS
DSL components.

### What Changed
- Added `setuptools_scm>=8.0` to the `[build-system]` requirements.
- Configured `[tool.setuptools_scm]` with the CUTLASS project root (`../..`).

### Motivation
Building nvidia-cutlass-dsl with dynamic versioning currently produces a wheel with version 0.0.0 because the required VERSION.EDITABLE file is missing. This causes incorrect versioning for any wheel built from the repository.
Using `setuptools_scm` provides consistent, tag-driven versioning across the project
and aligns the DSL build with the broader CUTLASS packaging strategy.
It also improves build reproducibility and reduces manual version maintenance.

Fixes: https://github.com/NVIDIA/cutlass/issues/2814

### Additional Notes
No changes to runtime behavior. Build-only modification.
