### PR TITLE
New RMS Norm example with unit tests

### DIFF
--- a/examples/python/CuTeDSL/blackwell/reduce.py
+++ b/examples/python/CuTeDSL/blackwell/reduce.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without

--- a/examples/python/CuTeDSL/blackwell/rmsnorm.py
+++ b/examples/python/CuTeDSL/blackwell/rmsnorm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without

--- a/test/examples/CuTeDSL/sm_100a/test_rmsnorm.py
+++ b/test/examples/CuTeDSL/sm_100a/test_rmsnorm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The example showcases a memory bound rmsnorm kernel achieving above 6.5 TB/s on B200.

Unit test results:
```
$ pytest test/examples/CuTeDSL/sm_100a/test_rmsnorm.py -W ignore::pytest.PytestRemovedIn9Warning
==================================== test session starts ====================================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
...
collected 79 items                                                                          

test/examples/CuTeDSL/sm_100a/test_rmsnorm.py ....................................... [ 49%]
........................................                                              [100%]

==================================== 79 passed in 5.64s =====================================
```

Benchmark results from calling the script on B200
```
$ python examples/python/CuTeDSL/blackwell/rmsnorm.py --M 32768 --N 16384 --dtype BFloat16 --benchmark
Running RMSNorm test with:
  M: 32768, N: 16384
  dtype: BFloat16
  has_weight: True
  eps: 1e-06
  SM version: 100
  cluster_n: 1
  threads_per_row: 128
  rows_per_block: 1
Correctness check passed!

Benchmarking with 2 warmup, 100 iterations...
Kernel execution time: 329.54 us
Memory throughput: 6516.67 GB/s
PASS

$ python examples/python/CuTeDSL/blackwell/rmsnorm.py --M 32768 --N 32768 --dtype BFloat16 --benchmark
Running RMSNorm test with:
  M: 32768, N: 32768
  dtype: BFloat16
  has_weight: True
  eps: 1e-06
  SM version: 100
  cluster_n: 2
  threads_per_row: 128
  rows_per_block: 1
Correctness check passed!

Benchmarking with 2 warmup, 100 iterations...
Kernel execution time: 612.90 us
Memory throughput: 7007.68 GB/s
PASS
```