### PR TITLE
add `SM75_16x8x8_F16F16F16F16_TN`

### DIFF
--- a/include/cute/arch/mma_sm75.hpp
+++ b/include/cute/arch/mma_sm75.hpp
@@ -82,6 +82,42 @@ struct SM75_16x8x8_F32F16F16F32_TN
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //
+// SM75 MMA 1688 F16F16F16
+//
+
+struct SM75_16x8x8_F16F16F16F16_TN
+{
+  using DRegisters = uint32_t[2];
+  using ARegisters = uint32_t[2];
+  using BRegisters = uint32_t[1];
+  using CRegisters = uint32_t[2];
+
+  // Register asm fma
+  CUTE_HOST_DEVICE static void
+  fma(uint32_t &d0, uint32_t &d1,
+      uint32_t const &a0, uint32_t const &a1,
+      uint32_t const &b0,
+      uint32_t const &c0, uint32_t const &c1)
+  {
+#if defined(CUTE_ARCH_MMA_SM75_ENABLED)
+    asm volatile("mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16"
+                 "{%0, %1},"
+                 "{%2, %3},"
+                 "{%4},"
+                 "{%5, %6};\n"
+        : "=r"(d0), "=r"(d1)
+        :  "r"(a0),  "r"(a1),
+           "r"(b0),
+           "r"(c0),  "r"(c1));
+#else
+    CUTE_INVALID_CONTROL_PATH("Attempting to use SM75_16x8x8_F16F16F16F16_TN without CUTE_ARCH_MMA_SM75_ENABLED");
+#endif
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//
 // SM75 MMA 8816 S8S8S32
 //
 

--- a/include/cute/atom/mma_traits_sm75.hpp
+++ b/include/cute/atom/mma_traits_sm75.hpp
@@ -59,6 +59,26 @@ struct MMA_Traits<SM75_16x8x8_F32F16F16F32_TN>
 ///////////////////////////////////////////////////////////////////////////////
 
 template <>
+struct MMA_Traits<SM75_16x8x8_F16F16F16F16_TN>
+{
+  using ValTypeD = half_t;
+  using ValTypeA = half_t;
+  using ValTypeB = half_t;
+  using ValTypeC = half_t;
+
+  using Shape_MNK = Shape<_16,_8,_8>;
+  using ThrID   = Layout<_32>;
+  using ALayout = Layout<Shape <Shape < _4,_8>,Shape < _2,_2>>,
+                         Stride<Stride<_32,_1>,Stride<_16,_8>>>;
+  using BLayout = Layout<Shape <Shape < _4,_8>,_2>,
+                         Stride<Stride<_16,_1>,_8>>;
+  using CLayout = Layout<Shape <Shape < _4,_8>,Shape < _2,_2>>,
+                         Stride<Stride<_32,_1>,Stride<_16,_8>>>;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <>
 struct MMA_Traits<SM75_8x8x16_S32S8S8S32_TN>
 {
   using ValTypeD = int32_t;

--- a/test/unit/cute/turing/cooperative_gemm.cu
+++ b/test/unit/cute/turing/cooperative_gemm.cu
@@ -54,3 +54,17 @@ TEST(SM75_CuTe_Turing, CooperativeGemm1_MixedPrecisionFP16FP32_MMA) {
 
   test_cooperative_gemm_col_major_layout<thread_block_size, max_vec_bits, TA, TB, TC>(shape_mnk, tiled_mma);
 }
+
+TEST(SM75_CuTe_Turing, CooperativeGemm2_Half_MMA) {
+  constexpr uint32_t thread_block_size = 128;
+  using value_type = cutlass::half_t;
+
+  auto shape_mnk = make_shape(_64{}, _64{}, _64{});
+  auto tiled_mma =
+      TiledMMA<
+        MMA_Atom<SM75_16x8x8_F16F16F16F16_TN>,
+        Layout<Shape<_2, _2, _1>>
+      >{};
+
+  test_cooperative_gemm_col_major_layout<thread_block_size, value_type>(shape_mnk, tiled_mma);
+}


### PR DESCRIPTION
SM75 supports `mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16` ptx instruction, but cute/arch/mma_sm75.hpp doesn't include this instruction.

Close https://github.com/NVIDIA/cutlass/issues/2833