### PR TITLE
docs: note when DSL dumps are populated

### DIFF
--- a/media/docs/pythonDSL/cute_dsl_general/debugging.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/debugging.rst
@@ -112,6 +112,9 @@ For compiled kernels, the generated PTX/CUBIN/IR can be accessed programmaticall
 - ``__cubin__``: The generated CUBIN data of the compiled kernel.
 - ``__mlir__``: The generated IR code of the compiled kernel.
 
+These attributes are populated only when the corresponding ``CUTE_DSL_KEEP_*`` environment variable is enabled;
+otherwise they return ``None``.
+
 .. code:: python
     
     compiled_foo = cute.compile(foo, ...)


### PR DESCRIPTION
Added a disclaimer that __ptx__, __cubin__, and __mlir__ attributes are only populated when their respective CUTE_DSL_KEEP_* envvar are set.

```
print(f"PTX: {compiled_foo.__ptx__}")    # Otherwise, this prints None without CUTE_DSL_KEEP_PTX=1
```