### PR TITLE
Fix incorrect tensor layout strides in Blackwell MMA tutorial comments

### DIFF
--- a/examples/cute/tutorial/blackwell/01_mma_sm100.cu
+++ b/examples/cute/tutorial/blackwell/01_mma_sm100.cu
@@ -179,9 +179,9 @@ gemm_device(ATensor mA,                      // (Gemm_M, Gemm_K)
     print("mD:\t"); print(mD); print("\n");   // mD:   gmem_ptr[32b](GMEM_ADDR_D) o (512,1024):(1024,_1)
 
     print("gA:\t"); print(gA); print("\n");   // gA:   gmem_ptr[16b](GMEM_ADDR_A + offset_for_mma_tile) o (_128,_64,4):(256,_1,_64)
-    print("gB:\t"); print(gB); print("\n");   // gB:   gmem_ptr[16b](GMEM_ADDR_B + offset_for_mma_tile) o (_256,_64,4):(_1,256,16384)
-    print("gC:\t"); print(gC); print("\n");   // gC:   gmem_ptr[32b](GMEM_ADDR_C + offset_for_mma_tile) o (_128,_256):(256,_1)
-    print("gD:\t"); print(gD); print("\n");   // gD:   gmem_ptr[32b](GMEM_ADDR_D + offset_for_mma_tile) o (_128,_256):(256,_1)
+    print("gB:\t"); print(gB); print("\n");   // gB:   gmem_ptr[16b](GMEM_ADDR_B + offset_for_mma_tile) o (_256,_64,4):(256,_1,_64)
+    print("gC:\t"); print(gC); print("\n");   // gC:   gmem_ptr[32b](GMEM_ADDR_C + offset_for_mma_tile) o (_128,_256):(1024,_1)
+    print("gD:\t"); print(gD); print("\n");   // gD:   gmem_ptr[32b](GMEM_ADDR_D + offset_for_mma_tile) o (_128,_256):(1024,_1)
   } __syncthreads();
 
   // The SMEM tensors
@@ -209,9 +209,9 @@ gemm_device(ATensor mA,                      // (Gemm_M, Gemm_K)
 
   if (thread0()) {
     print("tCgA:\t"); print(tCgA); print("\n");  // tCgA:   gmem_ptr[16b](GMEM_ADDR_A + offset_for_mma_tile + offset_for_mma) o ((_128,_16),_1,_4,4):((256,_1),_0,_16,_64)
-    print("tCgB:\t"); print(tCgB); print("\n");  // tCgB:   gmem_ptr[16b](GMEM_ADDR_B + offset_for_mma_tile + offset_for_mma) o ((_256,_16),_1,_4,4):((_1,256),_0,4096,16384)
-    print("tCgC:\t"); print(tCgC); print("\n");  // tCgC:   gmem_ptr[32b](GMEM_ADDR_C + offset_for_mma_tile + offset_for_mma) o ((_128,_256),_1,_1):((256,_1),_0,_0)
-    print("tCgD:\t"); print(tCgD); print("\n");  // tCgD:   gmem_ptr[32b](GMEM_ADDR_D + offset_for_mma_tile + offset_for_mma) o ((_128,_256),_1,_1):((256,_1),_0,_0)
+    print("tCgB:\t"); print(tCgB); print("\n");  // tCgB:   gmem_ptr[16b](GMEM_ADDR_B + offset_for_mma_tile + offset_for_mma) o ((_256,_16),_1,_4,4):((256,_1),_0,_16,_64)
+    print("tCgC:\t"); print(tCgC); print("\n");  // tCgC:   gmem_ptr[32b](GMEM_ADDR_C + offset_for_mma_tile + offset_for_mma) o ((_128,_256),_1,_1):((1024,_1),_0,_0)
+    print("tCgD:\t"); print(tCgD); print("\n");  // tCgD:   gmem_ptr[32b](GMEM_ADDR_D + offset_for_mma_tile + offset_for_mma) o ((_128,_256),_1,_1):((1024,_1),_0,_0)
   } __syncthreads();
 
   // MMA Fragment Allocation


### PR DESCRIPTION
## Summary

  This PR fixes incorrect tensor layout stride values in the documentation comments of the Blackwell MMA tutorial (`01_mma_sm100.cu`). 
The details https://github.com/NVIDIA/cutlass/issues/2920

  ## Problem

  The comments documenting tensor layouts contained incorrect stride values that did not match the actual layouts produced by the code execution. This could confuse users learning from the tutorial.

  ## Changes

  Updated documentation comments for the following tensors in `examples/cute/tutorial/blackwell/01_mma_sm100.cu`:

  | Tensor | Previous Stride | Corrected Stride |
  |--------|----------------|------------------|
  | gB | `(_1,256,16384)` | `(256,_1,_64)` |
  | gC | `(256,_1)` | `(1024,_1)` |
  | gD | `(256,_1)` | `(1024,_1)` |
  | tCgB | `((_1,256),_0,4096,16384)` | `((256,_1),_0,_16,_64)` |
  | tCgC | `((256,_1),_0,_0)` | `((1024,_1),_0,_0)` |
  | tCgD | `((256,_1),_0,_0)` | `((1024,_1),_0,_0)` |

<img width="718" height="317" alt="image" src="https://github.com/user-attachments/assets/dec1addc-cfc1-4a03-9580-a39ad6801f65" />  

## Testing

  - [x] Verified stride values match actual runtime output
  - [x] Confirmed tutorial still compiles and runs correctly

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Documentation update
  - [ ] Verified stride values match actual runtime output
  - [ ] Confirmed tutorial still compiles and runs correctly

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Documentation update