### PR TITLE
[Cute-DSL] Add option for issue_clc_query without multicast

### DIFF
--- a/python/CuTeDSL/cutlass/cute/arch/clc.py
+++ b/python/CuTeDSL/cutlass/cute/arch/clc.py
@@ -23,6 +23,7 @@ from ..typing import Int32, Pointer, Int128
 def issue_clc_query(
     mbar_ptr: Pointer,
     clc_response_ptr: Pointer,
+    multicast: bool = True,
     loc=None,
     ip=None,
 ) -> None:
@@ -39,12 +40,20 @@ def issue_clc_query(
     """
     mbar_llvm_ptr = mbar_ptr.llvm_ptr
     clc_response_llvm_ptr = clc_response_ptr.llvm_ptr
-    nvvm.clusterlaunchcontrol_try_cancel_multicast(
-        clc_response_llvm_ptr,
-        mbar_llvm_ptr,
-        loc=loc,
-        ip=ip,
-    )
+    if multicast:
+        nvvm.clusterlaunchcontrol_try_cancel_multicast(
+            clc_response_llvm_ptr,
+            mbar_llvm_ptr,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        nvvm.clusterlaunchcontrol_try_cancel(
+            clc_response_llvm_ptr,
+            mbar_llvm_ptr,
+            loc=loc,
+            ip=ip,
+        )
 
 
 @dsl_user_op


### PR DESCRIPTION
We're using this in `quack` where only 1 warp in the cluster issue the CLC query, get the query, swizzle to find (cid_m, cid_n), write those to smem, then all other warps in the cluster can read from smem.
https://github.com/Dao-AILab/quack/blob/2bf4e72e296dc322fd94ee19f11d1f1bd0afbc31/quack/utils.py#L263