### PR TITLE
docs: Add FP16 GEMM documentation to sgemm_sm80.cu - Fixes #1686

### DIFF
--- a/examples/cute/tutorial/sgemm_sm80.cu
+++ b/examples/cute/tutorial/sgemm_sm80.cu
@@ -28,6 +28,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **************************************************************************************************/
+
+/*
+  This example demonstrates a high-performance FP16xFP16 GEMM (HGEMM) using CuTe
+  for SM80 (Ampere) and later architectures.
+
+  Key features:
+  - Half-precision (FP16) inputs and outputs using cute::half_t
+  - Tensor Core operations via SM80_16x8x16_F16F16F16F16_TN MMA atom
+  - Asynchronous global-to-shared memory copy using cp.async (SM80_CP_ASYNC)
+  - Multi-stage software pipelining for latency hiding
+  - Swizzled shared memory layouts to avoid bank conflicts
+
+  Note: Despite the filename "sgemm", this example uses FP16 data types for the
+  TN (A transposed, B normal) layout variant, making it suitable as a reference
+  for developing fused FP16 GEMM kernels with CuTe.
+
+  Usage:
+    ./cute_tutorial_sgemm_sm80 [M] [N] [K] [transA] [transB]
+
+  Example:
+    ./cute_tutorial_sgemm_sm80 4096 4096 4096 T N
+*/
 #include <cstdlib>
 #include <cstdio>
 #include <cassert>


### PR DESCRIPTION
## Summary
Add descriptive documentation to [sgemm_sm80.cu](cci:7://file:///d:/Desktop/cutlass-1/examples/cute/tutorial/sgemm_sm80.cu:0:0-0:0) explaining that it is actually an FP16xFP16 GEMM (HGEMM) tutorial using CuTe.

## Problem
Issue #1686 reports that users cannot find an fp16 GEMM tutorial in the CuTe examples.

## Solution
The existing [sgemm_sm80.cu](cci:7://file:///d:/Desktop/cutlass-1/examples/cute/tutorial/sgemm_sm80.cu:0:0-0:0) already implements FP16 GEMM using `cute::half_t`, but this was not documented. This PR adds a documentation block clarifying:
- This example uses FP16 data types despite the "sgemm" filename
- Key features: Tensor Cores, cp.async, pipelining, swizzled shared memory
- Usage examples

Fixes #1686