### PR TITLE
[CuTeDSL] implment a cta-level norm example (both layernorm and rmsnorm)

### DIFF
--- a/examples/python/CuTeDSL/hopper/cta_norm.py
+++ b/examples/python/CuTeDSL/hopper/cta_norm.py
@@ -1,4 +1,30 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
 import torch


### PR DESCRIPTION
### Overview

This PR implemented LayerNorm and RMSNorm as a small CuTeDSL example.

On H200 and A100, this implementation runs faster than PyTorch’s native LayerNorm and RMSNorm.

This PR includes:

- Implementations of LayerNorm and RMSNorm
- Support for FP16, BF16, and FP32
- An assumption that the hidden size is a multiple of 8
- User-configurable threads count for finer-grained performance tuning

This PR intentionally does not cover the following cases:

- Hidden sizes that are not multiples of 8, which are rarely encountered in LLM workloads.
- Very small hidden sizes (e.g. 128 or 256), where a warp-level norm would be more efficient than a cta-level norm. This is left to a separate example to keep the kernel simple.

### Example

```
# A100
# python cta_norm.py --N 8192 --benchmark
Running CtaNorm test with:
Tensor dimensions: [4096, 8192]
Input and Output Data type: Float16
Input tensor shapes:
x: torch.Size([4096, 8192]), dtype: torch.float16
weight: torch.Size([8192]), dtype: torch.float16
bias: torch.Size([8192]), dtype: torch.float16
y: torch.Size([4096, 8192]), dtype: torch.float16

Compiling kernel with cute.compile ...
[DSL INFO] Input Tensors:
[DSL INFO]   mY = !cute.memref<f16, gmem, align<16>, "(4096,8192):(8192,1)">
[DSL INFO]   mX = !cute.memref<f16, gmem, align<16>, "(4096,8192):(8192,1)">
[DSL INFO]   mWeight = !cute.memref<f16, gmem, align<16>, "(8192):(1)">
[DSL INFO]   mBias = !cute.memref<f16, gmem, align<16>, "(8192):(1)">
[DSL INFO] Tiling Parameters:
[DSL INFO]   tiled_copy = Tiled Copy
  Tiler MN:        (2048:1)
  TV Layout tiled: (256,8):(8,1)
Copy Atom
  ThrID:           1:0
  TV Layout Src:   (1,8):(0,1)
  TV Layout Dst:   (1,8):(0,1)
  Value type:      f16
[DSL INFO] Tiled Tensors:
[DSL INFO]   gY = !cute.memref<f16, gmem, align<16>, "(8192):(1)">
[DSL INFO]   gX = !cute.memref<f16, gmem, align<16>, "(8192):(1)">
[DSL INFO] Sliced Tensors per thread:
[DSL INFO]   tYgY = !cute.memref<f16, gmem, align<16>, "((8,1),(4)):((1,0),(2048))">
[DSL INFO]   tXgX = !cute.memref<f16, gmem, align<16>, "((8,1),(4)):((1,0),(2048))">
[DSL INFO]   tWgW = !cute.memref<f16, gmem, align<16>, "((8,1),(4)):((1,0),(2048))">
[DSL INFO]   tBgB = !cute.memref<f16, gmem, align<16>, "((8,1),(4)):((1,0),(2048))">
[DSL INFO]   pred = !cute.memref<i8, rmem, align<32>, "4:1">
Compilation time: 0.4172 seconds
Executing vector add kernel...
Verifying results...
Results verified successfully!

CuTe layernorm kernel
Kernel execution time: 0.0844 ms
Achieved memory throughput: 1591.07 GB/s

PyTorch layernorm reference
Kernel execution time: 0.1410 ms
Achieved memory throughput: 951.82 GB/s

PASS
```

### Accuracy test

`python examples/python/CuTeDSL/hopper/cta_norm.py`

### Benchmark

common setup: M=4096, dtype=bfloat16

One reason this kernel runs faster than the native PyTorch implementation may be that it assumes N is a multiple of 8, which allows the use of 128-bit vectorized loads and stores.

#### H200 layernorm 

| Case | CuTe Throughput (GB/s) | PyTorch Throughput (GB/s) | Speedup |
|------|------------------------|---------------------------|---------|
| LayerNorm N=512 | 1171.67 | 811.64 | 1.44× |
| LayerNorm N=1024 | 1957.14 | 1280.88 | 1.53× |
| LayerNorm N=1536 | 2198.26 | 1584.40 | 1.39× |
| LayerNorm N=2048 | 2634.99 | 1815.03 | 1.45× |
| LayerNorm N=3072 | 2664.35 | 1997.29 | 1.33× |
| LayerNorm N=4096 | 3207.63 | 2092.50 | 1.53× |
| LayerNorm N=8192 | 3510.29 | 2129.49 | 1.65× |
| LayerNorm N=16384 | 2583.21 | 2159.28 | 1.20× |

#### H200 rmsnorm

| Case | CuTe Throughput (GB/s) | PyTorch Throughput (GB/s) | Speedup |
|------|------------------------|---------------------------|---------|
| LayerNorm N=512 | 1436.44 | 1364.60 | 1.05× |
| LayerNorm N=1024 | 2045.70 | 1988.68 | 1.03× |
| LayerNorm N=1536 | 2742.09 | 2422.84 | 1.13× |
| LayerNorm N=2048 | 2711.28 | 2618.61 | 1.04× |
| LayerNorm N=3072 | 3327.37 | 2619.77 | 1.27× |
| LayerNorm N=4096 | 3319.88 | 2656.82 | 1.25× |
| LayerNorm N=8192 | 3686.32 | 2453.49 | 1.50× |
| LayerNorm N=16384 | 3950.31 | 2353.04 | 1.68× |

#### A100 layernorm

| Case | CuTe Throughput (GB/s) | PyTorch Throughput (GB/s) | Speedup |
|------|------------------------|---------------------------|---------|
| LayerNorm N=512 | 899.45 | 432.63 | 2.08× |
| LayerNorm N=1024 | 1062.78 | 673.30 | 1.58× |
| LayerNorm N=1536 | 1265.81 | 819.40 | 1.54× |
| LayerNorm N=2048 | 1267.44 | 877.54 | 1.44× |
| LayerNorm N=3072 | 1419.28 | 976.44 | 1.45× |
| LayerNorm N=4096 | 1459.96 | 1032.15 | 1.41× |
| LayerNorm N=8192 | 1589.91 | 950.24 | 1.67× |
| LayerNorm N=16384 | 1465.83 | 936.99 | 1.56× |

#### A100 rmsnorm

| Case | CuTe Throughput (GB/s) | PyTorch Throughput (GB/s) | Speedup |
|------|------------------------|---------------------------|---------|
| LayerNorm N=512 | 945.10 | 724.49 | 1.30× |
| LayerNorm N=1024 | 1215.73 | 1068.32 | 1.14× |
| LayerNorm N=1536 | 1323.04 | 1205.00 | 1.10× |
| LayerNorm N=2048 | 1321.08 | 1148.42 | 1.15× |
| LayerNorm N=3072 | 1481.74 | 1183.25 | 1.25× |
| LayerNorm N=4096 | 1481.07 | 1217.08 | 1.22× |
| LayerNorm N=8192 | 1607.26 | 1001.86 | 1.60× |
| LayerNorm N=16384 | 1676.41 | 980.03 | 1.71× |