### PR TITLE
Minor fix for testing of blockscaled dense GEMM with TMA prefetch

### DIFF
--- a/test/examples/CuTeDSL/sm_100a/test_dense_blockscaled_gemm_persistent_prefetch.py
+++ b/test/examples/CuTeDSL/sm_100a/test_dense_blockscaled_gemm_persistent_prefetch.py
@@ -47,7 +47,7 @@ from blackwell.dense_blockscaled_gemm_persistent_prefetch import (
 )
 
 import cutlass
-
+pytestmark = [pytest.mark.arch(["100a"])]
 
 @pytest.mark.invalid_case(
     lambda: not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
@@ -66,8 +66,6 @@ import cutlass
         c_major,
     )
 )
-
-@pytest.mark.arch("100a")
 @pytest.mark.parametrize(
     "mnkl",
     [


### PR DESCRIPTION
Only support sm100a as testing arch