### PR TITLE
[CuTeDSL] Add sub_packed_f32x2 operation

### DIFF
--- a/python/CuTeDSL/cutlass/cute/arch/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/arch/__init__.py
@@ -96,6 +96,7 @@ __all__ = [
     "fma_packed_f32x2",
     "mul_packed_f32x2",
     "add_packed_f32x2",
+    "sub_packed_f32x2",
     "fmax",
     "rcp_approx",
     "exp2",

--- a/python/CuTeDSL/cutlass/cute/arch/nvvm_wrappers.py
+++ b/python/CuTeDSL/cutlass/cute/arch/nvvm_wrappers.py
@@ -940,6 +940,9 @@ mul_packed_f32x2 = partial(
 add_packed_f32x2 = partial(
     calc_packed_f32x2_op, src_c=None, calc_func=nvvm.add_packed_f32x2
 )
+sub_packed_f32x2 = partial(
+    calc_packed_f32x2_op, src_c=None, calc_func=nvvm.sub_packed_f32x2
+)
 
 
 @dsl_user_op


### PR DESCRIPTION
Add subtraction operation for packed f32x2 values, following the same pattern as the existing add_packed_f32x2 and mul_packed_f32x2 operations.

We use this for some activation functions:
https://github.com/Dao-AILab/quack/blob/62258f911a43d253d7e6484c98ab44bc82f649e1/quack/activation.py#L444