### PR TITLE
Remove deprecated newshape argument.

### DIFF
--- a/python/cutlass_cppgen/epilogue/evt_ops.py
+++ b/python/cutlass_cppgen/epilogue/evt_ops.py
@@ -93,6 +93,6 @@ def permute(x, indices: tuple):
 
 def reshape(x, new_shape: tuple):
     if is_numpy_tensor(x):
-        return np.reshape(x, newshape=new_shape)
+        return np.reshape(x, new_shape)
     elif is_torch_tensor(x):
         return x.view(new_shape)


### PR DESCRIPTION
Remove use of deprecated `newshape` argument of np.reshape. It's been deprecated since numpy v2.1, and is removed in v2.4.
https://numpy.org/doc/stable/reference/generated/numpy.reshape.html

Its job is now done by the `shape` argument which can be used w/o the key, as a purely positional argument.