### PR TITLE
[CuTeDSL] Fix: SM100 block-scale gemm overlapping accumulator

### DIFF
--- a/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py
+++ b/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py
@@ -210,17 +210,18 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
         self.mma_warp_id = 4
         self.tma_warp_id = 5
-        self.threads_per_cta = 32 * len(
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
             (self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id)
         )
         # Set barrier id for epilogue sync and tmem ptr sync
         self.epilog_sync_barrier = pipeline.NamedBarrier(
             barrier_id=1,
-            num_threads=32 * len(self.epilog_warp_id),
+            num_threads=self.threads_per_warp * len(self.epilog_warp_id),
         )
         self.tmem_alloc_barrier = pipeline.NamedBarrier(
             barrier_id=2,
-            num_threads=32 * len((self.mma_warp_id, *self.epilog_warp_id)),
+            num_threads=self.threads_per_warp * len((self.mma_warp_id, *self.epilog_warp_id)),
         )
         self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
         SM100_TMEM_CAPACITY_COLUMNS = 512
@@ -754,7 +755,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         # Initialize acc_pipeline (barrier) and states
         acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        num_acc_consumer_threads = len(self.epilog_warp_id) * (
+        num_acc_consumer_threads = self.threads_per_warp * len(self.epilog_warp_id) * (
             2 if use_2cta_instrs else 1
         )
         acc_pipeline_consumer_group = pipeline.CooperativeGroup(
@@ -1365,7 +1366,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             # Threads/warps participating in tma store pipeline
             c_producer_group = pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
-                32 * len(self.epilog_warp_id),
+                self.threads_per_warp * len(self.epilog_warp_id),
             )
             c_pipeline = pipeline.PipelineTmaStore.create(
                 num_stages=self.num_c_stage,
@@ -1438,8 +1439,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         if subtile_idx == self.iter_acc_early_release_in_epilogue:
                             # Fence for TMEM load
                             cute.arch.fence_view_async_tmem_load()
-                            with cute.arch.elect_one():
-                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
 
                     #
@@ -1480,8 +1480,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # Async arrive accumulator buffer empty
                 #
                 if cutlass.const_expr(not self.overlapping_accum):
-                    with cute.arch.elect_one():
-                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
 
                 #


### PR DESCRIPTION
The following command triggers the error:

```bash
$ python dense_blockscaled_gemm_persistent.py --mma_tiler_mn 256,256 --cluster_shape_mn 2,1 --mnkl 16384,2048,512,1
Running Sm100 Persistent Dense BlockScaled GEMM test with:
mnkl: (16384, 2048, 512, 1)
AB dtype: Float4E2M1FN, SF dtype: Float8E8M0FNU, SF Vec size: 16
C dtype: Float16
Matrix majors - A: k, B: k, C: n
Mma Tiler (M, N): (256, 256), Cluster Shape (M, N): (2, 1)
Tolerance: 0.1
Warmup iterations: 0
Iterations: 1
Skip reference checking: False
Use cold L2: False
Verifying results...
Traceback (most recent call last):
  File "/home/scratch.huah_gpu/cutlass-github/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py", line 2521, in <module>
    run(
  File "/home/scratch.huah_gpu/cutlass-github/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py", line 2372, in run
    torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
  File "/home/huah/scratch.huah_gpu/miniconda3/envs/py3.12-cu13/lib/python3.12/site-packages/torch/testing/_comparison.py", line 1589, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 499601 / 33554432 (1.5%)
Greatest absolute difference: 629.0 at index (8810, 480, 0) (up to 0.1 allowed)
Greatest relative difference: inf at index (2284, 769, 0) (up to 0.01 allowed)
```


This PR fixes one bug: when using overlapping accumulator, `real_subtile_idx` was used for smem buffer index `c_buffer`, leading to collision on two phases.

This PR also improves the logic of computing `iter_acc_early_release_in_epilogue` for early release in overlapping accumulator. See the comments for the reason of change.

All changes have been tested locally on a B200 GPU.

