### PR TITLE
fix performance regression in cute-dsl examples for 4.4-ctk13.1 release 

### DIFF
--- a/examples/python/CuTeDSL/blackwell/blockwise_gemm/blockwise_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/blockwise_gemm/blockwise_gemm.py
@@ -2685,7 +2685,7 @@ def run(
     torch_stream = torch.cuda.current_stream()
     # Get the raw stream pointer as a CUstream
     current_stream = cuda.CUstream(torch_stream.cuda_stream)
-    # try to check CUDA version to decide the opt level 3
+    # try to check CUDA version to decide the opt level
     try:
         from cutlass import CUDA_VERSION
         opt_level = (


### PR DESCRIPTION
1. add opt level to blockwise gemm example for ctk13.1
2. change register config for ctk13.1 (not cause perf drop for ctk12.9)