### PR TITLE
cutlass profiler - align emitted SFA/SFB kernel naming with typical convention

### DIFF
--- a/python/cutlass_library/gemm_operation.py
+++ b/python/cutlass_library/gemm_operation.py
@@ -274,7 +274,7 @@ class GemmOperation:
     if is_blockwise(self.gemm_kind):
       d_type_names = DataTypeNames[self.D.element]
 
-      extended_name = "{core_name}_{sfvec_m_size}x{sfvec_k_size}{element_sfa}x{element_a}_{sfvec_n_size}x{sfvec_k_size}{element_sfb}x{element_b}_{element_acc}_{element_c}_{element_d}".format(
+      extended_name = "{core_name}_{sfvec_m_size}x{sfvec_k_size}{element_sfa}x{element_a}_{sfvec_k_size}x{sfvec_n_size}{element_sfb}x{element_b}_{element_acc}_{element_c}_{element_d}".format(
         element_sfa = DataTypeNames[self.accumulator_type()],
         element_a = DataTypeNames[self.A.element],
         element_sfb = DataTypeNames[self.accumulator_type()],


### PR DESCRIPTION
This one tripped me up a bit - typically we denote A.shape=m x k and B.shape=k x n, but the scales in SFB are ordered backwards (n x k)

This PR swaps the SFA/SFB naming order so it follows the standard m × k, k × n convention.

Note: This is a backward-incompatible change for kernel filters but my sense is that SFA/SFB isn’t commonly used for filtering, but let me know if we should add any compatibility handling.

cc @hwu36 @depaulmillz 