### PR TITLE
Example77 blackwell FMHA decode attention optimization

### DIFF
--- a/examples/77_blackwell_fmha/77_blackwell_fmha_gen.cu
+++ b/examples/77_blackwell_fmha/77_blackwell_fmha_gen.cu
@@ -794,6 +794,14 @@ int main_single(int argc, char const **args) {
     )
 
   if (options.d == 128) {
+    // MTile=64
+    RUN(UMMA_I, 64, 64, 128, 1, 2, 1);
+    RUN(UMMA_I, 64, 128, 128, 1, 2, 1);
+    RUN(UMMA_I, 64, 256, 128, 1, 2, 1);
+    RUN(UMMA_P, 64, 64, 128, 1, 2, 1);
+    RUN(UMMA_P, 64, 128, 128, 1, 2, 1);
+    RUN(UMMA_P, 64, 256, 128, 1, 2, 1);
+    // MTile=128
     RUN(UMMA_I, 128, 64, 128, 1, 2, 1);
     RUN(UMMA_I, 128, 128, 128, 1, 2, 1);
     RUN(UMMA_I, 128, 256, 128, 1, 2, 1);

--- a/examples/77_blackwell_fmha/77_blackwell_fmha_gen.cu
+++ b/examples/77_blackwell_fmha/77_blackwell_fmha_gen.cu
@@ -338,7 +338,7 @@ struct ExampleRunner {
 
   using StrideQ = Stride<_0, _1, Stride<Stride<int, int>, int>>;
   using StrideNewK = Stride<_0, _1, Stride<Stride<_0, int>, int>>;
-  using StrideCacheK = Stride<int, _1, Stride<Stride<_0, int>, int>>;
+  using StrideCacheK = Stride<int, _1, Stride<Stride<_0, int64_t>, int64_t>>;
   using StrideNewV = StrideNewK;
   using StrideCacheV = StrideCacheK;
   using StrideO = StrideQ;
@@ -478,7 +478,7 @@ struct ExampleRunner {
 
     stride_q = make_stride(_0{}, _1{}, make_stride(make_stride(options.d, options.d * size<3,0,0>(result)), options.d * size<3,0>(result)));
     stride_new_k = make_stride(_0{}, _1{}, make_stride(make_stride(_0{}, options.d), options.d * size<3,0,1>(result)));
-    stride_cache_k = make_stride(options.d * size<3,0,1>(result), _1{}, make_stride(make_stride(_0{}, options.d), options.d * size<3,0,1>(result) * get<1>(result)));
+    stride_cache_k = make_stride(options.d * size<3,0,1>(result), _1{}, make_stride(make_stride(_0{}, static_cast<int64_t>(options.d)), static_cast<int64_t>(options.d) * size<3,0,1>(result) * get<1>(result)));
 
     stride_new_v = stride_new_k;
     stride_cache_v = stride_cache_k;

--- a/examples/77_blackwell_fmha/collective/sm100_fmha_gen_mainloop_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/collective/sm100_fmha_gen_mainloop_warpspecialized.hpp
@@ -86,13 +86,31 @@ struct Sm100FmhaGenMainloopWarpspecialized {
   using StrideO = decltype(replace<0>(StrideO_{}, 0));
   using Mask = Mask_;
 
+  using TileM = decltype(get<0>(TileShape{})); // seq Q dim
+  static_assert(TileM::value == 64 || TileM::value == 128, "Only expecting TileM to be 64 or 128");
   static constexpr int StageCountQ = get<1>(TileShape{}) == 256 ? 1 : 2;
-  using StageCountKVSelector = kValValMap<
+  // Choose StageCountKV based on:
+  // - Tile shape on the M (i.e., Query) dimension
+  // - Element size
+  using StageCountKVSelector = kValTyMap<
+    void,
+    kValTyPair<64,
+      kValValMap<
+        65536 /* default, arbitrarily large to trigger smem OOM error */,
+        kValValPair<1, 12>, // fp8
+        kValValPair<2, 6>  // bf16/fp16
+      >>,
+    kValTyPair<128,
+      kValValMap<
         65536 /* default, arbitrarily large to trigger smem OOM error */,
         kValValPair<1, 11>, // fp8
         kValValPair<2, 5>  // bf16/fp16
+      >>
   >;
-  static constexpr int StageCountKV = StageCountQ * StageCountKVSelector::template query<sizeof(Element)>;
+  static constexpr int StageCountKV = StageCountQ *
+    StageCountKVSelector::
+      template query<TileM::value>::
+      template query<sizeof(Element)>;
 
   using StagesQ = cutlass::gemm::collective::StageCount<StageCountQ>;
   using StagesKV = cutlass::gemm::collective::StageCount<StageCountKV>;
@@ -134,28 +152,65 @@ struct Sm100FmhaGenMainloopWarpspecialized {
     };
   };
 
-  enum class TmemAllocation : uint32_t {
-    kSizeS = 128,
-    kSizeO = 128,
-    kSizeP = 32,
-    S0 = 0,
-    S1 = S0 + kSizeS,
-    V0 = S0,  // stats storage from softmax to correction
-    V1 = S1,
-    P0 = S0 + kSizeP,
-    P1 = S1 + kSizeP,
-    O0 = S1 + kSizeS,
-    O1 = O0 + kSizeO,
-    kEnd = O1 + kSizeO
-  };
-
   // indices for V0 / V1
   enum : int {
     kIdxOldRowMax = 0,
     kIdxNewRowMax = 1,
     kIdxFinalRowSum = 0,
-    kIdxFinalRowMax = 1
+    kIdxFinalRowMax = 1,
+    kIdxStatsEnd = 2
   };
+
+  // Each storage reserves kTMEM_V_COLUMNS for row max/sum stats
+  // TileM=64 uses 16dp32b --> two threads processing a row
+  // TileM=128 uses 32dp32b --> one thread processing a row
+  using kTMEM_V_COLUMNS = typename kValTyMap<void,
+      kValTyPair<64, Int<kIdxStatsEnd*2>>,
+      kValTyPair<128, Int<kIdxStatsEnd>>
+      >::template query<TileM::value>;
+
+  // TMEM column allocation, offset will be used to calc the lower 16-bit of tmem addresses.
+  // TMEM row/lane dimension is for the Q dim.
+  //
+  // TMEM address layout:
+  // https://asciiflow.com/#/share/eJyrVspLzE1VslIqyU3NjU9MSSlKLS6Oz0mszC8tUdJRAjJSi4Cy1TFKZalFxZn5eTFKVkY6MUoVQNrSxATIqgSJmBsAWSWpFSVAToySAjYQ4uvqqwC1QAFiATZlMTF5WLUTCVC1P5rSpBAdZhALZihEBwBZMEFDuKAhTBC%2FQY%2Bmtzya0pAdBiQeTdsFEdDIDtbNDtOE84EcXeySGIaDjEFG0zahi0zZgyGCSxCO5pCuBavsGmyCE2BhAvMP3F%2FIHiRSEMgAGgdOFD6JeanFVDCMym7DiCHMkMIadltID24ytGAVXIIj1aKh7GAsmmHJlnTl2f64BTDzIxhEB4OzIqqQIZJQtD8010b7Q3JqjFKtUi0Ac90R%2Fw%3D%3D)
+  //
+  //            | [V0] |  [P0]   | [V1] |  [P1]   |
+  //            |<-kV->|<(kS-kV)>|<-kV->|<(kS-kV)>|
+  // -----^-----+------+---------+------+---------+------+------+
+  //      |     |      |         |      |         |      |      |
+  // TMEM Lanes |      |         |      |         |      |      |
+  //      |     |      |         |      |         |      |      |
+  // -----v-----+------+---------+------+---------+------+------+
+  //            |<------kS------>|<------kS------>|<-kO->|<-kO->|
+  //            |      [S0]      |      [S1]      | [O0] | [O1] |
+  enum class TmemAllocation : uint32_t {
+    kSizeS = get<1>(TileShapeQK{}), // i.e., KV dim in a tile
+    kSizeO = get<2>(TileShapeQK{}), // i.e., head dim
+    // carve kSizeS to two parts: first 1/4 for V0/V1 stats storage; the rest for P0/P1
+    // 1/4 is wasting some storage here but there seems to be column-wise address alignment requirements not found in spec.
+    // Since there is enough storage left for P0/P1, chose to not debug alignment issues.
+    kSizeV = kSizeS / 4,
+    // P will be casted to the same type as V
+    kSizeP = kSizeS * sizeof(Element) / sizeof(float),
+    S0 = 0,
+    S1 = S0 + kSizeS,
+    V0 = S0,  // stats storage from softmax to correction
+    V1 = S1,
+    P0 = V0 + kSizeV,
+    P1 = V1 + kSizeV,
+    O0 = S1 + kSizeS,
+    O1 = O0 + kSizeO,
+    kEnd = O1 + kSizeO
+  };
+  static_assert(static_cast<uint32_t>(TmemAllocation::kEnd) <= 512, "Exceeds TMEM 512 columns");
+  static_assert(
+    static_cast<uint32_t>(TmemAllocation::kSizeV) + static_cast<uint32_t>(TmemAllocation::kSizeP) <=
+    static_cast<uint32_t>(TmemAllocation::kSizeS),
+    "Not enough storage to carve V and P out of S");
+  static_assert(
+    static_cast<uint32_t>(kTMEM_V_COLUMNS::value) <= static_cast<uint32_t>(TmemAllocation::kSizeV),
+    "Not enough storage reserved for V");
 
   // from load to mma warp, protects q in smem
   using PipelineQ = cutlass::PipelineUmmaConsumerAsync<
@@ -531,33 +586,56 @@ struct Sm100FmhaGenMainloopWarpspecialized {
       PipelineS& pipeline_s, typename PipelineS::PipelineState& pipeline_s_consumer_state,
       PipelineC& pipeline_c, typename PipelineC::PipelineState& pipeline_c_producer_state,
       OrderBarrierSoftmax& order_s) {
-
-    Tensor tScS = typename CollectiveMmaQK::TiledMma{}.get_slice(0).partition_C(cS);
+    int thread_idx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+    Tensor tScS =
+        typename CollectiveMmaQK::TiledMma{}.get_slice(0).partition_C(cS);
 
     Tensor tStS = partition_fragment_C(typename CollectiveMmaQK::TiledMma{}, select<0,1>(TileShapeQK{}));
     tStS.data() = uint32_t(stage == _0{} ? TmemAllocation::S0 : TmemAllocation::S1);
 
-    Tensor tStS_v = tStS.compose(make_layout(make_shape(_128{}, _2{})));
+    Tensor tStS_v = tStS.compose(make_layout(make_shape(TileM{}, kTMEM_V_COLUMNS{})));
     tStS_v.data() = uint32_t(stage == _0{} ? TmemAllocation::V0 : TmemAllocation::V1);
-    Tensor tScS_v = tScS.compose(make_layout(make_shape(_128{}, _2{})));
+    Tensor tScS_v = tScS.compose(make_layout(make_shape(TileM{}, kTMEM_V_COLUMNS{})));
 
     auto tilePlikeFP32 = size<1>(TileShapeQK{}) / Int<sizeof(float)>{} * Int<sizeof(Element)>{};
-    Tensor tStS_P = tStS.compose(make_layout(make_shape(_128{}, tilePlikeFP32)));
+    Tensor tStS_P = tStS.compose(make_layout(make_shape(TileM{}, tilePlikeFP32)));
     tStS_P.data() = warp_uniform(uint32_t(stage == _0{} ? TmemAllocation::P0 : TmemAllocation::P1));
-    Tensor tScS_P = tScS.compose(make_layout(make_shape(_128{}, tilePlikeFP32)));
+    Tensor tScS_P = tScS.compose(make_layout(make_shape(TileM{}, tilePlikeFP32)));
 
-    // Each thread owns a single row
-    constexpr int kTMEMOpsPerRow = 2; // each thread processes an entire row, but convert+store half at a time to reduce reg pressure.
+    using TMEM_LOAD_1xOP = typename kValTyMap<void,
+        // Two threads collaborate on a single row
+        kValTyPair<64, SM100_TMEM_LOAD_16dp32b1x>,
+        // Each thread owns a single row
+        kValTyPair<128, SM100_TMEM_LOAD_32dp32b1x>
+      >::template query<TileM::value>;
+    using TMEM_STORE_1xOP = decltype(TMEM::tmem_load_to_store(TMEM_LOAD_1xOP{}));
+
+    // Summary of per-thread compute logic, each thread process all (TileM=128)/half(TileM=64) of a row:
+    // 1. Read all data going to processed by this thread from one row of S=QK.
+    // 2. Compute the "row_max" of that row of S.
+    // 3. Loop through that row of S via `kTMEMOpsPerRow` number of TMEM_LOAD/STORE
+    // instructions, each processing `kTmemLoadNcells` elements:
+    //   3.1 P=softmax(S)
+    //   3.2 Convert P's dtype from ElementQK -> Element, each conversion step processes `kConversionsPerStep` elements.
+    //   3.3 Store the converted P to TMEM, unblocks MMA_PV.
+    //
+    // Considerations for `kTMEMOpsPerRow`: it determines the intermediate
+    // registers required to perform "3.1 softmax" and "3.2 conversion", in
+    // addition to the input data (a row of S).
+
+    constexpr int kTMEMOpsPerRow = kValValMap<0 /* default, trigger static_assert error*/,
+        kValValPair<64, 1>,  // each thread processes half of a row.
+        kValValPair<128, 2>  // each thread processes an entire row, but convert+store half at a time to reduce reg pressure.
+      >::template query<TileM::value>;
     static_assert(size<1>(TileShapeQK{}) % kTMEMOpsPerRow == 0);
     constexpr int kTmemLoadNcells = size<1>(TileShapeQK{}) / kTMEMOpsPerRow;
     constexpr int kTmemStoreNcells = kTmemLoadNcells * sizeof_bits_v<Element> / sizeof_bits_v<float>;
-    using TMEM_LOAD_1xOP = SM100_TMEM_LOAD_32dp32b1x;
-    using TMEM_STORE_1xOP = decltype(TMEM::tmem_load_to_store(TMEM_LOAD_1xOP{}));
     using TMEM_LOAD = decltype(TMEM::op_repeater<TMEM_LOAD_1xOP, kTmemLoadNcells * 32>());
     using TMEM_STORE = decltype(TMEM::op_repeater<TMEM_STORE_1xOP, kTmemStoreNcells * 32>());
-    using TMEM_STORE_V = SM100_TMEM_STORE_32dp32b2x;   // 4x32 threads with 2 cols of 32b elem
-
-    int thread_idx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+    using TMEM_STORE_V = typename kValTyMap<void,
+        kValTyPair<64, SM100_TMEM_STORE_16dp32b2x>,
+        kValTyPair<128, SM100_TMEM_STORE_32dp32b2x> // 4x32 threads with 2 cols of 32b elem
+      >::template query<TileM::value>;
 
     auto tiled_tmem_load = make_tmem_copy(TMEM_LOAD{}, tStS);
     auto thr_tmem_load   = tiled_tmem_load.get_slice(thread_idx);
@@ -591,7 +669,8 @@ struct Sm100FmhaGenMainloopWarpspecialized {
 
     ElementQK old_row_max = row_max;
     {
-      // compute rowmax
+      // compute rowmax with steps of 4 elements
+      static_assert(size(tTMEM_LOADrS) % 4 == 0);
       float row_max_0 = row_max;
       float row_max_1 = row_max;
       float row_max_2 = row_max;
@@ -606,11 +685,17 @@ struct Sm100FmhaGenMainloopWarpspecialized {
       row_max = ::fmax(row_max_0, row_max_1);
       row_max = ::fmax(row_max, row_max_2);
       row_max = ::fmax(row_max, row_max_3);
+      if constexpr (TileM{} == 64) {
+        // Need to perform intra-warp reduction corresponding to the 16dp tmem.ld reg layout
+        // reduction group: (0,16), (1,17), ..., (15,31)
+        float other_row_max = __shfl_xor_sync(0xffffffff, row_max, 16);
+        row_max = ::fmax(row_max, other_row_max);
+      }
     }
-
     ElementQK row_max_safe = row_max == -INFINITY ? 0 : row_max;
 
     Tensor tTMEM_STOREVrS = make_tensor<ElementQK>(shape(tTMEM_STOREVcS));
+    static_assert(size(tTMEM_STOREVrS) == 2);
     tTMEM_STOREVrS(kIdxOldRowMax) = old_row_max;
     tTMEM_STOREVrS(kIdxNewRowMax) = row_max_safe;
     copy(tiled_tmem_storev, tTMEM_STOREVrS, tTMEM_STOREVtS);
@@ -634,12 +719,17 @@ struct Sm100FmhaGenMainloopWarpspecialized {
 
     NumericArrayConverter<Element, ElementQK, kConversionsPerStep> convert;
 
-    const int kReleasePipeCount = 10;  // must be multiple of 2
+    // `kReleasePipeCount` is for synchronizing between the two softmax warps (i.e., order_s).
+    // Note that order_s is not for correctness, but as a scheduling optimization to overlap softmax and mma while avoid overlapping two softmax warps (both warp_idx==0).
+    // The synchronization happens `kReleasePipeCount` iterations before the end of all softmax operations because barrier takes time to propogate.
+    constexpr int kReleasePipeCount = 10;  // must be multiple of kConversionsPerStep
+    static_assert(kReleasePipeCount % kConversionsPerStep == 0);
 
     order_s.wait();
 
     CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < size(tTMEM_LOADrS); i += 2) {
+    for (int i = 0; i < size(tTMEM_LOADrS); i += kConversionsPerStep) {
+      static_assert(size(tTMEM_LOADrS) % kConversionsPerStep == 0);
       float2 in = make_float2(
         tTMEM_LOADrS(i + 0),
         tTMEM_LOADrS(i + 1)
@@ -664,18 +754,18 @@ struct Sm100FmhaGenMainloopWarpspecialized {
         order_s.arrive();
       }
 
-      // this prevents register spills in fp16
-      if constexpr (size<2>(tTMEM_STORErS_x4) == _2{}) {
-        if (i == size(tTMEM_LOADrS) - 6) {
-          copy(tiled_tmem_store, tTMEM_STORErS_x4(_, _, 0), tTMEM_STOREtS_x4(_, _, 0));
-        }
+      // Write back the processed TMEM cells at the TMEMOp granularity.
+      // This is to allow register reuse, thus reducing max live registers and spills.
+      constexpr int kNcellsPerTMEMOp = size<0>(shape(tTMEM_LOADrS));
+      if ((i % kNcellsPerTMEMOp) == (kNcellsPerTMEMOp - kConversionsPerStep)) {
+        const int tmem_i = i / kNcellsPerTMEMOp;
+        // tmem_store(reg_S) -> op_P
+        copy(tiled_tmem_store, tTMEM_STORErS_x4(_, _, tmem_i), tTMEM_STOREtS_x4(_, _, tmem_i));
       }
     }
 
-    // tmem_store(reg_S8) -> op_P
     CUTE_STATIC_ASSERT_V(size<2>(tTMEM_STORErS_x4) <= _2{});
     CUTE_STATIC_ASSERT_V(size<1>(tTMEM_STORErS_x4) == _1{});
-    copy(tiled_tmem_store, tTMEM_STORErS_x4(_, _, size<2>(tTMEM_STORErS_x4) - 1), tTMEM_STOREtS_x4(_, _, size<2>(tTMEM_STORErS_x4) - 1));
 
     cutlass::arch::fence_view_async_tmem_store();
 
@@ -717,6 +807,11 @@ struct Sm100FmhaGenMainloopWarpspecialized {
     row_sum = local_row_sum;
 
     if (final_call) {
+      if constexpr (TileM{} == 64) {
+          // shuffle and aggregate row_sum across T0 and T16 due to 16dp32b thr->val layout.
+          row_sum += __shfl_xor_sync(0xffffffff, row_sum, 16);
+      }
+
       // re-acquire the S part in the final step
       pipeline_s.consumer_wait(pipeline_s_consumer_state);
 
@@ -807,16 +902,31 @@ struct Sm100FmhaGenMainloopWarpspecialized {
     // good values would be either 32 or 64
     const int kCorrectionTileSize = 32 / sizeof(ElementOut);
 
-    using TMEM_LOAD = std::conditional_t<kCorrectionTileSize == 32, SM100_TMEM_LOAD_32dp32b32x, SM100_TMEM_LOAD_32dp32b16x>;  // 4x32 threads with 64 cols of 32b elem
+
+    // Choose TMEM OP based on
+    // - TileM shape
+    // - kCorrectionTileSize
+    using TMEM_LOAD_OPMAP = kValTyMap<void,
+        kValTyPair<64,
+          kValTyMap</* default */ SM100_TMEM_LOAD_16dp32b8x,
+            kValTyPair<32, SM100_TMEM_LOAD_16dp32b16x>
+          >
+        >,
+        kValTyPair<128,
+          kValTyMap</* default*/ SM100_TMEM_LOAD_32dp32b16x,
+            kValTyPair<32, SM100_TMEM_LOAD_32dp32b32x>
+        >> // 4x32 threads with 64 cols of 32b elem
+    >;
+    using TMEM_LOAD = typename TMEM_LOAD_OPMAP::template query<TileM::value>::template query<kCorrectionTileSize>;
 
     typename CollectiveMmaPV::TiledMma mma;
     Tensor tOtO = partition_fragment_C(mma, select<0,1>(TileShapePV{}));
     Tensor tOcO = mma.get_slice(0).partition_C(cO);
     Tensor tOgO = mma.get_slice(0).partition_C(gO);
 
-    Tensor tOtO_i = tOtO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
-    Tensor tOcO_i = tOcO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
-    Tensor tOgO_i = tOgO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+    Tensor tOtO_i = tOtO.compose(make_layout(make_shape(TileM{}, Int<kCorrectionTileSize>{})));
+    Tensor tOcO_i = tOcO.compose(make_layout(make_shape(TileM{}, Int<kCorrectionTileSize>{})));
+    Tensor tOgO_i = tOgO.compose(make_layout(make_shape(TileM{}, Int<kCorrectionTileSize>{})));
 
     Tensor tOtO0 = tOtO_i;
     tOtO0.data() = tOtO0.data().get() + uint32_t(TmemAllocation::O0);
@@ -904,16 +1014,22 @@ struct Sm100FmhaGenMainloopWarpspecialized {
     // good values would be either 32 or 64
     const int kCorrectionTileSize = 32;
 
-    using TMEM_LOAD = SM100_TMEM_LOAD_32dp32b32x;  // 4x32 threads with 64 cols of 32b elem
-    using TMEM_STORE = SM100_TMEM_STORE_32dp32b32x;  // 4x32 threads with 64 cols of 32b elem
+    using TMEM_LOAD = typename kValTyMap<void,
+        kValTyPair<64, SM100_TMEM_LOAD_16dp32b16x>,
+        kValTyPair<128, SM100_TMEM_LOAD_32dp32b32x> // 4x32 threads with 64 cols of 32b elem
+      >::template query<TileM::value>;
+    using TMEM_STORE = typename kValTyMap<void,
+        kValTyPair<64, SM100_TMEM_STORE_16dp32b16x>,
+        kValTyPair<128, SM100_TMEM_STORE_32dp32b32x> // 4x32 threads with 64 cols of 32b elem
+      >::template query<TileM::value>;
 
     typename CollectiveMmaPV::TiledMma mma;
     Tensor cO = make_identity_tensor(select<0,1>(TileShapePV{}));
     Tensor tOtO = partition_fragment_C(mma, select<0,1>(TileShapePV{}));
     Tensor tOcO = mma.get_slice(0).partition_C(cO);
 
-    Tensor tOtO_i = tOtO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
-    Tensor tOcO_i = tOcO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+    Tensor tOtO_i = tOtO.compose(make_layout(make_shape(TileM{}, Int<kCorrectionTileSize>{})));
+    Tensor tOcO_i = tOcO.compose(make_layout(make_shape(TileM{}, Int<kCorrectionTileSize>{})));
 
     tOtO_i.data() = tOtO_i.data().get() + tmem_O;
 
@@ -998,10 +1114,13 @@ struct Sm100FmhaGenMainloopWarpspecialized {
     Tensor cS = make_identity_tensor(select<0,1>(TileShapeQK{}));
     Tensor tScS = typename CollectiveMmaQK::TiledMma{}.get_slice(0).partition_C(cS);
 
-    Tensor tStS_v = tStS.compose(make_layout(make_shape(_128{}, _2{})));
-    Tensor tScS_v = tScS.compose(make_layout(make_shape(_128{}, _2{})));
+    Tensor tStS_v = tStS.compose(make_layout(make_shape(TileM{}, kTMEM_V_COLUMNS{})));
+    Tensor tScS_v = tScS.compose(make_layout(make_shape(TileM{}, kTMEM_V_COLUMNS{})));
 
-    using TMEM_LOAD_V = SM100_TMEM_LOAD_32dp32b2x;   // 4x32 threads with 2 cols of 32b elem
+    using TMEM_LOAD_V = typename kValTyMap<void,
+        kValTyPair<64, SM100_TMEM_LOAD_16dp32b2x>,
+        kValTyPair<128, SM100_TMEM_LOAD_32dp32b2x> // 4x32 threads with 2 cols of 32b elem
+      >::template query<TileM::value>;
 
     auto tiled_tmem_loadv = make_tmem_copy(TMEM_LOAD_V{}, tStS_v);
     auto thr_tmem_loadv  = tiled_tmem_loadv.get_slice(thread_idx);
@@ -1030,6 +1149,7 @@ struct Sm100FmhaGenMainloopWarpspecialized {
       pipeline_s0_c.consumer_wait(pipeline_s0_c_consumer_state);
 
       Tensor tTMEM_LOADVrS = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+      static_assert(size(tTMEM_LOADVrS) == 2);
 
       // read row_wise new global max
       copy(tiled_tmem_loadv, tTMEM_LOADVtS0, tTMEM_LOADVrS);

--- a/examples/77_blackwell_fmha/collective/sm100_fmha_load_cpasync_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/collective/sm100_fmha_load_cpasync_warpspecialized.hpp
@@ -170,8 +170,12 @@ struct Sm100FmhaLoadCpAsyncWarpspecialized {
     auto tSgQ = thr_mma_qk.partition_A(gQ);
     auto tScQ = thr_mma_qk.partition_A(cQ);
 
-    auto atom_q_tv = Layout<Shape<Shape<_2, _32>, _16>, Stride<Stride<_16, _32>, _1>>{};
-    auto atom_kv_tv = Layout<Shape<Shape<_2, _32>, _16>, Stride<Stride<_16, _32>, _1>>{};
+    // Each cp.async copy atom is 16-bytes uint128_t. So we adjust the number of
+    // elements in atom's TV layout accordingly to match Element dtype.
+    // This avoids uncoalesced gmem access according to ncu.
+    using ElemPerAtom = cute::Int<sizeof(uint128_t) / sizeof(Element)>;
+    auto atom_q_tv = Layout<Shape<Shape<_2, _32>, ElemPerAtom>, Stride<Stride<ElemPerAtom, decltype(_2{} * ElemPerAtom{})>, _1>>{};
+    auto atom_kv_tv = Layout<Shape<Shape<_2, _32>, ElemPerAtom>, Stride<Stride<ElemPerAtom, decltype(_2{} * ElemPerAtom{})>, _1>>{};
 
     auto tiled_copy_q = make_cotiled_copy(
         Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, Element>{},

--- a/examples/77_blackwell_fmha/device/fmha.hpp
+++ b/examples/77_blackwell_fmha/device/fmha.hpp
@@ -38,7 +38,7 @@
 // common
 #include "cutlass/cutlass.h"
 #include "cutlass/device_kernel.h"
-
+#include "cutlass/arch/arch.h"
 #if !defined(__CUDACC_RTC__)
 #include "cutlass/cluster_launch.hpp"
 #include "cutlass/trace.h"
@@ -56,7 +56,7 @@ template <class Kernel_>
 class FMHA {
 public:
   using Kernel = Kernel_;
-
+  static_assert(Kernel::SharedStorageSize <= cutlass::arch::sm100_smem_capacity_bytes, "SMEM usage exceeded capacity.");
   static int const kThreadCount = Kernel::MaxThreadsPerBlock;
 
   /// Argument structure: User API


### PR DESCRIPTION
Hi,

This PR mainly aims to upstream some fixes and optimizations we developed for the blackwell FMHA decode attention in Meta's [FBGEMM](https://github.com/pytorch/FBGEMM/blob/903002ae54448dee6d43c9bb0f1d3fd4249b6101/fbgemm_gpu/experimental/gen_ai/src/attention/cuda/cutlass_blackwell_fmha/collective/sm100_fmha_gen_mainloop_warpspecialized.hpp).

**Change1:** support FP16 in the `fmha_gen` kernel. Previously the fmha_gen uses hardcoded fp8 and ignores the precision compiler macros.
**Change2:** improve the `fmha_gen` kernel performance by reducing the MTile from 128 to 64.

More details available in the commit messages.

cc previous example_77 contributors who also reviewed this PR: @v0i0 @Aya-ZIbra 

Overview of the perf improvements (measured on B200):

| BW (TB/s) |       |       |              | seqlen    |         |         |         |         |         |
| --------- | ----- | ----- | ------------ | ------- | ------- | ------- | ------- | ------- | ------- |
| precision | MTile | NTile | KernSchedule | 512     | 1024    | 2048    | 4096    | 8192    | 16384   |
| fp16      | 64    | 64    | UMMA_I       | 3.17476 | 4.49264 | 5.19867 | 5.28804 | 4.85761 | 4.8774  |
| fp16      | 64    | 64    | UMMA_P       | 3.72582 | 4.61441 | 4.62711 | 4.74302 | 4.70932 | 4.64647 |
| fp16      | 64    | 128   | UMMA_I       | 3.31873 | 4.53742 | 5.1661  | 5.5619  | 5.10862 | 4.97582 |
| fp16      | 64    | 128   | UMMA_P       | 3.79117 | 4.80919 | 5.28695 | 5.41161 | 5.11698 | 5.01131 |
| fp16      | 64    | 256   | UMMA_I       | 3.0013  | 4.31719 | 4.80408 | 5.26672 | 5.16098 | 4.88833 |
| fp16      | 64    | 256   | UMMA_P       | 3.30899 | 4.43762 | 5.06723 | 5.40213 | 5.16288 | 5.0174  |
| fp16      | 128   | 64    | UMMA_I       | 2.53065 | 3.41101 | 3.83049 | 4.17756 | 4.25571 | 4.2076  |
| fp16      | 128   | 64    | UMMA_P       | 3.25735 | 3.94733 | 4.0979  | 4.27806 | 4.19192 | 4.17491 |
| fp16      | 128   | 128   | UMMA_I       | 2.79024 | 3.86101 | 4.48453 | 4.73089 | 4.42713 | 4.36846 |
| fp16      | 128   | 128   | UMMA_P       | 3.46795 | 4.42207 | 4.74267 | 4.5842  | 4.56293 | 4.47918 |
| fp16      | 128   | 256   | UMMA_I       | 2.54354 | 3.68322 | 4.47963 | 4.62111 | 4.62095 | 4.51716 |
| fp16      | 128   | 256   | UMMA_P       | 2.92147 | 4.09284 | 4.47127 | 4.66789 | 4.55911 | 4.51602 |

fp16 MTile=64/MTile=128

 MTile | NTile  | KernelSchedule  |   |   |   |   |   |   | geomean(row)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
64/128 | 64 | UMMA_I | 125.45% | 131.71% | 135.72% | 126.58% | 114.14% | 115.92% | 124.68%
64/128 | 64 | UMMA_P | 114.38% | 116.90% | 112.91% | 110.87% | 112.34% | 111.30% | 113.10%
64/128 | 128 | UMMA_I | 118.94% | 117.52% | 115.20% | 117.57% | 115.39% | 113.90% | 116.41%
64/128 | 128 | UMMA_P | 109.32% | 108.75% | 111.48% | 118.05% | 112.14% | 111.88% | 111.90%
64/128 | 256 | UMMA_I | 118.00% | 117.21% | 107.24% | 113.97% | 111.69% | 108.22% | 112.65%
64/128 | 256 | UMMA_P | 113.26% | 108.42% | 113.33% | 115.73% | 113.24% | 111.10% | 112.49%
  |   | geomean(col) | 116.45% | 116.51% | 115.64% | 117.03% | 113.15% | 112.03% | 115.12%

overall geomean(fp16 speedup) is 1.15x


| BW (TB/s) |       |       |              | seqlen     |         |         |         |         |         |
| --------- | ----- | ----- | ------------ | ------- | ------- | ------- | ------- | ------- | ------- |
| precision | MTile | NTile | KernSchedule | 512     | 1024    | 2048    | 4096    | 8192    | 16384   |
| fp8       | 64    | 64    | UMMA_I       | 1.94386 | 2.51525 | 3.24701 | 3.89887 | 4.01632 | 4.08602 |
| fp8       | 64    | 64    | UMMA_P       | 2.50369 | 3.11726 | 3.6986  | 4.13179 | 4.11397 | 4.18423 |
| fp8       | 64    | 128   | UMMA_I       | 2.34714 | 3.10015 | 4.13021 | 4.96551 | 5.14912 | 5.06843 |
| fp8       | 64    | 128   | UMMA_P       | 2.75716 | 3.8988  | 4.97269 | 5.42379 | 5.16682 | 4.95883 |
| fp8       | 64    | 256   | UMMA_I       | 2.27186 | 3.23571 | 4.31995 | 5.01347 | 5.44343 | 5.26331 |
| fp8       | 64    | 256   | UMMA_P       | 2.65845 | 3.76536 | 4.76387 | 5.24293 | 5.34911 | 5.25732 |
| fp8       | 128   | 64    | UMMA_I       | 1.44813 | 1.86377 | 2.33225 | 2.84555 | 3.10332 | 3.23485 |
| fp8       | 128   | 64    | UMMA_P       | 1.96491 | 2.43062 | 2.96345 | 3.32285 | 3.51813 | 3.56919 |
| fp8       | 128   | 128   | UMMA_I       | 1.73366 | 2.36751 | 3.21492 | 3.74087 | 3.89075 | 3.96716 |
| fp8       | 128   | 128   | UMMA_P       | 2.36905 | 3.24425 | 3.88743 | 4.00828 | 4.14043 | 4.0752  |
| fp8       | 128   | 256   | UMMA_I       | 1.60114 | 2.44246 | 3.45299 | 4.0291  | 4.25753 | 4.25951 |
| fp8       | 128   | 256   | UMMA_P       | 2.00025 | 2.96163 | 3.81701 | 4.19517 | 4.24847 | 4.20399 |

fp8 MTile=64/MTile=128

 MTile | NTile  | KernelSchedule  |   |   |   |   |   |   | geomean(row)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
64/128 | 64 | UMMA_I | 134.23% | 134.95% | 139.22% | 137.02% | 129.42% | 126.31% | 133.45%
64/128 | 64 | UMMA_P | 127.42% | 128.25% | 124.81% | 124.34% | 116.94% | 117.23% | 123.08%
64/128 | 128 | UMMA_I | 135.39% | 130.95% | 128.47% | 132.74% | 132.34% | 127.76% | 131.25%
64/128 | 128 | UMMA_P | 116.38% | 120.18% | 127.92% | 135.31% | 124.79% | 121.68% | 124.23%
64/128 | 256 | UMMA_I | 141.89% | 132.48% | 125.11% | 124.43% | 127.85% | 123.57% | 129.07%
64/128 | 256 | UMMA_P | 132.91% | 127.14% | 124.81% | 124.98% | 125.91% | 125.06% | 126.77%
  |   | geomean(col) | 131.12% | 128.90% | 128.29% | 129.69% | 126.11% | 123.55% | 127.92%

overall geomean(fp8 speedup) is 1.28x