### PR TITLE
Fix out-of-bounds TMA access in wgmma_tma_sm90 tutorial

### DIFF
--- a/examples/cute/tutorial/hopper/wgmma_tma_sm90.cu
+++ b/examples/cute/tutorial/hopper/wgmma_tma_sm90.cu
@@ -236,7 +236,8 @@ gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
     ConsumerBarType::arrive(&consumer_mbar[read_pipe]);
     ++read_state;
 
-    if ((warp_idx == 0) && lane_predicate)
+    // Only issue new TMA copies if there are more tiles to fetch
+    if ((warp_idx == 0) && lane_predicate && (k_tile_count > 0))
     {
       int pipe = write_state.index();
       // Wait for Consumer to complete consumption


### PR DESCRIPTION
Add <code inline="">k_tile_count</code> guard to prevent TMA copies during pipeline drain https://github.com/NVIDIA/cutlass/issues/2944 </strong></p><hr><p><strong>Summary</strong></p><p>This PR fixes an out-of-bounds memory access bug in <code inline="">wgmma_tma_sm90.cu</code><br>that occurred during the pipeline drain phase.</p><p>The main loop continued issuing TMA copy operations even after<br><code inline="">k_tile_count &lt;= 0</code>, leading to invalid accesses to the <code inline="">tAgA</code> and <code inline="">tBgB</code><br>tensors once <code inline="">k_tile</code> advanced beyond the valid tile range.</p><p>The fix adds a guard to ensure that new TMA copies are only issued when<br>valid tiles remain. During the drain phase, the loop now correctly<br>consumes only pre-fetched data already present in the pipeline.</p><hr><p><strong>Problem</strong></p><ul><li><p>During the pipeline drain phase, <code inline="">k_tile</code> continues to increment</p></li><li><p>TMA copy operations were still issued when <code inline="">k_tile_count &lt;= 0</code></p></li><li><p>This resulted in out-of-bounds memory accesses to: tAgA and tBgB</code></p></li></ul></li></ul><hr><p><strong>Solution</strong></p><ul><li><p>Add a <code inline="">k_tile_count &gt; 0</code> guard before issuing TMA copy operations</p></li><li><p>During the drain phase (<code inline="">k_tile_count &lt;= 0</code>):</p><ul><li><p>No new TMA copies are issued</p></li><li><p>The loop consumes only previously fetched pipeline data</p></li></ul></li></ul><hr><p><strong>Changes</strong></p><ul><li><p>Add <code inline="">k_tile_count &gt; 0</code> guard before TMA copy (line 240)</p></li><li><p>Add an explanatory comment clarifying drain-phase behavior</p></li></ul><hr><p><strong>Impact</strong></p><ul><li><p>Prevents potential memory corruption</p></li><li><p>Ensures correct and safe TMA pipeline usage</p></li><li><p>Makes the tutorial code more robust and semantically correct</p></li></ul><hr><p><strong>Performance Results</strong></p>
Performance | 11,845.5 GFLOP/s | 12,503.9 GFLOP/s
Exec Time | 0.0227 ms | 0.0215 ms

</div></div>
<p data-start="1816" data-end="1831"><strong data-start="1816" data-end="1831">Improvement</strong></p>
<ul data-start="1832" data-end="1903">
<li data-start="1832" data-end="1871">
<p data-start="1834" data-end="1871"><strong data-start="1834" data-end="1852">+658.4 GFLOP/s</strong> (<strong data-start="1854" data-end="1870">~5.6% faster</strong>)</p>
</li>
<li data-start="1872" data-end="1903">
<p data-start="1874" data-end="1903"><strong data-start="1874" data-end="1888">−0.0012 ms</strong> execution time</p>
</li>
</ul>

<img width="971" height="83" alt="image" src="https://github.com/user-attachments/assets/6454ada2-00c4-41fd-9d4a-af83b7b4398c" />

