### PR TITLE
Fix tensor refs being held too long

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/compiler.py
+++ b/python/CuTeDSL/cutlass/base_dsl/compiler.py
@@ -649,4 +649,9 @@ class CompileCallable:
 
         if hasattr(func, "_decorator_frame"):
             kwargs["_decorator_frame"] = func._decorator_frame
-        return func._dsl_object._func(fcn_ptr, *args, **kwargs)
+        result = func._dsl_object._func(fcn_ptr, *args, **kwargs)
+        # Drop the decorator frame to avoid holding onto the caller's locals
+        # (e.g., tensors) longer than necessary once compilation is done.
+        if hasattr(func, "_decorator_frame"):
+            func._decorator_frame = None
+        return result


### PR DESCRIPTION
# Summary

repro:
https://github.com/pytorch/pytorch/issues/169921 which is blocking cuda-graph trees from fa4 in flex.
```Py
"""Minimal proof that cute.compile causes cudagraph pool issues."""
import torch
from cutlass.cute.runtime import from_dlpack
import cutlass.cute as cute
import cuda.bindings.driver as cuda

def kernel_with_compile(x, out):
    """Kernel that calls cute.compile - THIS IS THE CULPRIT."""
    x_tensor = from_dlpack(x.detach(), assumed_align=16).mark_layout_dynamic(leading_dim=x.ndim - 1)
    o_tensor = from_dlpack(out.detach(), assumed_align=16).mark_layout_dynamic(leading_dim=out.ndim - 1)
    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)

    @cute.kernel
    def copy_kernel(src, dst, stream):
        pass

    # THIS LINE causes the cudagraph pool leak
    compiled = cute.compile(copy_kernel, x_tensor, o_tensor, current_stream)

    out.copy_(x)

@torch.library.custom_op("test::compile_proof", mutates_args={"out"})
def compile_proof_op(x: torch.Tensor, out: torch.Tensor) -> None:
    kernel_with_compile(x, out)

@compile_proof_op.register_fake
def _(x, out):
    pass

def fn(x):
    out = torch.empty_like(x)
    compile_proof_op(x, out)
    return out

x = torch.randn(128, 128, device="cuda")
compiled_fn = torch.compile(fn, mode="max-autotune", fullgraph=True)

print("\nRunning with cute.compile inside kernel...")
for i in range(3):
    out = compiled_fn(x)
    torch.cuda.synchronize()
    print(f"Iteration {i+1}: {'SUCCESS' if i > 0 else 'warmup'}")

```

If I but a breakpoint in this file (in my site packages) and print the frame locals

```
(Pdb) p func._decorator_frame.f_locals.keys()
dict_keys(['x', 'out', 'x_tensor', 'o_tensor', 'current_stream', 'copy_kernel'])
(Pdb) 
```

which in this case x,out, etc are the tensors in the and it appears as though the the func holding onto this keeps a weak ref alive and thus not letting us dealloc the tensor storage. And this causes an issue for cuda-graph storage_ptr tracking.


In what I am acutally trying to enable:

```Py
[cute.compile debug] frame <frame at 0x564d91f83dc0, file '/home/dev/meta/flash-attention/flash_attn/cute/flash_fwd_sm100.py', line 2630, code FlashAttentionForwardSm100> locals keys ['__module__', '__qualname__', 'arch', '__init__', '_setup_attributes', '__call__', 'kernel', 'load', 'mma', 'softmax_loop', 'softmax_step', 'correction_loop', 'correction_rescale', 'correction_epilogue', 'epilogue_s2g', 'load_Q', 'load_KV', 'offset_kv_smem', 'make_and_init_load_kv_pipeline', 'apply_score_mod']
```

And with this patch we 
```Py
# clearing the decorator frame to none
[cute.compile debug] frame cleared: None

    raise RuntimeError(msg)
RuntimeError: These live storage data ptrs are in the cudagraph pool but not accounted for as an output of cudagraph trees: 
...
Data Pointer: 139619729408000, history: 
  File "??", line 0, in torch::unwind::unwind()
  File "??", line 0, in torch::CapturedTraceback::gather(bool, bool, bool)
  File "memory_snapshot.cpp", line 0, in torch::cuda::(anonymous namespace)::gather_with_cpp()
  File "CUDACachingAllocator.cpp", line 0, in c10::cuda::CUDACachingAllocator::Native::DeviceCachingAllocator::malloc(unsigned long, CUstream_st*)
  File "", line 0, in c10::cuda::CUDACachingAllocator::Native::NativeCachingAllocator::malloc(void**, signed char, unsigned long, CUstream_st*)
  File "", line 0, in c10::cuda::CUDACachingAllocator::Native::NativeCachingAllocator::allocate(unsigned long)
  File "??", line 0, in at::detail::empty_strided_generic(c10::ArrayRef<long>, c10::ArrayRef<long>, c10::Allocator*, c10::DispatchKeySet, c10::ScalarType)
  File "??", line 0, in at::detail::empty_strided_cuda(c10::ArrayRef<long>, c10::ArrayRef<long>, c10::ScalarType, std::optional<c10::Device>)
```
Still causes a problem... 🙃. okay not sure this is it



