### PR TITLE
[CuTeDSL] Flash Attention v2 for SM120 (Blackwell GeForce)

### DIFF
--- a/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Benchmark FP8 vs BF16 Flash Attention on SM120 (DGX Spark / GB10).
+
+Runs both kernels across a sweep of configs and prints a comparison table.
+"""
+import argparse
+import sys
+import os
+import torch
+import cuda.bindings.driver as cuda
+
+# Add parent path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import cutlass
+import cutlass.cute as cute
+
+
+def compute_flops(B, H, Sq, Sk, D, is_causal):
+    flops = 4 * B * H * Sq * Sk * D
+    if is_causal:
+        flops //= 2
+    return flops
+
+
+def run_fp8(B, Sq, Sk, H, D, is_causal, warmup, iters, skip_ref):
+    from fp8_flash_attention import run_benchmark
+    try:
+        return run_benchmark(
+            B, Sq, Sk, H, D,
+            is_causal=is_causal,
+            warmup_iterations=warmup,
+            iterations=iters,
+            skip_ref_check=skip_ref,
+            use_opt=True,
+        )
+    except Exception as e:
+        print(f"  FP8 failed: {e}")
+        return None
+
+
+def run_bf16(B, Sq, Sk, H, D, is_causal, warmup, iters, skip_ref):
+    from flash_attention_v2 import run as run_bf16_impl
+    try:
+        return run_bf16_impl(
+            cutlass.BFloat16, B, Sq, Sk, H, D,
+            softmax_scale=1.0 / (D ** 0.5),
+            m_block_size=128, n_block_size=64, num_threads=128,
+            is_causal=is_causal,
+            warmup_iterations=warmup,
+            iterations=iters,
+            skip_ref_check=skip_ref,
+        )
+    except Exception as e:
+        print(f"  BF16 failed: {e}")
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FP8 vs BF16 FA Benchmark")
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--skip_ref", action="store_true",
+                        help="Skip reference correctness check")
+    parser.add_argument("--quick", action="store_true",
+                        help="Run a small subset of configs")
+    args = parser.parse_args()
+
+    configs = [
+        # (B, SeqLen, HeadDim, Causal)
+        (1, 512, 64, False),
+        (1, 512, 64, True),
+        (1, 512, 128, False),
+        (1, 512, 128, True),
+        (1, 1024, 64, False),
+        (1, 1024, 64, True),
+        (1, 1024, 128, False),
+        (1, 1024, 128, True),
+        (1, 2048, 64, False),
+        (1, 2048, 64, True),
+        (1, 2048, 128, False),
+        (1, 2048, 128, True),
+        (4, 512, 64, False),
+        (4, 512, 128, False),
+        (4, 1024, 64, False),
+        (4, 1024, 128, False),
+    ]
+
+    if args.quick:
+        configs = [
+            (1, 512, 128, False),
+            (1, 1024, 128, False),
+            (1, 2048, 128, False),
+            (4, 1024, 128, False),
+        ]
+
+    H = 16  # Fixed heads across all configs
+
+    results = []
+    for B, S, D, causal in configs:
+        label = f"B={B} S={S:4d} D={D:3d} {'causal' if causal else '      '}"
+        print(f"\n{'='*60}")
+        print(f"Config: {label}")
+        print(f"{'='*60}")
+
+        fp8_us = run_fp8(B, S, S, H, D, causal, args.warmup, args.iters, args.skip_ref)
+        bf16_us = run_bf16(B, S, S, H, D, causal, args.warmup, args.iters, args.skip_ref)
+
+        flops = compute_flops(B, H, S, S, D, causal)
+        fp8_tflops = flops / (fp8_us * 1e-6) / 1e12 if fp8_us else None
+        bf16_tflops = flops / (bf16_us * 1e-6) / 1e12 if bf16_us else None
+        speedup = bf16_us / fp8_us if (fp8_us and bf16_us) else None
+
+        results.append((B, S, D, causal, fp8_us, bf16_us, fp8_tflops, bf16_tflops, speedup))
+
+    # Print summary table
+    print(f"\n\n{'='*120}")
+    print("BENCHMARK RESULTS: FP8 (kind::f8f6f4.m16n8k32) vs BF16 (mma.sync.m16n8k16)")
+    print(f"FP8 kernel: FP8FlashAttentionSm120Opt (CpAsync, bank-conflict-free, 4 warps, M=64, N=32)")
+    print(f"BF16 kernel: FlashAttentionForwardSm120 (CpAsync, tiled MMA, M=128, N=64)")
+    print(f"Device: {torch.cuda.get_device_name(0)}")
+    print(f"Heads: {H}, Warmup: {args.warmup}, Iterations: {args.iters}")
+    print(f"{'='*120}")
+    print(f"| {'Batch':>5} | {'SeqLen':>6} | {'HeadDim':>7} | {'Causal':>6} | "
+          f"{'FP8 (μs)':>10} | {'BF16 (μs)':>10} | "
+          f"{'FP8 TFLOPS':>10} | {'BF16 TFLOPS':>11} | {'Ratio':>8} |")
+    print(f"|{'-'*7}|{'-'*8}|{'-'*9}|{'-'*8}|"
+          f"{'-'*12}|{'-'*12}|{'-'*12}|{'-'*13}|{'-'*10}|")
+
+    for B, S, D, causal, fp8_us, bf16_us, fp8_tf, bf16_tf, spd in results:
+        fp8_str = f"{fp8_us:10.1f}" if fp8_us else "     FAIL"
+        bf16_str = f"{bf16_us:10.1f}" if bf16_us else "     FAIL"
+        fp8_tf_str = f"{fp8_tf:10.2f}" if fp8_tf else "       N/A"
+        bf16_tf_str = f"{bf16_tf:11.2f}" if bf16_tf else "        N/A"
+        if spd is not None:
+            spd_str = f"{spd:.2f}x"
+        else:
+            spd_str = "     N/A"
+        print(f"| {B:>5} | {S:>6} | {D:>7} | {'yes' if causal else 'no':>6} | "
+              f"{fp8_str} | {bf16_str} | {fp8_tf_str} | {bf16_tf_str} | {spd_str:>8} |")
+
+    # Print markdown table for PR comment
+    print(f"\n\n### Markdown table for PR:")
+    print(f"| Batch | SeqLen | HeadDim | Causal | FP8 (μs) | BF16 (μs) | "
+          f"FP8 TFLOPS | BF16 TFLOPS | Ratio |")
+    print(f"|:-----:|:------:|:-------:|:------:|----------:|----------:|"
+          f"-----------:|------------:|:-----:|")
+    for B, S, D, causal, fp8_us, bf16_us, fp8_tf, bf16_tf, spd in results:
+        fp8_str = f"{fp8_us:.1f}" if fp8_us else "FAIL"
+        bf16_str = f"{bf16_us:.1f}" if bf16_us else "FAIL"
+        fp8_tf_str = f"{fp8_tf:.2f}" if fp8_tf else "N/A"
+        bf16_tf_str = f"{bf16_tf:.2f}" if bf16_tf else "N/A"
+        spd_str = f"{spd:.2f}x" if spd is not None else "N/A"
+        print(f"| {B} | {S} | {D} | {'yes' if causal else 'no'} | "
+              f"{fp8_str} | {bf16_str} | {fp8_tf_str} | {bf16_tf_str} | {spd_str} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
@@ -1,4 +1,31 @@
-#!/usr/bin/env python3
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 """Benchmark FP8 vs BF16 Flash Attention on SM120 (DGX Spark / GB10).
 
 Runs both kernels across a sweep of configs and prints a comparison table.

--- a/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
@@ -28,7 +28,10 @@
 
 """Benchmark FP8 vs BF16 Flash Attention on SM120 (DGX Spark / GB10).
 
-Runs both kernels across a sweep of configs and prints a comparison table.
+Compares three kernels across a sweep of configs:
+  - FP8FlashAttentionSm120Opt (CpAsync, M=64 N=32)
+  - FP8FlashAttentionSm120Tma (TMA + warp specialization, M=128 N=64)
+  - FlashAttentionForwardSm120 (BF16 CpAsync, M=128 N=64)
 """
 import argparse
 import sys
@@ -63,6 +66,21 @@ def run_fp8(B, Sq, Sk, H, D, is_causal, warmup, iters, skip_ref):
         )
     except Exception as e:
         print(f"  FP8 failed: {e}")
+        return None
+
+
+def run_fp8_tma(B, Sq, Sk, H, D, is_causal, warmup, iters, skip_ref):
+    from fp8_flash_attention_tma import run_benchmark as run_fp8_tma_impl
+    try:
+        return run_fp8_tma_impl(
+            B, Sq, Sk, H, D,
+            is_causal=is_causal,
+            warmup_iterations=warmup,
+            iterations=iters,
+            skip_ref_check=skip_ref,
+        )
+    except Exception as e:
+        print(f"  FP8 TMA failed: {e}")
         return None
 
 
@@ -131,55 +149,74 @@ def main():
         print(f"{'='*60}")
 
         fp8_us = run_fp8(B, S, S, H, D, causal, args.warmup, args.iters, args.skip_ref)
+        fp8_tma_us = run_fp8_tma(B, S, S, H, D, causal, args.warmup, args.iters, args.skip_ref)
         bf16_us = run_bf16(B, S, S, H, D, causal, args.warmup, args.iters, args.skip_ref)
 
         flops = compute_flops(B, H, S, S, D, causal)
         fp8_tflops = flops / (fp8_us * 1e-6) / 1e12 if fp8_us else None
+        fp8_tma_tflops = flops / (fp8_tma_us * 1e-6) / 1e12 if fp8_tma_us else None
         bf16_tflops = flops / (bf16_us * 1e-6) / 1e12 if bf16_us else None
-        speedup = bf16_us / fp8_us if (fp8_us and bf16_us) else None
+        # Speedup of FP8 TMA over the next-best of {FP8 Opt, BF16}
+        speedup_vs_fp8 = fp8_us / fp8_tma_us if (fp8_us and fp8_tma_us) else None
+        speedup_vs_bf16 = bf16_us / fp8_tma_us if (bf16_us and fp8_tma_us) else None
 
-        results.append((B, S, D, causal, fp8_us, bf16_us, fp8_tflops, bf16_tflops, speedup))
+        results.append((
+            B, S, D, causal, fp8_us, fp8_tma_us, bf16_us,
+            fp8_tflops, fp8_tma_tflops, bf16_tflops,
+            speedup_vs_fp8, speedup_vs_bf16,
+        ))
 
     # Print summary table
-    print(f"\n\n{'='*120}")
+    print(f"\n\n{'='*140}")
     print("BENCHMARK RESULTS: FP8 (kind::f8f6f4.m16n8k32) vs BF16 (mma.sync.m16n8k16)")
-    print(f"FP8 kernel: FP8FlashAttentionSm120Opt (CpAsync, bank-conflict-free, 4 warps, M=64, N=32)")
-    print(f"BF16 kernel: FlashAttentionForwardSm120 (CpAsync, tiled MMA, M=128, N=64)")
+    print(f"FP8 Opt:   FP8FlashAttentionSm120Opt   (CpAsync, 4 warps, M=64, N=32)")
+    print(f"FP8 TMA:   FP8FlashAttentionSm120Tma   (TMA + warp specialization, M=128, N=64)")
+    print(f"BF16:      FlashAttentionForwardSm120  (CpAsync, tiled MMA, M=128, N=64)")
     print(f"Device: {torch.cuda.get_device_name(0)}")
     print(f"Heads: {H}, Warmup: {args.warmup}, Iterations: {args.iters}")
-    print(f"{'='*120}")
-    print(f"| {'Batch':>5} | {'SeqLen':>6} | {'HeadDim':>7} | {'Causal':>6} | "
-          f"{'FP8 (μs)':>10} | {'BF16 (μs)':>10} | "
-          f"{'FP8 TFLOPS':>10} | {'BF16 TFLOPS':>11} | {'Ratio':>8} |")
-    print(f"|{'-'*7}|{'-'*8}|{'-'*9}|{'-'*8}|"
-          f"{'-'*12}|{'-'*12}|{'-'*12}|{'-'*13}|{'-'*10}|")
+    print(f"{'='*140}")
+    print(f"| {'B':>3} | {'S':>5} | {'D':>3} | {'Cau':>3} | "
+          f"{'FP8 Opt μs':>10} | {'FP8 TMA μs':>10} | {'BF16 μs':>9} | "
+          f"{'TMA TFLOPS':>10} | {'TMA/Opt':>7} | {'TMA/BF16':>8} |")
+    print(f"|{'-'*5}|{'-'*7}|{'-'*5}|{'-'*5}|"
+          f"{'-'*12}|{'-'*12}|{'-'*11}|{'-'*12}|{'-'*9}|{'-'*10}|")
 
-    for B, S, D, causal, fp8_us, bf16_us, fp8_tf, bf16_tf, spd in results:
-        fp8_str = f"{fp8_us:10.1f}" if fp8_us else "     FAIL"
-        bf16_str = f"{bf16_us:10.1f}" if bf16_us else "     FAIL"
-        fp8_tf_str = f"{fp8_tf:10.2f}" if fp8_tf else "       N/A"
-        bf16_tf_str = f"{bf16_tf:11.2f}" if bf16_tf else "        N/A"
-        if spd is not None:
-            spd_str = f"{spd:.2f}x"
-        else:
-            spd_str = "     N/A"
-        print(f"| {B:>5} | {S:>6} | {D:>7} | {'yes' if causal else 'no':>6} | "
-              f"{fp8_str} | {bf16_str} | {fp8_tf_str} | {bf16_tf_str} | {spd_str:>8} |")
+    sum_opt = sum_tma = sum_bf16 = 0.0
+    n_done = 0
+    for (B, S, D, causal, fp8_us, fp8_tma_us, bf16_us,
+         fp8_tf, fp8_tma_tf, bf16_tf, spd_opt, spd_bf16) in results:
+        opt_s = f"{fp8_us:10.1f}" if fp8_us else "     FAIL"
+        tma_s = f"{fp8_tma_us:10.1f}" if fp8_tma_us else "     FAIL"
+        bf16_s = f"{bf16_us:9.1f}" if bf16_us else "    FAIL"
+        tma_tf_s = f"{fp8_tma_tf:10.2f}" if fp8_tma_tf else "       N/A"
+        spd_o_s = f"{spd_opt:.2f}x" if spd_opt is not None else "  N/A"
+        spd_b_s = f"{spd_bf16:.2f}x" if spd_bf16 is not None else "   N/A"
+        if fp8_us and fp8_tma_us and bf16_us:
+            sum_opt += fp8_us; sum_tma += fp8_tma_us; sum_bf16 += bf16_us
+            n_done += 1
+        print(f"| {B:>3} | {S:>5} | {D:>3} | {'y' if causal else 'n':>3} | "
+              f"{opt_s} | {tma_s} | {bf16_s} | {tma_tf_s} | "
+              f"{spd_o_s:>7} | {spd_b_s:>8} |")
+    if n_done:
+        print(f"\nSum-time speedup (FP8 TMA vs FP8 Opt): {sum_opt/sum_tma:.2f}x")
+        print(f"Sum-time speedup (FP8 TMA vs BF16):    {sum_bf16/sum_tma:.2f}x")
 
     # Print markdown table for PR comment
     print(f"\n\n### Markdown table for PR:")
-    print(f"| Batch | SeqLen | HeadDim | Causal | FP8 (μs) | BF16 (μs) | "
-          f"FP8 TFLOPS | BF16 TFLOPS | Ratio |")
-    print(f"|:-----:|:------:|:-------:|:------:|----------:|----------:|"
-          f"-----------:|------------:|:-----:|")
-    for B, S, D, causal, fp8_us, bf16_us, fp8_tf, bf16_tf, spd in results:
-        fp8_str = f"{fp8_us:.1f}" if fp8_us else "FAIL"
-        bf16_str = f"{bf16_us:.1f}" if bf16_us else "FAIL"
-        fp8_tf_str = f"{fp8_tf:.2f}" if fp8_tf else "N/A"
-        bf16_tf_str = f"{bf16_tf:.2f}" if bf16_tf else "N/A"
-        spd_str = f"{spd:.2f}x" if spd is not None else "N/A"
+    print(f"| Batch | SeqLen | HeadDim | Causal | FP8 Opt (μs) | FP8 TMA (μs) | BF16 (μs) | "
+          f"TMA TFLOPS | TMA/Opt | TMA/BF16 |")
+    print(f"|:-----:|:------:|:-------:|:------:|------------:|------------:|----------:|"
+          f"-----------:|--------:|---------:|")
+    for (B, S, D, causal, fp8_us, fp8_tma_us, bf16_us,
+         fp8_tf, fp8_tma_tf, bf16_tf, spd_opt, spd_bf16) in results:
+        opt_s = f"{fp8_us:.1f}" if fp8_us else "FAIL"
+        tma_s = f"{fp8_tma_us:.1f}" if fp8_tma_us else "FAIL"
+        bf16_s = f"{bf16_us:.1f}" if bf16_us else "FAIL"
+        tma_tf_s = f"{fp8_tma_tf:.2f}" if fp8_tma_tf else "N/A"
+        spd_o_s = f"{spd_opt:.2f}x" if spd_opt is not None else "N/A"
+        spd_b_s = f"{spd_bf16:.2f}x" if spd_bf16 is not None else "N/A"
         print(f"| {B} | {S} | {D} | {'yes' if causal else 'no'} | "
-              f"{fp8_str} | {bf16_str} | {fp8_tf_str} | {bf16_tf_str} | {spd_str} |")
+              f"{opt_s} | {tma_s} | {bf16_s} | {tma_tf_s} | {spd_o_s} | {spd_b_s} |")
 
 
 if __name__ == "__main__":

--- a/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/benchmark_fp8_vs_bf16.py
@@ -30,7 +30,7 @@
 
 Compares three kernels across a sweep of configs:
   - FP8FlashAttentionSm120Opt (CpAsync, M=64 N=32)
-  - FP8FlashAttentionSm120Tma (TMA + warp specialization, M=128 N=64)
+  - FP8FlashAttentionSm120Tma (TMA + warp specialization, M=128, per-shape N)
   - FlashAttentionForwardSm120 (BF16 CpAsync, M=128 N=64)
 """
 import argparse
@@ -69,12 +69,26 @@ def run_fp8(B, Sq, Sk, H, D, is_causal, warmup, iters, skip_ref):
         return None
 
 
+def _pick_n_block(B, Sq, D, is_causal):
+    """Per-shape N tile selection.
+
+    Empirical: N=64 beats N=32 only for non-causal D=128 with high CTA count
+    (B≥4 and S in the medium range, or single-batch S=2048). Everywhere else
+    N=32 wins because the smaller tile reduces fixed per-K-iter overhead and
+    helps causal cases (which halve the work per CTA).
+    """
+    if (not is_causal) and D >= 128 and (B >= 4 or Sq >= 2048):
+        return 64
+    return 32
+
+
 def run_fp8_tma(B, Sq, Sk, H, D, is_causal, warmup, iters, skip_ref):
     from fp8_flash_attention_tma import run_benchmark as run_fp8_tma_impl
     try:
         return run_fp8_tma_impl(
             B, Sq, Sk, H, D,
             is_causal=is_causal,
+            n_block_size=_pick_n_block(B, Sq, D, is_causal),
             warmup_iterations=warmup,
             iterations=iters,
             skip_ref_check=skip_ref,
@@ -170,7 +184,7 @@ def main():
     print(f"\n\n{'='*140}")
     print("BENCHMARK RESULTS: FP8 (kind::f8f6f4.m16n8k32) vs BF16 (mma.sync.m16n8k16)")
     print(f"FP8 Opt:   FP8FlashAttentionSm120Opt   (CpAsync, 4 warps, M=64, N=32)")
-    print(f"FP8 TMA:   FP8FlashAttentionSm120Tma   (TMA + warp specialization, M=128, N=64)")
+    print(f"FP8 TMA:   FP8FlashAttentionSm120Tma   (TMA + warp specialization, M=128, N picked per shape: 64 if non-causal & D=128 & high-CTA, else 32)")
     print(f"BF16:      FlashAttentionForwardSm120  (CpAsync, tiled MMA, M=128, N=64)")
     print(f"Device: {torch.cuda.get_device_name(0)}")
     print(f"Heads: {H}, Warmup: {args.warmup}, Iterations: {args.iters}")

--- a/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
@@ -866,6 +866,838 @@ class FlashAttentionForwardSm120:
         return self._threadquad_reduce(val, lambda x, y: x + y)
 
 
+class FlashAttentionForwardSm120Tma:
+    """Flash Attention v2 for SM120 using TMA loads and warp specialization.
+
+    Uses TMA (cp.async.bulk) for global→shared memory transfers with a dedicated
+    DMA warp, while MMA warps perform computation. This enables overlapping loads
+    with compute via multi-stage KV pipelining.
+
+    Key differences from FlashAttentionForwardSm120 (CpAsync):
+      - TMA loads instead of CpAsync (hardware-managed bulk transfers)
+      - Warp specialization: 1 DMA warp + N MMA warps (vs all threads load+compute)
+      - PipelineTmaAsync with mbarrier synchronization
+      - Multi-stage KV double-buffering for load/compute overlap
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        m_block_size: int = 128,
+        n_block_size: int = 64,
+        num_mma_warps: int = 4,
+        kv_stages: int = 2,
+        is_causal: bool = False,
+    ):
+        self._head_dim = head_dim
+        self._m_block_size = m_block_size
+        self._n_block_size = n_block_size
+        self._head_dim_padded = (head_dim + 31) // 32 * 32
+        self._num_mma_warps = num_mma_warps
+        self._kv_stages = kv_stages
+        self._num_threads = (num_mma_warps + 1) * 32  # +1 for DMA warp
+        self._is_causal = is_causal
+
+        # NamedBarrier for MMA warps only (DMA warp does not participate)
+        self.mma_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1, num_threads=num_mma_warps * 32
+        )
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+
+    @staticmethod
+    def can_implement(
+        dtype, head_dim, m_block_size, n_block_size, num_mma_warps, kv_stages,
+        is_causal,
+    ) -> bool:
+        if dtype != cutlass.Float16 and dtype != cutlass.BFloat16:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        # m_block_size must be divisible by MMA tile M (num_mma_warps * 16)
+        if m_block_size % (num_mma_warps * 16) != 0:
+            return False
+        head_dim_padded = (head_dim + 31) // 32 * 32
+        # SMEM: sQ (1 stage) + sK (kv_stages) + sV (kv_stages) + mbar arrays
+        smem_q = m_block_size * head_dim_padded * (dtype.width // 8)
+        smem_kv = n_block_size * head_dim_padded * (dtype.width // 8) * kv_stages * 2
+        smem_mbar = (1 * 2 + kv_stages * 2 * 2) * 8  # Q + K + V mbar arrays
+        smem_align = 3 * 1024  # alignment overhead for 3 buffers
+        smem_total = smem_q + smem_kv + smem_mbar + smem_align
+        smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        if smem_total > smem_capacity:
+            return False
+        return True
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        softmax_scale: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        if cutlass.const_expr(
+            not (
+                mQ.element_type == mK.element_type
+                == mV.element_type == mO.element_type
+            )
+        ):
+            raise TypeError("All tensors must have the same data type")
+        if cutlass.const_expr(
+            not (
+                mQ.element_type == cutlass.Float16
+                or mQ.element_type == cutlass.BFloat16
+            )
+        ):
+            raise TypeError("Only Float16 or BFloat16 is supported")
+        self._dtype = mQ.element_type
+
+        # /////////////////////////////////////////////////////////////////////
+        # SMEM layouts with TMA-compatible swizzle (M=4 required for TMA).
+        # TMA hardware supports only Swizzle(B, 4, 3) patterns:
+        #   SW128: Swizzle(3, 4, 3) for 128-byte rows (64 bf16 elems)
+        #   SW64:  Swizzle(2, 4, 3) for 64-byte rows  (32 bf16 elems)
+        # The CpAsync version uses Swizzle(B, 3, 3) which is NOT valid for TMA.
+        # /////////////////////////////////////////////////////////////////////
+        smem_k_block_size = 64 if self._head_dim_padded % 64 == 0 else 32
+        # TMA-compatible swizzle: Swizzle(B, 4, 3) where B depends on row size.
+        # For bf16 with smem_k_block_size=64: 64*16=1024 bits → SW128 → B=3
+        # For bf16 with smem_k_block_size=32: 32*16=512 bits  → SW64  → B=2
+        swizzle_bits = 3 if smem_k_block_size == 64 else 2
+        sQ_layout_atom = cute.make_composed_layout(
+            cute.make_swizzle(swizzle_bits, 4, 3),
+            0,
+            cute.make_layout(
+                (8, smem_k_block_size), stride=(smem_k_block_size, 1)
+            ),
+        )
+        # Staged Q layout: (m_block, head_dim, 1_stage)
+        sQ_layout_staged = cute.tile_to_shape(
+            sQ_layout_atom,
+            (self._m_block_size, self._head_dim_padded, 1),
+            (0, 1, 2),
+        )
+        sQ_layout_one_stage = cute.slice_(sQ_layout_staged, (None, None, 0))
+        sKV_layout_atom = sQ_layout_atom
+        # Staged KV layout: (n_block, head_dim, kv_stages)
+        sKV_layout_staged = cute.tile_to_shape(
+            sKV_layout_atom,
+            (self._n_block_size, self._head_dim_padded, self._kv_stages),
+            (0, 1, 2),
+        )
+        sKV_layout_one_stage = cute.slice_(sKV_layout_staged, (None, None, 0))
+        sO_layout = sQ_layout_one_stage
+
+        # /////////////////////////////////////////////////////////////////////
+        # Reshape tensors for TMA: (batch, seq, head, dim) → (seq, dim, head, batch)
+        # TMA tiles the leading 2 modes (seq, dim); head and batch are
+        # coordinate modes indexed per CTA.
+        # /////////////////////////////////////////////////////////////////////
+        mQ_for_tma = cute.make_tensor(
+            mQ.iterator,
+            cute.make_layout(
+                (mQ.shape[1], mQ.shape[3], mQ.shape[2], mQ.shape[0]),
+                stride=(mQ.stride[1], mQ.stride[3], mQ.stride[2], mQ.stride[0]),
+            ),
+        )
+        mK_for_tma = cute.make_tensor(
+            mK.iterator,
+            cute.make_layout(
+                (mK.shape[1], mK.shape[3], mK.shape[2], mK.shape[0]),
+                stride=(mK.stride[1], mK.stride[3], mK.stride[2], mK.stride[0]),
+            ),
+        )
+        mV_for_tma = cute.make_tensor(
+            mV.iterator,
+            cute.make_layout(
+                (mV.shape[1], mV.shape[3], mV.shape[2], mV.shape[0]),
+                stride=(mV.stride[1], mV.stride[3], mV.stride[2], mV.stride[0]),
+            ),
+        )
+
+        # /////////////////////////////////////////////////////////////////////
+        # TMA descriptors for Q, K, V
+        # /////////////////////////////////////////////////////////////////////
+        tma_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
+            tma_op, mQ_for_tma, sQ_layout_one_stage,
+            (self._m_block_size, self._head_dim_padded), num_multicast=1,
+        )
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_op, mK_for_tma, sKV_layout_one_stage,
+            (self._n_block_size, self._head_dim_padded), num_multicast=1,
+        )
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
+            tma_op, mV_for_tma, sKV_layout_one_stage,
+            (self._n_block_size, self._head_dim_padded), num_multicast=1,
+        )
+
+        # TMA transfer sizes (bytes per load)
+        q_copy_bytes = cute.size_in_bytes(self._dtype, sQ_layout_one_stage)
+        kv_copy_bytes = cute.size_in_bytes(self._dtype, sKV_layout_one_stage)
+
+        # /////////////////////////////////////////////////////////////////////
+        # Shared storage
+        # /////////////////////////////////////////////////////////////////////
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1 * 2]
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self._kv_stages * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self._kv_stages * 2]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sQ_layout_staged)], 1024
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[
+                    self._dtype, cute.cosize(sKV_layout_staged)
+                ],
+                1024,
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[
+                    self._dtype, cute.cosize(sKV_layout_staged)
+                ],
+                1024,
+            ]
+
+        # /////////////////////////////////////////////////////////////////////
+        # MMA (same SM80-compatible tensor core ops as CpAsync version)
+        # /////////////////////////////////////////////////////////////////////
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self._dtype, cutlass.Float32, (16, 8, 16)),
+            (self._num_mma_warps, 1, 1),
+            permutation_mnk=(self._num_mma_warps * 16, 16, 16),
+        )
+
+        # Grid: (m_blocks, head*batch, 1) — head+batch folded into grid.y
+        # to match the 3D TMA tensor layout (seq, dim, (head, batch))
+        num_heads = cute.size(mQ.shape[2])
+        num_batches = cute.size(mQ.shape[0])
+        grid_dim = (
+            cute.ceil_div(mQ.shape[1], self._m_block_size),
+            num_heads * num_batches,
+            1,
+        )
+        LOG2_E = 1.4426950408889634074
+        softmax_scale_log2 = softmax_scale * LOG2_E
+        self.kernel(
+            tma_atom_q, tma_tensor_q,
+            tma_atom_k, tma_tensor_k,
+            tma_atom_v, tma_tensor_v,
+            mQ, mK, mV, mO,
+            softmax_scale_log2,
+            q_copy_bytes,
+            kv_copy_bytes,
+            sQ_layout_staged,
+            sKV_layout_staged,
+            sO_layout,
+            tiled_mma,
+            SharedStorage,
+            num_heads,
+        ).launch(
+            grid=grid_dim,
+            block=[self._num_threads, 1, 1],
+            cluster=[1, 1, 1],
+            smem=SharedStorage.size_in_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_q: cute.CopyAtom,
+        mQ_tma: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_tma: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_tma: cute.Tensor,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        softmax_scale_log2: cutlass.Float32,
+        q_copy_bytes: cutlass.Constexpr,
+        kv_copy_bytes: cutlass.Constexpr,
+        sQ_layout_staged: cute.ComposedLayout,
+        sKV_layout_staged: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        tiled_mma: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        num_heads: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        # Grid is (m_blocks, head*batch, 1) — decompose hb_idx
+        m_block, hb_idx, _ = cute.arch.block_idx()
+        head_idx = hb_idx % num_heads
+        batch_idx = hb_idx // num_heads
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        n_block_max = cute.ceil_div(mK.shape[1], self._n_block_size)
+        if self._is_causal:
+            n_block_max = min(
+                cute.ceil_div(
+                    (m_block + 1) * self._m_block_size,
+                    self._n_block_size,
+                ),
+                n_block_max,
+            )
+
+        # /////////////////////////////////////////////////////////////////////
+        # Allocate SMEM and create tensors
+        # /////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(
+            sQ_layout_staged.outer, swizzle=sQ_layout_staged.inner
+        )
+        sK = storage.sK.get_tensor(
+            sKV_layout_staged.outer, swizzle=sKV_layout_staged.inner
+        )
+        sV = storage.sV.get_tensor(
+            sKV_layout_staged.outer, swizzle=sKV_layout_staged.inner
+        )
+
+        # Transposed V view for PV GEMM (same composition as CpAsync version,
+        # extended with stage dimension)
+        sVt_staged = cute.composition(
+            sV,
+            cute.make_layout(
+                (self._head_dim_padded, self._n_block_size, self._kv_stages),
+                stride=(
+                    self._n_block_size,
+                    1,
+                    self._n_block_size * self._head_dim_padded,
+                ),
+            ),
+        )
+
+        # /////////////////////////////////////////////////////////////////////
+        # TMA partition: global → smem tile mapping
+        # /////////////////////////////////////////////////////////////////////
+        # Q, K, V: (seq, dim, head, batch) → 4D TMA
+        # Tile first 2 modes (seq, dim); head and batch are coordinate modes
+        gQ = cute.local_tile(
+            mQ_tma,
+            (self._m_block_size, self._head_dim_padded),
+            (None, 0, None, None),
+        )
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_atom_q, 0, cute.make_layout(1),
+            cute.group_modes(sQ, 0, 2),
+            cute.group_modes(gQ, 0, 2),
+        )
+
+        gK = cute.local_tile(
+            mK_tma,
+            (self._n_block_size, self._head_dim_padded),
+            (None, 0, None, None),
+        )
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_atom_k, 0, cute.make_layout(1),
+            cute.group_modes(sK, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+
+        gV = cute.local_tile(
+            mV_tma,
+            (self._n_block_size, self._head_dim_padded),
+            (None, 0, None, None),
+        )
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_atom_v, 0, cute.make_layout(1),
+            cute.group_modes(sV, 0, 2),
+            cute.group_modes(gV, 0, 2),
+        )
+
+        # Select this CTA's head and batch coordinates
+        tQgQ_block = tQgQ[(None, m_block, head_idx, batch_idx)]
+        tKgK_block = tKgK[(None, None, head_idx, batch_idx)]
+        tVgV_block = tVgV[(None, None, head_idx, batch_idx)]
+
+        # /////////////////////////////////////////////////////////////////////
+        # Init pipelines
+        # /////////////////////////////////////////////////////////////////////
+        q_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self._num_mma_warps
+            ),
+            tx_count=q_copy_bytes,
+            barrier_storage=storage.q_mbar_ptr.data_ptr(),
+        )
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self._kv_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self._num_mma_warps
+            ),
+            tx_count=kv_copy_bytes,
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self._kv_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self._num_mma_warps
+            ),
+            tx_count=kv_copy_bytes,
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+        )
+
+        pipeline.sync(barrier_id=0)
+
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+
+        # /////////////////////////////////////////////////////////////////////
+        # MMA partition setup (same as CpAsync version)
+        # /////////////////////////////////////////////////////////////////////
+        thr_mma = tiled_mma.get_slice(tidx)
+        sQ_one = sQ[None, None, 0]
+        sK_one = sK[None, None, 0]
+        tSrQ = thr_mma.make_fragment_A(thr_mma.partition_A(sQ_one))
+        tSrK = thr_mma.make_fragment_B(thr_mma.partition_B(sK_one))
+        sVt_one = sVt_staged[None, None, 0]
+        tOrVt = thr_mma.make_fragment_B(thr_mma.partition_B(sVt_one))
+        acc_shape_O = thr_mma.partition_shape_C(
+            (self._m_block_size, self._head_dim_padded)
+        )
+        acc_O = cute.make_rmem_tensor(acc_shape_O, cutlass.Float32)
+        acc_O.fill(0.0)
+
+        # LdMatrix atoms: shared → register
+        smem_copy_atom_Q = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self._dtype,
+        )
+        smem_copy_atom_K = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self._dtype,
+        )
+        smem_copy_atom_V = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+            self._dtype,
+        )
+        smem_tiled_copy_Q = cute.make_tiled_copy_A(smem_copy_atom_Q, tiled_mma)
+        smem_tiled_copy_K = cute.make_tiled_copy_B(smem_copy_atom_K, tiled_mma)
+        smem_tiled_copy_V = cute.make_tiled_copy_B(smem_copy_atom_V, tiled_mma)
+
+        smem_thr_copy_Q = smem_tiled_copy_Q.get_slice(tidx)
+        smem_thr_copy_K = smem_tiled_copy_K.get_slice(tidx)
+        smem_thr_copy_V = smem_tiled_copy_V.get_slice(tidx)
+
+        tSsQ = smem_thr_copy_Q.partition_S(sQ_one)
+        tSrQ_copy_view = smem_thr_copy_Q.retile(tSrQ)
+
+        # Softmax state
+        row_max = cute.make_rmem_tensor(
+            (acc_O.shape[0][0] * acc_O.shape[1]), cutlass.Float32
+        )
+        row_sum = cute.make_rmem_tensor(
+            (acc_O.shape[0][0] * acc_O.shape[1]), cutlass.Float32
+        )
+        row_max.fill(-cutlass.Float32.inf)
+        row_sum.fill(0.0)
+
+        # Pipeline states
+        q_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, 1
+        )
+        k_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self._kv_stages
+        )
+        v_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self._kv_stages
+        )
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._kv_stages
+        )
+        v_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._kv_stages
+        )
+
+        # /////////////////////////////////////////////////////////////////////
+        # Warp specialization
+        # /////////////////////////////////////////////////////////////////////
+        if warp_idx < self._num_mma_warps:
+            # === MMA warps (consumer) ===
+            cute.arch.setmaxregister_increase(232)
+
+            # Wait for Q to be loaded
+            q_pipeline.consumer_wait(
+                pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, 1
+                )
+            )
+
+            # Main attention loop (iterate over KV tiles, high to low for causal)
+            for n_tile in range(0, n_block_max, 1, unroll=1):
+                n_block = n_block_max - n_tile - 1
+
+                # --- Wait for K, compute S = Q * K^T ---
+                k_pipeline.consumer_wait(k_consumer_state)
+                k_stage = k_consumer_state.index
+
+                acc_shape_S = thr_mma.partition_shape_C(
+                    (self._m_block_size, self._n_block_size)
+                )
+                acc_S = cute.make_rmem_tensor(acc_shape_S, cutlass.Float32)
+                acc_S.fill(0.0)
+
+                # Partition K for this stage
+                tSsK_stage = smem_thr_copy_K.partition_S(sK[None, None, k_stage])
+                tSrK_copy_view = smem_thr_copy_K.retile(tSrK)
+
+                # Prefetch Q and K into registers
+                cute.copy(
+                    smem_tiled_copy_Q,
+                    tSsQ[None, None, 0],
+                    tSrQ_copy_view[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_K,
+                    tSsK_stage[None, None, 0],
+                    tSrK_copy_view[None, None, 0],
+                )
+                # QK GEMM with register pipeline
+                for k in cutlass.range_constexpr(cute.size(tSsQ.shape[2])):
+                    k_next = (k + 1) % cute.size(tSsQ.shape[2])
+                    cute.copy(
+                        smem_tiled_copy_Q,
+                        tSsQ[None, None, k_next],
+                        tSrQ_copy_view[None, None, k_next],
+                    )
+                    cute.copy(
+                        smem_tiled_copy_K,
+                        tSsK_stage[None, None, k_next],
+                        tSrK_copy_view[None, None, k_next],
+                    )
+                    cute.gemm(
+                        tiled_mma, acc_S,
+                        tSrQ[None, None, k],
+                        tSrK[None, None, k],
+                        acc_S,
+                    )
+
+                k_pipeline.consumer_release(k_consumer_state)
+                k_consumer_state.advance()
+
+                # --- Online softmax ---
+                self._softmax_rescale_O(
+                    m_block, n_block, mQ, mK, batch_idx, head_idx,
+                    thr_mma, tiled_mma, acc_O,
+                    row_max, row_sum, softmax_scale_log2,
+                    acc_S,
+                    in_mask_steps=cutlass.const_expr(self._is_causal),
+                )
+                rP = cute.make_fragment_like(acc_S, self._dtype)
+                rP.store(acc_S.load().to(self._dtype))
+
+                # --- Wait for V, compute O += P * V ---
+                v_pipeline.consumer_wait(v_consumer_state)
+                v_stage = v_consumer_state.index
+
+                rP_layout_divided = cute.logical_divide(rP.layout, (None, None, 2))
+                rP_mma_view = cute.make_layout(
+                    (
+                        (rP_layout_divided.shape[0], rP_layout_divided.shape[2][0]),
+                        rP_layout_divided.shape[1],
+                        rP_layout_divided.shape[2][1],
+                    ),
+                    stride=(
+                        (rP_layout_divided.stride[0], rP_layout_divided.stride[2][0]),
+                        rP_layout_divided.stride[1],
+                        rP_layout_divided.stride[2][1],
+                    ),
+                )
+                tOrS = cute.make_tensor(rP.iterator, rP_mma_view)
+
+                # Partition V for this stage
+                tOsVt_stage = smem_thr_copy_V.partition_S(
+                    sVt_staged[None, None, v_stage]
+                )
+                tOrVt_copy_view = smem_thr_copy_V.retile(tOrVt)
+
+                cute.copy(
+                    smem_tiled_copy_V,
+                    tOsVt_stage[None, None, 0],
+                    tOrVt_copy_view[None, None, 0],
+                )
+                for k in cutlass.range_constexpr(cute.size(tOrS.shape[2])):
+                    k_next = (k + 1) % cute.size(tOrS.shape[2])
+                    cute.copy(
+                        smem_tiled_copy_V,
+                        tOsVt_stage[None, None, k_next],
+                        tOrVt_copy_view[None, None, k_next],
+                    )
+                    cute.gemm(
+                        tiled_mma, acc_O,
+                        tOrS[None, None, k],
+                        tOrVt[None, None, k],
+                        acc_O,
+                    )
+
+                v_pipeline.consumer_release(v_consumer_state)
+                v_consumer_state.advance()
+
+            # Epilogue: normalize and store O
+            self._normalize_softmax(acc_O, row_sum)
+            rO = cute.make_fragment_like(acc_O, self._dtype)
+            rO.store(acc_O.load().to(self._dtype))
+            # sQ_one.iterator already has the swizzle from get_tensor(outer, swizzle=inner),
+            # so use sO_layout.outer (plain layout) to avoid double-swizzle conflict
+            sO = cute.make_tensor(sQ_one.iterator, sO_layout.outer)
+
+            smem_copy_atom_O = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), self._dtype
+            )
+            smem_tiled_copy_O = cute.make_tiled_copy_C(
+                smem_copy_atom_O, tiled_mma
+            )
+            smem_thr_copy_O = smem_tiled_copy_O.get_slice(tidx)
+            taccOrO = smem_thr_copy_O.retile(rO)
+            taccOsO = smem_thr_copy_O.partition_D(sO)
+            cute.copy(smem_copy_atom_O, taccOrO, taccOsO)
+
+            gO = cute.local_tile(
+                mO[batch_idx, None, head_idx, None],
+                (self._m_block_size, self._head_dim_padded),
+                (m_block, 0),
+            )
+            universal_copy_bits = 128
+            async_copy_elems = universal_copy_bits // self._dtype.width
+            atom_universal_copy = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self._dtype,
+                num_bits_per_copy=universal_copy_bits,
+            )
+            tO_shape_dim_1 = cute.size(sO_layout.outer.shape[1]) // async_copy_elems
+            tO_layout = cute.make_layout(
+                (self._num_mma_warps * 32 // tO_shape_dim_1, tO_shape_dim_1),
+                stride=(tO_shape_dim_1, 1),
+            )
+            vO_layout = cute.make_layout((1, async_copy_elems))
+            gmem_tiled_copy_O = cute.make_tiled_copy_tv(
+                atom_universal_copy, tO_layout, vO_layout
+            )
+            gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+            tOsO = gmem_thr_copy_O.partition_S(sO)
+            tOgO = gmem_thr_copy_O.partition_D(gO)
+            tOrO_out = cute.make_fragment_like(tOgO, self._dtype)
+            self.mma_sync_barrier.arrive_and_wait()
+            cute.copy(gmem_tiled_copy_O, tOsO, tOrO_out)
+
+            mcO = cute.make_identity_tensor(mO.layout.shape)
+            cO = cute.local_tile(
+                mcO[batch_idx, None, head_idx, None],
+                (self._m_block_size, self._head_dim_padded),
+                (m_block, 0),
+            )
+            tOcO = gmem_thr_copy_O.partition_D(cO)
+            tOpO = cute.make_rmem_tensor(
+                cute.make_layout(
+                    (tOgO.shape[0][1], tOgO.shape[1], tOgO.shape[2]),
+                    stride=(tOgO.shape[2], 0, 1),
+                ),
+                cutlass.Boolean,
+            )
+            for rest_v in cutlass.range_constexpr(tOpO.shape[0]):
+                for rest_n in cutlass.range_constexpr(cute.size(tOpO.shape[2])):
+                    tOpO[rest_v, 0, rest_n] = cute.elem_less(
+                        tOcO[(0, rest_v), 0, rest_n][3], mO.layout.shape[3]
+                    )
+            for rest_m in cutlass.range_constexpr(cute.size(tOpO.shape[1])):
+                if cute.elem_less(tOcO[0, rest_m, 0][1], mO.layout.shape[1]):
+                    cute.copy(
+                        gmem_tiled_copy_O,
+                        tOrO_out[None, rest_m, None],
+                        tOgO[None, rest_m, None],
+                        pred=tOpO[None, rest_m, None],
+                    )
+
+        elif warp_idx == self._num_mma_warps:
+            # === DMA warp (producer) ===
+            cute.arch.setmaxregister_decrease(40)
+
+            # Load Q (once, stage 0)
+            q_pipeline.producer_acquire(q_producer_state)
+            cute.copy(
+                tma_atom_q, tQgQ_block,
+                tQsQ[(None, q_producer_state.index)],
+                tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state),
+            )
+            q_pipeline.producer_commit(q_producer_state)
+
+            # Load KV tiles (high to low for causal, matching consumer order)
+            for n_tile in range(0, n_block_max, 1, unroll=1):
+                n_block = n_block_max - n_tile - 1
+
+                # Load K
+                k_pipeline.producer_acquire(k_producer_state)
+                cute.copy(
+                    tma_atom_k,
+                    tKgK_block[(None, n_block)],
+                    tKsK[(None, k_producer_state.index)],
+                    tma_bar_ptr=k_pipeline.producer_get_barrier(
+                        k_producer_state
+                    ),
+                )
+                k_pipeline.producer_commit(k_producer_state)
+                k_producer_state.advance()
+
+                # Load V
+                v_pipeline.producer_acquire(v_producer_state)
+                cute.copy(
+                    tma_atom_v,
+                    tVgV_block[(None, n_block)],
+                    tVsV[(None, v_producer_state.index)],
+                    tma_bar_ptr=v_pipeline.producer_get_barrier(
+                        v_producer_state
+                    ),
+                )
+                v_pipeline.producer_commit(v_producer_state)
+                v_producer_state.advance()
+
+            # Signal pipeline tail
+            k_pipeline.producer_tail(k_producer_state)
+            v_pipeline.producer_tail(v_producer_state)
+
+    # /////////////////////////////////////////////////////////////////////////
+    # Softmax helpers (reused from CpAsync version)
+    # /////////////////////////////////////////////////////////////////////////
+    @cute.jit
+    def _softmax_rescale_O(
+        self,
+        m_block, n_block, mQ, mK, batch_idx, head_idx,
+        thr_mma, tiled_mma, acc_O,
+        row_max, row_sum, softmax_scale_log2,
+        acc_S, in_mask_steps,
+    ):
+        acc_S_mn = self._make_acc_tensor_mn_view(acc_S)
+        acc_O_mn = self._make_acc_tensor_mn_view(acc_O)
+        # Save previous row_max for rescaling (on first iter, row_max=-inf
+        # so prev_minus_cur_exp=0, making rescale a no-op)
+        row_max_prev = cute.make_fragment_like(row_max, cutlass.Float32)
+        cute.basic_copy(row_max, row_max_prev)
+
+        for r in cutlass.range_constexpr(cute.size(row_max)):
+            if cutlass.const_expr(in_mask_steps and self._is_causal):
+                mcS = cute.make_identity_tensor((
+                    mQ.shape[0], mQ.shape[1], mQ.shape[2], mK.shape[1],
+                ))
+                cS = cute.local_tile(
+                    mcS[batch_idx, None, head_idx, None],
+                    (self._m_block_size, self._n_block_size),
+                    (m_block, n_block),
+                )
+                tScS = thr_mma.partition_C(cS)
+                tScS_mn = self._make_acc_tensor_mn_view(tScS)
+                col_idx_limit = cutlass.min(
+                    tScS_mn[r, 0][1] + 1, mK.shape[1]
+                )
+                for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                    if cute.elem_less(col_idx_limit, tScS_mn[0, c][3] + 1):
+                        acc_S_mn[r, c] = -cutlass.Float32.inf
+
+            acc_S_row = acc_S_mn[r, None].load()
+            row_max_cur_row = acc_S_row.reduce(
+                cute.ReductionOp.MAX, -cutlass.Float32.inf, 0
+            )
+            row_max_cur_row = self._threadquad_reduce_max(row_max_cur_row)
+            row_max_prev_row = row_max_prev[r]
+            row_max_cur_row = cute.arch.fmax(
+                row_max_prev_row, row_max_cur_row
+            )
+            if cutlass.const_expr(self._is_causal):
+                row_max_cur_row = (
+                    0.0
+                    if row_max_cur_row == -cutlass.Float32.inf
+                    else row_max_cur_row
+                )
+
+            acc_S_row_exp = cute.math.exp2(
+                acc_S_row * softmax_scale_log2
+                - row_max_cur_row * softmax_scale_log2,
+                fastmath=True,
+            )
+            acc_S_row_sum = acc_S_row_exp.reduce(
+                cute.ReductionOp.ADD, cutlass.Float32.zero, 0
+            )
+            prev_minus_cur_exp = cute.math.exp2(
+                row_max_prev_row * softmax_scale_log2
+                - row_max_cur_row * softmax_scale_log2,
+                fastmath=True,
+            )
+            acc_S_row_sum = (
+                acc_S_row_sum + row_sum[r] * prev_minus_cur_exp
+            )
+            acc_O_mn[r, None] = acc_O_mn[r, None].load() * prev_minus_cur_exp
+            row_max[r] = row_max_cur_row
+            row_sum[r] = acc_S_row_sum
+            acc_S_mn[r, None] = acc_S_row_exp
+
+    @cute.jit
+    def _normalize_softmax(self, acc_O: cute.Tensor, row_sum: cute.Tensor):
+        acc_O_mn = self._make_acc_tensor_mn_view(acc_O)
+        for r in cutlass.range_constexpr(cute.size(row_sum)):
+            row_sum[r] = self._threadquad_reduce_sum(row_sum[r])
+            acc_O_mn_row_is_zero_or_nan = (
+                row_sum[r] == 0.0 or row_sum[r] != row_sum[r]
+            )
+            scale = (
+                1.0
+                if acc_O_mn_row_is_zero_or_nan
+                else cute.arch.rcp_approx(row_sum[r])
+            )
+            acc_O_mn[r, None] = acc_O_mn[r, None].load() * scale
+
+    def _make_acc_tensor_mn_view(self, acc: cute.Tensor) -> cute.Tensor:
+        acc_layout_col_major = cute.make_layout(acc.layout.shape)
+        acc_layout_mn = cute.make_layout(
+            (
+                (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+                (acc_layout_col_major.shape[0][0], acc_layout_col_major.shape[2]),
+            ),
+            stride=(
+                (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+                (acc_layout_col_major.stride[0][0], acc_layout_col_major.stride[2]),
+            ),
+        )
+        acc_layout_mn = cute.composition(acc.layout, acc_layout_mn)
+        return cute.make_tensor(acc.iterator, acc_layout_mn)
+
+    def _threadquad_reduce(
+        self, val: cutlass.Float32, op
+    ) -> cutlass.Float32:
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(
+                val, offset=2, mask=-1, mask_and_clamp=31
+            ),
+        )
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(
+                val, offset=1, mask=-1, mask_and_clamp=31
+            ),
+        )
+        return val
+
+    def _threadquad_reduce_max(self, val: cutlass.Float32) -> cutlass.Float32:
+        return self._threadquad_reduce(val, lambda x, y: cute.arch.fmax(x, y))
+
+    def _threadquad_reduce_sum(self, val: cutlass.Float32) -> cutlass.Float32:
+        return self._threadquad_reduce(val, lambda x, y: x + y)
+
+
 def run(
     dtype: Type[cutlass.Numeric],
     batch_size: int,
@@ -985,6 +1817,130 @@ def run(
     return avg_time_us
 
 
+def run_tma(
+    dtype: Type[cutlass.Numeric],
+    batch_size: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    num_head: int,
+    head_dim: int,
+    softmax_scale: float = 1.0,
+    m_block_size: int = 128,
+    n_block_size: int = 64,
+    num_mma_warps: int = 4,
+    kv_stages: int = 2,
+    is_causal: bool = False,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    **kwargs,
+):
+    if not FlashAttentionForwardSm120Tma.can_implement(
+        dtype, head_dim, m_block_size, n_block_size, num_mma_warps, kv_stages,
+        is_causal,
+    ):
+        raise TypeError(
+            f"Unsupported config: {dtype}, {head_dim}, {m_block_size}, "
+            f"{n_block_size}, {num_mma_warps}, {kv_stages}, {is_causal}"
+        )
+
+    num_threads = (num_mma_warps + 1) * 32
+
+    print("Running Blackwell GeForce SM120 FlashAttentionForward TMA test with:")
+    print(f"  dtype: {dtype}")
+    print(f"  batch_size: {batch_size}")
+    print(f"  seqlen_q: {seqlen_q}")
+    print(f"  seqlen_k: {seqlen_k}")
+    print(f"  num_head: {num_head}")
+    print(f"  head_dim: {head_dim}")
+    print(f"  softmax_scale: {softmax_scale}")
+    print(f"  m_block_size: {m_block_size}")
+    print(f"  n_block_size: {n_block_size}")
+    print(f"  num_mma_warps: {num_mma_warps} (num_threads: {num_threads})")
+    print(f"  kv_stages: {kv_stages}")
+    print(f"  is_causal: {is_causal}")
+
+    def create_tensor(batch_size, seqlen, num_head, head_dim, dtype):
+        shape = (batch_size, seqlen, num_head, head_dim)
+        torch_tensor = (
+            torch.empty(*shape, dtype=torch.int32)
+            .random_(-2, 2)
+            .to(dtype=cutlass_torch.dtype(dtype))
+            .cuda()
+        )
+        cute_tensor = (
+            from_dlpack(torch_tensor, assumed_align=16)
+            .mark_layout_dynamic(leading_dim=3)
+            .mark_compact_shape_dynamic(
+                mode=3,
+                stride_order=torch_tensor.dim_order(),
+                divisibility=(128 // dtype.width),
+            )
+        )
+        return cute_tensor, torch_tensor
+
+    q, q_torch = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+    k, k_torch = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+    v, v_torch = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+    o, o_torch = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+
+    fa2_fwd = FlashAttentionForwardSm120Tma(
+        head_dim, m_block_size, n_block_size, num_mma_warps, kv_stages, is_causal,
+    )
+
+    torch_stream = torch.cuda.current_stream()
+    current_stream = cuda.CUstream(torch_stream.cuda_stream)
+    compiled_fa2_fwd = cute.compile(
+        fa2_fwd, q, k, v, o, softmax_scale, current_stream
+    )
+
+    if not skip_ref_check:
+        compiled_fa2_fwd(q, k, v, o, softmax_scale, current_stream)
+        torch.cuda.synchronize()
+        q_ref = q_torch.permute(0, 2, 1, 3)
+        k_ref = k_torch.permute(0, 2, 1, 3)
+        v_ref = v_torch.permute(0, 2, 1, 3)
+        torch.backends.cuda.enable_flash_sdp(enabled=True)
+        ref_o = torch.nn.functional.scaled_dot_product_attention(
+            q_ref, k_ref, v_ref, scale=softmax_scale, is_causal=is_causal
+        ).permute(0, 2, 1, 3)
+        torch.testing.assert_close(o_torch.cpu(), ref_o.cpu(), atol=1e-02, rtol=1e-04)
+        print("Results verified successfully!")
+
+    def generate_tensors():
+        q_w, _ = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+        k_w, _ = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+        v_w, _ = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+        o_w, _ = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+        return testing.JitArguments(
+            q_w, k_w, v_w, o_w, softmax_scale, current_stream,
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            q_torch.numel() * q_torch.element_size()
+            + k_torch.numel() * k_torch.element_size()
+            + v_torch.numel() * v_torch.element_size()
+            + o_torch.numel() * o_torch.element_size()
+        )
+        workspace_count = testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    avg_time_us = testing.benchmark(
+        compiled_fa2_fwd,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=current_stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+    )
+
+    return avg_time_us
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Flash Attention v2 for Blackwell GeForce SM120"
@@ -1009,13 +1965,31 @@ if __name__ == "__main__":
         "--use_cold_l2", action="store_true", default=False,
         help="Use circular buffer tensor sets to ensure L2 cold cache",
     )
+    parser.add_argument(
+        "--use_tma", action="store_true", default=False,
+        help="Use TMA variant with warp specialization",
+    )
+    parser.add_argument("--num_mma_warps", type=int, default=4,
+        help="Number of MMA warps (TMA variant only)")
+    parser.add_argument("--kv_stages", type=int, default=2,
+        help="Number of KV pipeline stages (TMA variant only)")
 
     args = parser.parse_args()
-    run(
-        args.dtype, args.batch_size, args.seqlen_q, args.seqlen_k,
-        args.num_head, args.head_dim, args.softmax_scale,
-        args.m_block_size, args.n_block_size, args.num_threads,
-        args.is_causal, args.warmup_iterations, args.iterations,
-        args.skip_ref_check, args.use_cold_l2,
-    )
+
+    if args.use_tma:
+        run_tma(
+            args.dtype, args.batch_size, args.seqlen_q, args.seqlen_k,
+            args.num_head, args.head_dim, args.softmax_scale,
+            args.m_block_size, args.n_block_size, args.num_mma_warps,
+            args.kv_stages, args.is_causal, args.warmup_iterations,
+            args.iterations, args.skip_ref_check, args.use_cold_l2,
+        )
+    else:
+        run(
+            args.dtype, args.batch_size, args.seqlen_q, args.seqlen_k,
+            args.num_head, args.head_dim, args.softmax_scale,
+            args.m_block_size, args.n_block_size, args.num_threads,
+            args.is_causal, args.warmup_iterations, args.iterations,
+            args.skip_ref_check, args.use_cold_l2,
+        )
     print("PASS")

--- a/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
@@ -1,0 +1,1021 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+from types import SimpleNamespace
+from typing import Type, Callable
+
+import torch
+import cuda.bindings.driver as cuda
+import cutlass.cute.testing as testing
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, warp
+import cutlass.torch as cutlass_torch
+from cutlass.cute.runtime import from_dlpack
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+
+"""
+A flash attention v2 forward pass example for NVIDIA Blackwell GeForce SM120 architecture
+(RTX 5090, GB10 / DGX Spark) using CUTE DSL.
+
+- Matrix Q is BxSqxNxH, B is batch, Sq is query sequence length, N is heads, H is head dim
+- Matrix K is BxSkxNxH, B is batch, Sk is key sequence length, N is heads, H is head dim
+- Matrix V is BxSkxNxH, B is batch, Sk is key sequence length, N is heads, H is head dim
+- Matrix O is BxSqxNxH, B is batch, Sq is query sequence length, N is heads, H is head dim
+
+SM120 Architecture Notes:
+    - Supports SM80-era `mma.sync.aligned.m16n8k16` tensor core instructions for FP16/BF16
+    - Supports CpAsync (cp.async) for asynchronous global → shared memory copies
+    - Supports TMA (cp.async.bulk) for bulk memory transfers (used in GEMM, future FA opt)
+    - Does NOT support tcgen05 MMA (datacenter Blackwell SM100 only)
+    - Does NOT support TMA multicast (single-CTA copies only)
+    - Has 101 KB shared memory per SM (vs 164 KB for SM80, 228 KB for SM90)
+
+This kernel leverages:
+    - CpAsync for efficient global → shared memory transfers
+    - SM80-compatible tensor cores for MMA operations
+    - Online softmax fusion following the Flash Attention v2 algorithm
+    - Register pipeline to overlap shared memory-to-register transfers with computation
+
+To run this example:
+
+.. code-block:: bash
+
+    python examples/blackwell_geforce/flash_attention_v2.py                        \\
+      --dtype Float16 --head_dim 128 --m_block_size 128 --n_block_size 128         \\
+      --num_threads 128 --batch_size 1 --seqlen_q 1024 --seqlen_k 1024            \\
+      --num_head 16 --softmax_scale 1.0 --is_causal
+
+Constraints:
+* Only fp16 and bf16 data types are supported.
+* The contiguous dimension of each tensor must be at least 16 bytes aligned.
+* The log-sum-exp (for training) is not computed in the kernel.
+* `m_block_size`, `n_block_size`, and `head_dim` must fit within SM120 shared memory.
+* `m_block_size * 2` must be divisible by `num_threads`.
+"""
+
+
+class FlashAttentionForwardSm120:
+    def __init__(
+        self,
+        head_dim: int,
+        m_block_size: int = 128,
+        n_block_size: int = 128,
+        num_threads: int = 128,
+        is_causal: bool = False,
+    ):
+        """Initializes the configuration for an SM120 flash attention v2 kernel.
+
+        :param head_dim: head dimension
+        :type head_dim: int
+        :param m_block_size: m block size (query tile rows)
+        :type m_block_size: int
+        :param n_block_size: n block size (key/value tile rows)
+        :type n_block_size: int
+        :param num_threads: number of threads per CTA
+        :type num_threads: int
+        :param is_causal: enable causal masking
+        :type is_causal: bool
+        """
+        self._head_dim = head_dim
+        self._m_block_size = m_block_size
+        self._n_block_size = n_block_size
+        # Pad head_dim to a multiple of 32 for MMA alignment
+        self._head_dim_padded = (head_dim + 31) // 32 * 32
+        self._num_threads = num_threads
+        self._is_causal = is_causal
+
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1, num_threads=num_threads
+        )
+
+    @staticmethod
+    def can_implement(
+        dtype, head_dim, m_block_size, n_block_size, num_threads, is_causal
+    ) -> bool:
+        """Check if the kernel can be implemented with the given parameters."""
+        if dtype != cutlass.Float16 and dtype != cutlass.BFloat16:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        # SM120 shared memory capacity check
+        smem_usage = (m_block_size * head_dim + n_block_size * head_dim * 2) * 2
+        smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        if smem_usage > smem_capacity:
+            return False
+        if (m_block_size * 2) % num_threads != 0:
+            return False
+        return True
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        softmax_scale: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        """Configures and launches the SM120 flash attention v2 kernel.
+
+        mQ/mK/mV/mO layout: (batch_size, seqlen, num_head, head_dim)
+        """
+        if cutlass.const_expr(
+            not (
+                mQ.element_type == mK.element_type == mV.element_type == mO.element_type
+            )
+        ):
+            raise TypeError("All tensors must have the same data type")
+        if cutlass.const_expr(
+            not (
+                mQ.element_type == cutlass.Float16
+                or mQ.element_type == cutlass.BFloat16
+            )
+        ):
+            raise TypeError("Only Float16 or BFloat16 is supported")
+        self._dtype: Type[cutlass.Numeric] = mQ.element_type
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Shared memory layout: Q/K/V (swizzled for bank conflict avoidance)
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem_k_block_size = 64 if self._head_dim_padded % 64 == 0 else 32
+        swizzle_bits = 3 if smem_k_block_size == 64 else 2
+        sQ_layout_atom = cute.make_composed_layout(
+            cute.make_swizzle(swizzle_bits, 3, 3),
+            0,
+            cute.make_layout((8, smem_k_block_size), stride=(smem_k_block_size, 1)),
+        )
+        sQ_layout = cute.tile_to_shape(
+            sQ_layout_atom,
+            (self._m_block_size, self._head_dim_padded),
+            (0, 1),
+        )
+        sKV_layout_atom = sQ_layout_atom
+        sKV_layout = cute.tile_to_shape(
+            sKV_layout_atom,
+            (self._n_block_size, self._head_dim_padded),
+            (0, 1),
+        )
+        sO_layout = sQ_layout
+
+        @cute.struct
+        class SharedStorage:
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sQ_layout)], 1024
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sKV_layout)], 1024
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self._dtype, cute.cosize(sKV_layout)], 1024
+            ]
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # GMEM Tiled copy: CpAsync for QKV load, Universal for O store
+        # ///////////////////////////////////////////////////////////////////////////////
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self._dtype.width
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self._dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self._dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tQKV_shape_dim_1 = sQ_layout_atom.outer.shape[1] // async_copy_elems
+        tQKV_layout = cute.make_layout(
+            (self._num_threads // tQKV_shape_dim_1, tQKV_shape_dim_1),
+            stride=(tQKV_shape_dim_1, 1),
+        )
+        tO_layout = tQKV_layout
+        vQKV_layout = cute.make_layout((1, async_copy_elems))
+        vO_layout = vQKV_layout
+
+        gmem_tiled_copy_QKV = cute.make_tiled_copy_tv(
+            atom_async_copy, tQKV_layout, vQKV_layout
+        )
+        gmem_tiled_copy_O = cute.make_tiled_copy_tv(
+            atom_universal_copy, tO_layout, vO_layout
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Tiled MMA — SM80-compatible tensor core ops (supported on SM120)
+        # ///////////////////////////////////////////////////////////////////////////////
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self._dtype, cutlass.Float32, (16, 8, 16)),
+            (self._num_threads // 32, 1, 1),
+            permutation_mnk=(self._num_threads // 32 * 16, 16, 16),
+        )
+
+        grid_dim = (
+            cute.ceil_div(mQ.shape[1], self._m_block_size),
+            cute.size(mQ.shape[0]),
+            cute.size(mQ.shape[2]),
+        )
+        LOG2_E = 1.4426950408889634074
+        softmax_scale_log2 = softmax_scale * LOG2_E
+        self.kernel(
+            mQ,
+            mK,
+            mV,
+            mO,
+            softmax_scale_log2,
+            sQ_layout,
+            sKV_layout,
+            sO_layout,
+            gmem_tiled_copy_QKV,
+            gmem_tiled_copy_O,
+            tiled_mma,
+            SharedStorage,
+        ).launch(
+            grid=grid_dim,
+            block=[self._num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        softmax_scale_log2: cutlass.Float32,
+        sQ_layout: cute.ComposedLayout,
+        sKV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        gmem_tiled_copy_QKV: cute.TiledCopy,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+    ):
+        """SM120 flash attention v2 kernel.
+
+        Uses CpAsync for global→shared loads, SM80-compatible tensor core
+        MMA for computation, and online softmax for numerical stability.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        m_block, batch_size, num_head = cute.arch.block_idx()
+
+        n_block_max = cute.ceil_div(mK.shape[1], self._n_block_size)
+        if self._is_causal:
+            n_block_max = min(
+                cute.ceil_div(
+                    (m_block + 1) * self._m_block_size,
+                    self._n_block_size,
+                ),
+                n_block_max,
+            )
+        n_block = n_block_max - 1
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Get tiles for this thread block
+        # ///////////////////////////////////////////////////////////////////////////////
+        gQ = cute.local_tile(
+            mQ[batch_size, None, num_head, None],
+            (self._m_block_size, self._head_dim_padded),
+            (m_block, 0),
+        )
+        gK = cute.local_tile(
+            mK[batch_size, None, num_head, None],
+            (self._n_block_size, self._head_dim_padded),
+            (None, 0),
+        )
+        gV = cute.local_tile(
+            mV[batch_size, None, num_head, None],
+            (self._n_block_size, self._head_dim_padded),
+            (None, 0),
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Get shared memory
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(sQ_layout)
+        sK = storage.sK.get_tensor(sKV_layout)
+        sV = storage.sV.get_tensor(sKV_layout)
+
+        sVt = cute.composition(
+            sV,
+            cute.make_layout(
+                (self._head_dim_padded, self._n_block_size),
+                stride=(self._n_block_size, 1),
+            ),
+        )
+
+        gmem_thr_copy_QKV = gmem_tiled_copy_QKV.get_slice(tidx)
+        tQgQ = gmem_thr_copy_QKV.partition_S(gQ)
+        tQsQ = gmem_thr_copy_QKV.partition_D(sQ)
+        tKgK = gmem_thr_copy_QKV.partition_S(gK)
+        tKsK = gmem_thr_copy_QKV.partition_D(sK)
+        tVgV = gmem_thr_copy_QKV.partition_S(gV)
+        tVsV = gmem_thr_copy_QKV.partition_D(sV)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # MMA compute partitions and accumulators
+        # ///////////////////////////////////////////////////////////////////////////////
+        thr_mma = tiled_mma.get_slice(tidx)
+        tSrQ = thr_mma.make_fragment_A(thr_mma.partition_A(sQ))
+        tSrK = thr_mma.make_fragment_B(thr_mma.partition_B(sK))
+        tOrVt = thr_mma.make_fragment_B(thr_mma.partition_B(sVt))
+        acc_shape_O = thr_mma.partition_shape_C(
+            (self._m_block_size, self._head_dim_padded)
+        )
+        acc_O = cute.make_rmem_tensor(acc_shape_O, cutlass.Float32)
+        acc_O.fill(0.0)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Smem copy atoms (LdMatrix: shared → register)
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem_copy_atom_Q = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self._dtype,
+        )
+        smem_copy_atom_K = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self._dtype,
+        )
+        smem_copy_atom_V = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+            self._dtype,
+        )
+        smem_tiled_copy_Q = cute.make_tiled_copy_A(smem_copy_atom_Q, tiled_mma)
+        smem_tiled_copy_K = cute.make_tiled_copy_B(smem_copy_atom_K, tiled_mma)
+        smem_tiled_copy_V = cute.make_tiled_copy_B(smem_copy_atom_V, tiled_mma)
+
+        smem_thr_copy_Q = smem_tiled_copy_Q.get_slice(tidx)
+        smem_thr_copy_K = smem_tiled_copy_K.get_slice(tidx)
+        smem_thr_copy_V = smem_tiled_copy_V.get_slice(tidx)
+
+        tSsQ = smem_thr_copy_Q.partition_S(sQ)
+        tSrQ_copy_view = smem_thr_copy_Q.retile(tSrQ)
+        tSsK = smem_thr_copy_K.partition_S(sK)
+        tSrK_copy_view = smem_thr_copy_K.retile(tSrK)
+        tOsVt = smem_thr_copy_V.partition_S(sVt)
+        tOrVt_copy_view = smem_thr_copy_V.retile(tOrVt)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Predicates for out-of-bounds handling
+        # ///////////////////////////////////////////////////////////////////////////////
+        mcQ = cute.make_identity_tensor(mQ.layout.shape)
+        mcKV = cute.make_identity_tensor(mK.layout.shape)
+        cQ = cute.local_tile(
+            mcQ[batch_size, None, num_head, None],
+            (self._m_block_size, self._head_dim_padded),
+            (m_block, 0),
+        )
+        cKV = cute.local_tile(
+            mcKV[batch_size, None, num_head, None],
+            (self._n_block_size, self._head_dim_padded),
+            (n_block, 0),
+        )
+        tQcQ = gmem_thr_copy_QKV.partition_S(cQ)
+        tKVcKV = gmem_thr_copy_QKV.partition_S(cKV)
+        tQpQ = cute.make_rmem_tensor(
+            cute.make_layout(
+                (tQsQ.shape[0][1], cute.size(tQsQ, mode=[1]), cute.size(tQsQ, mode=[2])),
+                stride=(cute.size(tQsQ, mode=[2]), 0, 1),
+            ),
+            cutlass.Boolean,
+        )
+        tKVpKV = cute.make_rmem_tensor(
+            cute.make_layout(
+                (tKsK.shape[0][1], cute.size(tKsK, mode=[1]), cute.size(tKsK, mode=[2])),
+                stride=(cute.size(tKsK, mode=[2]), 0, 1),
+            ),
+            cutlass.Boolean,
+        )
+        for rest_v in cutlass.range_constexpr(tQpQ.shape[0]):
+            for rest_k in cutlass.range_constexpr(tQpQ.shape[2]):
+                tQpQ[rest_v, 0, rest_k] = cute.elem_less(
+                    tQcQ[(0, rest_v), 0, rest_k][3], mQ.layout.shape[3]
+                )
+        for rest_v in cutlass.range_constexpr(tKVpKV.shape[0]):
+            for rest_k in cutlass.range_constexpr(tKVpKV.shape[2]):
+                tKVpKV[rest_v, 0, rest_k] = cute.elem_less(
+                    tKVcKV[(0, rest_v), 0, rest_k][3], mK.layout.shape[3]
+                )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Prologue: async load Q and first K tile
+        # ///////////////////////////////////////////////////////////////////////////////
+        for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+            if cute.elem_less(tQcQ[0, m, 0][1], mQ.layout.shape[1]):
+                cute.copy(
+                    gmem_tiled_copy_QKV,
+                    tQgQ[None, m, None],
+                    tQsQ[None, m, None],
+                    pred=tQpQ[None, m, None],
+                )
+            else:
+                tQsQ[None, m, None].fill(0)
+        for n in cutlass.range_constexpr(cute.size(tKsK.shape[1])):
+            if cute.elem_less(tKVcKV[0, n, 0][1], mK.layout.shape[1]):
+                cute.copy(
+                    gmem_tiled_copy_QKV,
+                    tKgK[None, n, None, n_block],
+                    tKsK[None, n, None],
+                    pred=tKVpKV[None, n, None],
+                )
+            else:
+                tKsK[None, n, None].fill(0)
+
+        cute.arch.cp_async_commit_group()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Softmax intermediate results
+        # ///////////////////////////////////////////////////////////////////////////////
+        row_max = cute.make_rmem_tensor(
+            (acc_O.shape[0][0] * acc_O.shape[1]), cutlass.Float32
+        )
+        row_sum = cute.make_rmem_tensor(
+            (acc_O.shape[0][0] * acc_O.shape[1]), cutlass.Float32
+        )
+        row_max.fill(-cutlass.Float32.inf)
+        row_sum.fill(0.0)
+
+        basic_params = SimpleNamespace(
+            m_block=m_block, n_block=n_block, mQ=mQ, mK=mK,
+            batch_size=batch_size, num_head=num_head,
+        )
+        mma_params = SimpleNamespace(
+            thr_mma=thr_mma, tiled_mma=tiled_mma,
+            tSrQ=tSrQ, tSrK=tSrK, tOrVt=tOrVt, acc_O=acc_O,
+        )
+        gmem_copy_params = SimpleNamespace(
+            gmem_tiled_copy_QKV=gmem_tiled_copy_QKV,
+            tKVcKV=tKVcKV,
+            tKgK=tKgK, tKsK=tKsK,
+            tVgV=tVgV, tVsV=tVsV,
+            tKVpKV=tKVpKV,
+        )
+        smem_copy_params = SimpleNamespace(
+            smem_tiled_copy_Q=smem_tiled_copy_Q,
+            smem_tiled_copy_K=smem_tiled_copy_K,
+            smem_tiled_copy_V=smem_tiled_copy_V,
+            tSsQ=tSsQ, tSrQ_copy_view=tSrQ_copy_view,
+            tSsK=tSsK, tSrK_copy_view=tSrK_copy_view,
+            tOsVt=tOsVt, tOrVt_copy_view=tOrVt_copy_view,
+        )
+        softmax_params = SimpleNamespace(
+            row_max=row_max, row_sum=row_sum,
+            softmax_scale_log2=softmax_scale_log2,
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Main attention loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        mask_steps = 1
+        if cutlass.const_expr(self._is_causal):
+            mask_steps = cute.ceil_div(self._m_block_size, self._n_block_size)
+
+        for n_tile in cutlass.range_constexpr(mask_steps):
+            n_block = n_block_max - n_tile - 1
+            basic_params.n_block = n_block
+            if cutlass.const_expr(self._is_causal):
+                if n_block >= 0:
+                    self.compute_one_n_block(
+                        basic_params, mma_params, gmem_copy_params,
+                        smem_copy_params, softmax_params,
+                        is_first_n_block=(n_tile == 0), in_mask_steps=True,
+                    )
+            else:
+                self.compute_one_n_block(
+                    basic_params, mma_params, gmem_copy_params,
+                    smem_copy_params, softmax_params,
+                    is_first_n_block=True, in_mask_steps=True,
+                )
+
+        for n_tile in range(mask_steps, n_block_max, 1):
+            n_block = n_block_max - n_tile - 1
+            basic_params.n_block = n_block
+            self.compute_one_n_block(
+                basic_params, mma_params, gmem_copy_params,
+                smem_copy_params, softmax_params,
+                is_first_n_block=False, in_mask_steps=False,
+            )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Epilogue: normalize and store O
+        # ///////////////////////////////////////////////////////////////////////////////
+        self.normalize_softmax(acc_O, row_sum)
+        rO = cute.make_fragment_like(acc_O, self._dtype)
+        rO.store(acc_O.load().to(self._dtype))
+        sO = cute.make_tensor(sQ.iterator, sO_layout)
+
+        smem_copy_atom_O = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self._dtype
+        )
+        smem_tiled_copy_O = cute.make_tiled_copy_C(smem_copy_atom_O, tiled_mma)
+        smem_thr_copy_O = smem_tiled_copy_O.get_slice(tidx)
+        taccOrO = smem_thr_copy_O.retile(rO)
+        taccOsO = smem_thr_copy_O.partition_D(sO)
+        cute.copy(smem_copy_atom_O, taccOrO, taccOsO)
+
+        gO = cute.local_tile(
+            mO[batch_size, None, num_head, None],
+            (self._m_block_size, self._head_dim_padded),
+            (m_block, 0),
+        )
+        gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+        tOsO = gmem_thr_copy_O.partition_S(sO)
+        tOgO = gmem_thr_copy_O.partition_D(gO)
+        tOrO = cute.make_fragment_like(tOgO, self._dtype)
+        self.cta_sync_barrier.arrive_and_wait()
+        cute.copy(gmem_tiled_copy_O, tOsO, tOrO)
+
+        mcO = cute.make_identity_tensor(mO.layout.shape)
+        cO = cute.local_tile(
+            mcO[batch_size, None, num_head, None],
+            (self._m_block_size, self._head_dim_padded),
+            (m_block, 0),
+        )
+        tOcO = gmem_thr_copy_O.partition_D(cO)
+        tOpO = cute.make_rmem_tensor(
+            cute.make_layout(
+                (tOgO.shape[0][1], tOgO.shape[1], tOgO.shape[2]),
+                stride=(tOgO.shape[2], 0, 1),
+            ),
+            cutlass.Boolean,
+        )
+        for rest_v in cutlass.range_constexpr(tOpO.shape[0]):
+            for rest_n in cutlass.range_constexpr(cute.size(tOpO.shape[2])):
+                tOpO[rest_v, 0, rest_n] = cute.elem_less(
+                    tOcO[(0, rest_v), 0, rest_n][3], mO.layout.shape[3]
+                )
+        for rest_m in cutlass.range_constexpr(cute.size(tOpO.shape[1])):
+            if cute.elem_less(tOcO[0, rest_m, 0][1], mO.layout.shape[1]):
+                cute.copy(
+                    gmem_tiled_copy_O,
+                    tOrO[None, rest_m, None],
+                    tOgO[None, rest_m, None],
+                    pred=tOpO[None, rest_m, None],
+                )
+
+    @cute.jit
+    def compute_one_n_block(
+        self,
+        basic_params: SimpleNamespace,
+        mma_params: SimpleNamespace,
+        gmem_copy_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
+        softmax_params: SimpleNamespace,
+        is_first_n_block: cutlass.Constexpr,
+        in_mask_steps: cutlass.Constexpr,
+    ):
+        """Compute one n_block of S/O."""
+        acc_shape_S = mma_params.thr_mma.partition_shape_C(
+            (self._m_block_size, self._n_block_size)
+        )
+        acc_S = cute.make_rmem_tensor(acc_shape_S, cutlass.Float32)
+        acc_S.fill(0.0)
+
+        # Wait for QK smem tiles
+        cute.arch.cp_async_wait_group(0)
+        self.cta_sync_barrier.arrive_and_wait()
+
+        # Load V (overlap with S computation)
+        if is_first_n_block:
+            for n in cutlass.range_constexpr(cute.size(gmem_copy_params.tVsV.shape[1])):
+                if cute.elem_less(
+                    gmem_copy_params.tKVcKV[0, n, 0][1],
+                    basic_params.mK.layout.shape[1],
+                ):
+                    cute.copy(
+                        gmem_copy_params.gmem_tiled_copy_QKV,
+                        gmem_copy_params.tVgV[None, n, None, basic_params.n_block],
+                        gmem_copy_params.tVsV[None, n, None],
+                        pred=gmem_copy_params.tKVpKV[None, n, None],
+                    )
+                else:
+                    gmem_copy_params.tVsV[None, n, None].fill(0.0)
+        else:
+            cute.copy(
+                gmem_copy_params.gmem_tiled_copy_QKV,
+                gmem_copy_params.tVgV[None, None, None, basic_params.n_block],
+                gmem_copy_params.tVsV,
+                pred=gmem_copy_params.tKVpKV,
+            )
+
+        cute.arch.cp_async_commit_group()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # S = Q * K^T
+        # ///////////////////////////////////////////////////////////////////////////////
+        cute.copy(
+            smem_copy_params.smem_tiled_copy_Q,
+            smem_copy_params.tSsQ[None, None, 0],
+            smem_copy_params.tSrQ_copy_view[None, None, 0],
+        )
+        cute.copy(
+            smem_copy_params.smem_tiled_copy_K,
+            smem_copy_params.tSsK[None, None, 0],
+            smem_copy_params.tSrK_copy_view[None, None, 0],
+        )
+        for k in cutlass.range_constexpr(cute.size(smem_copy_params.tSsQ.shape[2])):
+            k_next = (k + 1) % cute.size(smem_copy_params.tSsQ.shape[2])
+            cute.copy(
+                smem_copy_params.smem_tiled_copy_Q,
+                smem_copy_params.tSsQ[None, None, k_next],
+                smem_copy_params.tSrQ_copy_view[None, None, k_next],
+            )
+            cute.copy(
+                smem_copy_params.smem_tiled_copy_K,
+                smem_copy_params.tSsK[None, None, k_next],
+                smem_copy_params.tSrK_copy_view[None, None, k_next],
+            )
+            cute.gemm(
+                mma_params.tiled_mma, acc_S,
+                mma_params.tSrQ[None, None, k],
+                mma_params.tSrK[None, None, k],
+                acc_S,
+            )
+
+        # Wait for V
+        cute.arch.cp_async_wait_group(0)
+        self.cta_sync_barrier.arrive_and_wait()
+
+        # Prefetch next K
+        if basic_params.n_block > 0:
+            cute.copy(
+                gmem_copy_params.gmem_tiled_copy_QKV,
+                gmem_copy_params.tKgK[None, None, None, basic_params.n_block - 1],
+                gmem_copy_params.tKsK,
+                pred=gmem_copy_params.tKVpKV,
+            )
+            cute.arch.cp_async_commit_group()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Online softmax
+        # ///////////////////////////////////////////////////////////////////////////////
+        self.softmax_rescale_O(
+            basic_params, mma_params, softmax_params, acc_S,
+            is_first_n_block, in_mask_steps,
+        )
+
+        rP = cute.make_fragment_like(acc_S, self._dtype)
+        rP.store(acc_S.load().to(self._dtype))
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # O += P * V
+        # ///////////////////////////////////////////////////////////////////////////////
+        rP_layout_divided = cute.logical_divide(rP.layout, (None, None, 2))
+        rP_mma_view = cute.make_layout(
+            (
+                (rP_layout_divided.shape[0], rP_layout_divided.shape[2][0]),
+                rP_layout_divided.shape[1],
+                rP_layout_divided.shape[2][1],
+            ),
+            stride=(
+                (rP_layout_divided.stride[0], rP_layout_divided.stride[2][0]),
+                rP_layout_divided.stride[1],
+                rP_layout_divided.stride[2][1],
+            ),
+        )
+        tOrS = cute.make_tensor(rP.iterator, rP_mma_view)
+
+        cute.copy(
+            smem_copy_params.smem_tiled_copy_V,
+            smem_copy_params.tOsVt[None, None, 0],
+            smem_copy_params.tOrVt_copy_view[None, None, 0],
+        )
+        for k in cutlass.range_constexpr(cute.size(tOrS.shape[2])):
+            k_next = (k + 1) % cute.size(tOrS.shape[2])
+            cute.copy(
+                smem_copy_params.smem_tiled_copy_V,
+                smem_copy_params.tOsVt[None, None, k_next],
+                smem_copy_params.tOrVt_copy_view[None, None, k_next],
+            )
+            cute.gemm(
+                mma_params.tiled_mma, mma_params.acc_O,
+                tOrS[None, None, k],
+                mma_params.tOrVt[None, None, k],
+                mma_params.acc_O,
+            )
+
+    @cute.jit
+    def softmax_rescale_O(
+        self,
+        basic_params: SimpleNamespace,
+        mma_params: SimpleNamespace,
+        softmax_params: SimpleNamespace,
+        acc_S: cute.Tensor,
+        is_first_n_block: cutlass.Constexpr,
+        in_mask_steps: cutlass.Constexpr,
+    ):
+        """Apply online softmax and rescale acc_O."""
+        acc_S_mn = self._make_acc_tensor_mn_view(acc_S)
+        acc_O_mn = self._make_acc_tensor_mn_view(mma_params.acc_O)
+        row_max_prev = None
+        if cutlass.const_expr(not is_first_n_block):
+            row_max_prev = cute.make_fragment_like(
+                softmax_params.row_max, cutlass.Float32
+            )
+            cute.basic_copy(softmax_params.row_max, row_max_prev)
+
+        tScS_mn = None
+        if cutlass.const_expr(in_mask_steps):
+            mcS = cute.make_identity_tensor((
+                basic_params.mQ.shape[0], basic_params.mQ.shape[1],
+                basic_params.mQ.shape[2], basic_params.mK.shape[1],
+            ))
+            cS = cute.local_tile(
+                mcS[basic_params.batch_size, None, basic_params.num_head, None],
+                (self._m_block_size, self._n_block_size),
+                (basic_params.m_block, basic_params.n_block),
+            )
+            tScS = mma_params.thr_mma.partition_C(cS)
+            tScS_mn = self._make_acc_tensor_mn_view(tScS)
+
+        for r in cutlass.range_constexpr(cute.size(softmax_params.row_max)):
+            if cutlass.const_expr(in_mask_steps):
+                if cutlass.const_expr(not self._is_causal):
+                    for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                        if cute.elem_less(
+                            basic_params.mK.shape[1], tScS_mn[0, c][3] + 1
+                        ):
+                            acc_S_mn[r, c] = -cutlass.Float32.inf
+                else:
+                    col_idx_limit = cutlass.min(
+                        tScS_mn[r, 0][1] + 1, basic_params.mK.shape[1]
+                    )
+                    for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                        if cute.elem_less(col_idx_limit, tScS_mn[0, c][3] + 1):
+                            acc_S_mn[r, c] = -cutlass.Float32.inf
+
+            acc_S_row = acc_S_mn[r, None].load()
+            row_max_cur_row = acc_S_row.reduce(
+                cute.ReductionOp.MAX, -cutlass.Float32.inf, 0
+            )
+            row_max_cur_row = self._threadquad_reduce_max(row_max_cur_row)
+            row_max_prev_row = None
+            if cutlass.const_expr(not is_first_n_block):
+                row_max_prev_row = row_max_prev[r]
+                row_max_cur_row = cute.arch.fmax(row_max_prev_row, row_max_cur_row)
+            if cutlass.const_expr(self._is_causal):
+                row_max_cur_row = (
+                    0.0
+                    if row_max_cur_row == -cutlass.Float32.inf
+                    else row_max_cur_row
+                )
+
+            acc_S_row_exp = cute.math.exp2(
+                acc_S_row * softmax_params.softmax_scale_log2
+                - row_max_cur_row * softmax_params.softmax_scale_log2,
+                fastmath=True,
+            )
+            acc_S_row_sum = acc_S_row_exp.reduce(
+                cute.ReductionOp.ADD, cutlass.Float32.zero, 0
+            )
+            if cutlass.const_expr(not is_first_n_block):
+                prev_minus_cur_exp = cute.math.exp2(
+                    row_max_prev_row * softmax_params.softmax_scale_log2
+                    - row_max_cur_row * softmax_params.softmax_scale_log2,
+                    fastmath=True,
+                )
+                acc_S_row_sum = (
+                    acc_S_row_sum + softmax_params.row_sum[r] * prev_minus_cur_exp
+                )
+                acc_O_mn[r, None] = acc_O_mn[r, None].load() * prev_minus_cur_exp
+            softmax_params.row_max[r] = row_max_cur_row
+            softmax_params.row_sum[r] = acc_S_row_sum
+            acc_S_mn[r, None] = acc_S_row_exp
+
+    @cute.jit
+    def normalize_softmax(self, acc_O: cute.Tensor, row_sum: cute.Tensor):
+        """Normalize acc_O by row_sum."""
+        acc_O_mn = self._make_acc_tensor_mn_view(acc_O)
+        for r in cutlass.range_constexpr(cute.size(row_sum)):
+            row_sum[r] = self._threadquad_reduce_sum(row_sum[r])
+            acc_O_mn_row_is_zero_or_nan = row_sum[r] == 0.0 or row_sum[r] != row_sum[r]
+            scale = (
+                1.0
+                if acc_O_mn_row_is_zero_or_nan
+                else cute.arch.rcp_approx(row_sum[r])
+            )
+            acc_O_mn[r, None] = acc_O_mn[r, None].load() * scale
+
+    def _make_acc_tensor_mn_view(self, acc: cute.Tensor) -> cute.Tensor:
+        """Reshape accumulator to M,N layout view."""
+        acc_layout_col_major = cute.make_layout(acc.layout.shape)
+        acc_layout_mn = cute.make_layout(
+            (
+                (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+                (acc_layout_col_major.shape[0][0], acc_layout_col_major.shape[2]),
+            ),
+            stride=(
+                (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+                (acc_layout_col_major.stride[0][0], acc_layout_col_major.stride[2]),
+            ),
+        )
+        acc_layout_mn = cute.composition(acc.layout, acc_layout_mn)
+        return cute.make_tensor(acc.iterator, acc_layout_mn)
+
+    def _threadquad_reduce(
+        self, val: cutlass.Float32, op: Callable
+    ) -> cutlass.Float32:
+        """Thread quad reduction."""
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(val, offset=2, mask=-1, mask_and_clamp=31),
+        )
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(val, offset=1, mask=-1, mask_and_clamp=31),
+        )
+        return val
+
+    def _threadquad_reduce_max(self, val: cutlass.Float32) -> cutlass.Float32:
+        return self._threadquad_reduce(val, lambda x, y: cute.arch.fmax(x, y))
+
+    def _threadquad_reduce_sum(self, val: cutlass.Float32) -> cutlass.Float32:
+        return self._threadquad_reduce(val, lambda x, y: x + y)
+
+
+def run(
+    dtype: Type[cutlass.Numeric],
+    batch_size: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    num_head: int,
+    head_dim: int,
+    softmax_scale: float = 1.0,
+    m_block_size: int = 128,
+    n_block_size: int = 128,
+    num_threads: int = 128,
+    is_causal: bool = False,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    **kwargs,
+):
+    if not FlashAttentionForwardSm120.can_implement(
+        dtype, head_dim, m_block_size, n_block_size, num_threads, is_causal,
+    ):
+        raise TypeError(
+            f"Unsupported config: {dtype}, {head_dim}, {m_block_size}, "
+            f"{n_block_size}, {num_threads}, {is_causal}"
+        )
+
+    print("Running Blackwell GeForce SM120 FlashAttentionForward test with:")
+    print(f"  dtype: {dtype}")
+    print(f"  batch_size: {batch_size}")
+    print(f"  seqlen_q: {seqlen_q}")
+    print(f"  seqlen_k: {seqlen_k}")
+    print(f"  num_head: {num_head}")
+    print(f"  head_dim: {head_dim}")
+    print(f"  softmax_scale: {softmax_scale}")
+    print(f"  m_block_size: {m_block_size}")
+    print(f"  n_block_size: {n_block_size}")
+    print(f"  num_threads: {num_threads}")
+    print(f"  is_causal: {is_causal}")
+
+    def create_tensor(batch_size, seqlen, num_head, head_dim, dtype):
+        shape = (batch_size, seqlen, num_head, head_dim)
+        torch_tensor = (
+            torch.empty(*shape, dtype=torch.int32)
+            .random_(-2, 2)
+            .to(dtype=cutlass_torch.dtype(dtype))
+            .cuda()
+        )
+        cute_tensor = (
+            from_dlpack(torch_tensor, assumed_align=16)
+            .mark_layout_dynamic(leading_dim=3)
+            .mark_compact_shape_dynamic(
+                mode=3,
+                stride_order=torch_tensor.dim_order(),
+                divisibility=(128 // dtype.width),
+            )
+        )
+        return cute_tensor, torch_tensor
+
+    q, q_torch = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+    k, k_torch = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+    v, v_torch = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+    o, o_torch = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+
+    fa2_fwd = FlashAttentionForwardSm120(
+        head_dim, m_block_size, n_block_size, num_threads, is_causal,
+    )
+
+    torch_stream = torch.cuda.current_stream()
+    current_stream = cuda.CUstream(torch_stream.cuda_stream)
+    compiled_fa2_fwd = cute.compile(
+        fa2_fwd, q, k, v, o, softmax_scale, current_stream
+    )
+
+    if not skip_ref_check:
+        compiled_fa2_fwd(q, k, v, o, softmax_scale, current_stream)
+        torch.cuda.synchronize()
+        q_ref = q_torch.permute(0, 2, 1, 3)
+        k_ref = k_torch.permute(0, 2, 1, 3)
+        v_ref = v_torch.permute(0, 2, 1, 3)
+        torch.backends.cuda.enable_flash_sdp(enabled=True)
+        ref_o = torch.nn.functional.scaled_dot_product_attention(
+            q_ref, k_ref, v_ref, scale=softmax_scale, is_causal=is_causal
+        ).permute(0, 2, 1, 3)
+        torch.testing.assert_close(o_torch.cpu(), ref_o.cpu(), atol=1e-02, rtol=1e-04)
+        print("Results verified successfully!")
+
+    def generate_tensors():
+        q_w, _ = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+        k_w, _ = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+        v_w, _ = create_tensor(batch_size, seqlen_k, num_head, head_dim, dtype)
+        o_w, _ = create_tensor(batch_size, seqlen_q, num_head, head_dim, dtype)
+        return testing.JitArguments(
+            q_w, k_w, v_w, o_w, softmax_scale, current_stream,
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            q_torch.numel() * q_torch.element_size()
+            + k_torch.numel() * k_torch.element_size()
+            + v_torch.numel() * v_torch.element_size()
+            + o_torch.numel() * o_torch.element_size()
+        )
+        workspace_count = testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    avg_time_us = testing.benchmark(
+        compiled_fa2_fwd,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=current_stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+    )
+
+    return avg_time_us
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Flash Attention v2 for Blackwell GeForce SM120"
+    )
+    parser.add_argument("--dtype", type=cutlass.dtype, default=cutlass.BFloat16)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--seqlen_q", type=int, default=8192)
+    parser.add_argument("--seqlen_k", type=int, default=8192)
+    parser.add_argument("--num_head", type=int, default=16)
+    parser.add_argument("--head_dim", type=int, default=128)
+    parser.add_argument("--softmax_scale", type=float, default=0.5)
+    parser.add_argument("--m_block_size", type=int, default=128)
+    parser.add_argument("--n_block_size", type=int, default=64)
+    parser.add_argument("--num_threads", type=int, default=128)
+    parser.add_argument("--is_causal", action="store_true", help="Enable causal mask")
+    parser.add_argument("--warmup_iterations", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument(
+        "--skip_ref_check", action="store_true", help="Skip reference check"
+    )
+    parser.add_argument(
+        "--use_cold_l2", action="store_true", default=False,
+        help="Use circular buffer tensor sets to ensure L2 cold cache",
+    )
+
+    args = parser.parse_args()
+    run(
+        args.dtype, args.batch_size, args.seqlen_q, args.seqlen_k,
+        args.num_head, args.head_dim, args.softmax_scale,
+        args.m_block_size, args.n_block_size, args.num_threads,
+        args.is_causal, args.warmup_iterations, args.iterations,
+        args.skip_ref_check, args.use_cold_l2,
+    )
+    print("PASS")

--- a/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
@@ -1392,13 +1392,38 @@ class FlashAttentionForwardSm120Tma:
                 k_consumer_state.advance()
 
                 # --- Online softmax ---
-                self._softmax_rescale_O(
-                    m_block, n_block, mQ, mK, batch_idx, head_idx,
-                    thr_mma, tiled_mma, acc_O,
-                    row_max, row_sum, softmax_scale_log2,
-                    acc_S,
-                    in_mask_steps=cutlass.const_expr(self._is_causal),
-                )
+                # Two-path approach: only apply per-element causal masking
+                # for tiles near the diagonal (mask_steps tiles). For tiles
+                # fully below the diagonal, skip the expensive masking.
+                # This matches the CpAsync variant's two-loop structure.
+                if cutlass.const_expr(self._is_causal):
+                    causal_mask_boundary = n_block_max - cute.ceil_div(
+                        self._m_block_size, self._n_block_size
+                    )
+                    if n_block >= causal_mask_boundary:
+                        self._softmax_rescale_O(
+                            m_block, n_block, mQ, mK, batch_idx, head_idx,
+                            thr_mma, tiled_mma, acc_O,
+                            row_max, row_sum, softmax_scale_log2,
+                            acc_S,
+                            in_mask_steps=True,
+                        )
+                    else:
+                        self._softmax_rescale_O(
+                            m_block, n_block, mQ, mK, batch_idx, head_idx,
+                            thr_mma, tiled_mma, acc_O,
+                            row_max, row_sum, softmax_scale_log2,
+                            acc_S,
+                            in_mask_steps=False,
+                        )
+                else:
+                    self._softmax_rescale_O(
+                        m_block, n_block, mQ, mK, batch_idx, head_idx,
+                        thr_mma, tiled_mma, acc_O,
+                        row_max, row_sum, softmax_scale_log2,
+                        acc_S,
+                        in_mask_steps=False,
+                    )
                 rP = cute.make_fragment_like(acc_S, self._dtype)
                 rP.store(acc_S.load().to(self._dtype))
 

--- a/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/flash_attention_v2.py
@@ -919,12 +919,17 @@ class FlashAttentionForwardSm120Tma:
         if m_block_size % (num_mma_warps * 16) != 0:
             return False
         head_dim_padded = (head_dim + 31) // 32 * 32
-        # SMEM: sQ (1 stage) + sK (kv_stages) + sV (kv_stages) + mbar arrays
-        smem_q = m_block_size * head_dim_padded * (dtype.width // 8)
-        smem_kv = n_block_size * head_dim_padded * (dtype.width // 8) * kv_stages * 2
-        smem_mbar = (1 * 2 + kv_stages * 2 * 2) * 8  # Q + K + V mbar arrays
-        smem_align = 3 * 1024  # alignment overhead for 3 buffers
-        smem_total = smem_q + smem_kv + smem_mbar + smem_align
+        # SMEM layout: [q_mbar | k_mbar | v_mbar | <pad> | sQ | sK | sV]
+        # The mbar arrays are padded up to the first 1024-byte boundary by the
+        # first Align[..., 1024] field.  sQ, sK, sV are typically multiples of
+        # 1024 B (e.g. 128*128*2 = 32768) so they need no further padding.
+        elem_bytes = dtype.width // 8
+        smem_q = m_block_size * head_dim_padded * elem_bytes
+        smem_kv = n_block_size * head_dim_padded * elem_bytes * kv_stages * 2
+        smem_mbar = (1 * 2 + kv_stages * 2 * 2) * 8  # q + k + v mbar arrays
+        smem_mbar_region = ((smem_mbar + 1023) // 1024) * 1024  # round up to 1024
+        smem_align_q = (1024 - smem_q % 1024) % 1024        # padding after sQ
+        smem_total = smem_mbar_region + smem_q + smem_align_q + smem_kv
         smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
         if smem_total > smem_capacity:
             return False
@@ -1417,13 +1422,25 @@ class FlashAttentionForwardSm120Tma:
                             in_mask_steps=False,
                         )
                 else:
-                    self._softmax_rescale_O(
-                        m_block, n_block, mQ, mK, batch_idx, head_idx,
-                        thr_mma, tiled_mma, acc_O,
-                        row_max, row_sum, softmax_scale_log2,
-                        acc_S,
-                        in_mask_steps=False,
-                    )
+                    # Non-causal: the last K tile (highest n_block index) may be
+                    # partial if seqlen_k is not divisible by n_block_size. Apply
+                    # OOB masking on that tile only.
+                    if n_block == n_block_max - 1:
+                        self._softmax_rescale_O(
+                            m_block, n_block, mQ, mK, batch_idx, head_idx,
+                            thr_mma, tiled_mma, acc_O,
+                            row_max, row_sum, softmax_scale_log2,
+                            acc_S,
+                            in_mask_steps=True,
+                        )
+                    else:
+                        self._softmax_rescale_O(
+                            m_block, n_block, mQ, mK, batch_idx, head_idx,
+                            thr_mma, tiled_mma, acc_O,
+                            row_max, row_sum, softmax_scale_log2,
+                            acc_S,
+                            in_mask_steps=False,
+                        )
                 rP = cute.make_fragment_like(acc_S, self._dtype)
                 rP.store(acc_S.load().to(self._dtype))
 
@@ -1614,24 +1631,40 @@ class FlashAttentionForwardSm120Tma:
         row_max_prev = cute.make_fragment_like(row_max, cutlass.Float32)
         cute.basic_copy(row_max, row_max_prev)
 
+        # Build the S-tile coordinate view once (needed for masking).
+        # Constructed conditionally to avoid dead code when in_mask_steps=False.
+        tScS_mn = None
+        if cutlass.const_expr(in_mask_steps):
+            mcS = cute.make_identity_tensor((
+                mQ.shape[0], mQ.shape[1], mQ.shape[2], mK.shape[1],
+            ))
+            cS = cute.local_tile(
+                mcS[batch_idx, None, head_idx, None],
+                (self._m_block_size, self._n_block_size),
+                (m_block, n_block),
+            )
+            tScS = thr_mma.partition_C(cS)
+            tScS_mn = self._make_acc_tensor_mn_view(tScS)
+
         for r in cutlass.range_constexpr(cute.size(row_max)):
-            if cutlass.const_expr(in_mask_steps and self._is_causal):
-                mcS = cute.make_identity_tensor((
-                    mQ.shape[0], mQ.shape[1], mQ.shape[2], mK.shape[1],
-                ))
-                cS = cute.local_tile(
-                    mcS[batch_idx, None, head_idx, None],
-                    (self._m_block_size, self._n_block_size),
-                    (m_block, n_block),
-                )
-                tScS = thr_mma.partition_C(cS)
-                tScS_mn = self._make_acc_tensor_mn_view(tScS)
-                col_idx_limit = cutlass.min(
-                    tScS_mn[r, 0][1] + 1, mK.shape[1]
-                )
-                for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
-                    if cute.elem_less(col_idx_limit, tScS_mn[0, c][3] + 1):
-                        acc_S_mn[r, c] = -cutlass.Float32.inf
+            if cutlass.const_expr(in_mask_steps):
+                if cutlass.const_expr(self._is_causal):
+                    # Causal masking: zero out attention to future tokens,
+                    # and OOB tokens beyond seqlen_k.
+                    col_idx_limit = cutlass.min(
+                        tScS_mn[r, 0][1] + 1, mK.shape[1]
+                    )
+                    for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                        if cute.elem_less(col_idx_limit, tScS_mn[0, c][3] + 1):
+                            acc_S_mn[r, c] = -cutlass.Float32.inf
+                else:
+                    # Non-causal OOB masking: zero out columns beyond seqlen_k.
+                    # Needed when seqlen_k is not divisible by n_block_size (the
+                    # last K tile has padding that TMA zero-fills, but softmax
+                    # must treat those as -inf, not 0).
+                    for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
+                        if cute.elem_less(mK.shape[1], tScS_mn[0, c][3] + 1):
+                            acc_S_mn[r, c] = -cutlass.Float32.inf
 
             acc_S_row = acc_S_mn[r, None].load()
             row_max_cur_row = acc_S_row.reduce(

--- a/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention.py
@@ -1,0 +1,1086 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+FP8 Flash Attention v2 for SM120 (Blackwell GeForce / DGX Spark).
+
+Uses inline PTX ``mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32``
+since MmaAtomSM80Type segfaults with FP8 types on SM120 (CUTLASS #3044).
+
+Two implementations:
+
+**FP8FlashAttentionSm120** (proof-of-concept):
+  - 1 warp (32 threads), M=16, N=32 tiles
+  - O accumulated in GMEM — correct but slow (~1 TFLOPS)
+
+**FP8FlashAttentionSm120Opt** (optimized):
+  - 4 warps (128 threads), M=64, N=32 tiles
+  - O accumulated in registers (online softmax with rescaling)
+  - CpAsync GMEM→SMEM loads with double-buffered K/V pipeline
+  - SMEM bank-conflict-free padding (+16 bytes/row)
+  - Vectorized 4×4 byte transpose using ``prmt.b32`` for V
+  - Per-element causal masking
+  - 18-42 TFLOPS on DGX Spark (0.6-1.4x vs BF16 CuTe DSL kernel)
+
+FP32→FP8 conversion uses ``cvt.rn.satfinite.e4m3x2.f32`` pair variant.
+"""
+
+import argparse
+import torch
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int32, Float32
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Inline PTX helpers
+# /////////////////////////////////////////////////////////////////////////////
+
+@dsl_user_op
+def mma_f8f6f4_m16n8k32_e4m3(
+    a0, a1, a2, a3, b0, b1, c0, c1, c2, c3,
+    *, loc=None, ip=None,
+):
+    """kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32"""
+    vals = [Int32(x).ir_value(loc=loc, ip=ip) for x in [a0, a1, a2, a3, b0, b1]]
+    accs = [Float32(x).ir_value(loc=loc, ip=ip) for x in [c0, c1, c2, c3]]
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32,f32,f32,f32)>"),
+        vals + accs,
+        "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        "{$0,$1,$2,$3},{$4,$5,$6,$7},{$8,$9},{$10,$11,$12,$13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=True, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return tuple(
+        Float32(llvm.extractvalue(T.f32(), ret, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def bitcast_f32_to_i32(val, *, loc=None, ip=None):
+    f32_ir = Float32(val).ir_value(loc=loc, ip=ip)
+    return Int32(llvm.bitcast(T.i32(), f32_ir, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def bitcast_i32_to_f32(val, *, loc=None, ip=None):
+    i32_ir = Int32(val).ir_value(loc=loc, ip=ip)
+    return Float32(llvm.bitcast(T.f32(), i32_ir, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def transpose_4x4_bytes(r0, r1, r2, r3, *, loc=None, ip=None):
+    """Transpose a 4x4 byte matrix in registers using prmt.b32.
+
+    Input: r0..r3 = 4 rows, each containing 4 packed bytes (i32).
+      r0 = {a0, a1, a2, a3}, r1 = {b0, b1, b2, b3}, ...
+    Output: t0..t3 = 4 columns after transpose.
+      t0 = {a0, b0, c0, d0}, t1 = {a1, b1, c1, d1}, ...
+
+    Uses 8 prmt.b32 instructions (pure register ops, no SMEM).
+    """
+    args = [Int32(x).ir_value(loc=loc, ip=ip) for x in [r0, r1, r2, r3]]
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32,i32,i32,i32)>"),
+        args,
+        "{\n\t"
+        ".reg .b32 lo01, hi01, lo23, hi23;\n\t"
+        "prmt.b32 lo01, $4, $5, 0x5140;\n\t"
+        "prmt.b32 hi01, $4, $5, 0x7362;\n\t"
+        "prmt.b32 lo23, $6, $7, 0x5140;\n\t"
+        "prmt.b32 hi23, $6, $7, 0x7362;\n\t"
+        "prmt.b32 $0, lo01, lo23, 0x5410;\n\t"
+        "prmt.b32 $1, lo01, lo23, 0x7632;\n\t"
+        "prmt.b32 $2, hi01, hi23, 0x5410;\n\t"
+        "prmt.b32 $3, hi01, hi23, 0x7632;\n\t"
+        "}",
+        "=r,=r,=r,=r,r,r,r,r",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return tuple(
+        Int32(llvm.extractvalue(T.i32(), ret, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def cvt_f32_to_fp8x4(v0, v1, v2, v3, *, loc=None, ip=None):
+    """Pack 4 FP32 → 4 FP8 e4m3 bytes in uint32.
+
+    Uses cvt.rn.satfinite.e4m3x2.f32 (pair variant) + mov.b32 packing.
+    Byte layout: [v0, v1, v2, v3] low-to-high.
+    """
+    args = [Float32(x).ir_value(loc=loc, ip=ip) for x in [v0, v1, v2, v3]]
+    return Int32(llvm.inline_asm(
+        T.i32(), args,
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, $2, $1;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, $4, $3;\n\t"
+        "mov.b32 $0, {lo, hi};\n\t"
+        "}",
+        "=r,f,f,f,f",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    ))
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Kernel
+# /////////////////////////////////////////////////////////////////////////////
+
+class FP8FlashAttentionSm120:
+    """Single-warp FP8 Flash Attention for SM120. M=16, N=32 tiles."""
+
+    def __init__(self, head_dim, is_causal=False):
+        assert head_dim % 32 == 0
+        self._head_dim = head_dim
+        self._is_causal = is_causal
+        self._M = 16
+        self._N = 32
+
+    @cute.jit
+    def __call__(self, mQ, mK, mV, mO, softmax_scale, stream):
+        fp8 = cutlass.Float8E4M3FN
+        M, N, D = self._M, self._N, self._head_dim
+
+        sQ_layout = cute.make_layout((M, D), stride=(D, 1))
+        sK_layout = cute.make_layout((N, D), stride=(D, 1))
+        sVt_layout = cute.make_layout((D, N), stride=(N, 1))
+        sP_layout = cute.make_layout((M, N), stride=(N, 1))
+
+        @cute.struct
+        class SharedStorage:
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sQ_layout)], 128]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sK_layout)], 128]
+            sVt: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sVt_layout)], 128]
+            sP_f32: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(sP_layout)], 128]
+
+        # G→S copy setup (64-bit = 8 FP8 per copy)
+        g2s_bits = 64
+        g2s_elems = g2s_bits // fp8.width
+        g2s_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), fp8, num_bits_per_copy=g2s_bits)
+        t_dim = 32 // g2s_elems
+        num_m = 32 // t_dim
+        tv_layout = cute.make_layout((num_m, t_dim), stride=(t_dim, 1))
+        v_layout = cute.make_layout((1, g2s_elems))
+        g2s_tiled = cute.make_tiled_copy_tv(g2s_atom, tv_layout, v_layout)
+
+        grid = (cute.ceil_div(mQ.shape[1], M), cute.size(mQ.shape[0]),
+                cute.size(mQ.shape[2]))
+        LOG2E = 1.4426950408889634074
+        self.kernel(
+            mQ, mK, mV, mO, softmax_scale * LOG2E,
+            sQ_layout, sK_layout, sVt_layout, sP_layout,
+            g2s_tiled, SharedStorage,
+        ).launch(grid=grid, block=[32, 1, 1], stream=stream,
+                 smem=SharedStorage.size_in_bytes())
+
+    @cute.kernel
+    def kernel(self, mQ: cute.Tensor, mK: cute.Tensor, mV: cute.Tensor,
+               mO: cute.Tensor, scale_log2: cutlass.Float32,
+               sQ_layout: cute.Layout, sK_layout: cute.Layout,
+               sVt_layout: cute.Layout, sP_layout: cute.Layout,
+               g2s_tiled: cute.TiledCopy, SharedStorage: cutlass.Constexpr):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_block, batch, head = cute.arch.block_idx()
+        M, N, D = self._M, self._N, self._head_dim
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(sQ_layout)
+        sK = storage.sK.get_tensor(sK_layout)
+        sVt = storage.sVt.get_tensor(sVt_layout)
+        sP_f32 = storage.sP_f32.get_tensor(sP_layout)
+
+        gid = tidx // 4
+        tip = tidx % 4
+        m_base = m_block * M
+
+        n_block_max = cute.ceil_div(mK.shape[1], N)
+        if self._is_causal:
+            n_block_max = min(
+                cute.ceil_div((m_block + 1) * M, N), n_block_max)
+
+        # Load Q once
+        gQ = cute.local_tile(
+            mQ[batch, None, head, None], (M, D), (m_block, 0))
+        thr_g2s = g2s_tiled.get_slice(tidx)
+        cute.copy(g2s_tiled, thr_g2s.partition_S(gQ), thr_g2s.partition_D(sQ))
+        cute.arch.sync_threads()
+
+        # Init O to zero in GMEM
+        n_d_tiles = D // 8
+        for dt in range(n_d_tiles):
+            db = dt * 8
+            mO[batch, m_base + gid,     head, db + tip * 2]     = cutlass.Float32(0.0)
+            mO[batch, m_base + gid,     head, db + tip * 2 + 1] = cutlass.Float32(0.0)
+            mO[batch, m_base + gid + 8, head, db + tip * 2]     = cutlass.Float32(0.0)
+            mO[batch, m_base + gid + 8, head, db + tip * 2 + 1] = cutlass.Float32(0.0)
+
+        row_max_u = cutlass.Float32(-3.4028235e+38)
+        row_max_l = cutlass.Float32(-3.4028235e+38)
+        row_sum_u = cutlass.Float32(0.0)
+        row_sum_l = cutlass.Float32(0.0)
+
+        # Main attention loop
+        for n_tile in range(n_block_max):
+            nb = n_block_max - n_tile - 1
+
+            # ---- Load K ----
+            gK = cute.local_tile(
+                mK[batch, None, head, None], (N, D), (nb, 0))
+            cute.copy(g2s_tiled, thr_g2s.partition_S(gK),
+                      thr_g2s.partition_D(sK))
+            cute.arch.sync_threads()
+
+            sQ_f32 = cute.recast_tensor(sQ, cutlass.Float32)
+            sK_f32 = cute.recast_tensor(sK, cutlass.Float32)
+            n_k = D // 32
+
+            # ---- QK GEMM: 4 n-sub-tiles of m16n8k32 ----
+            s0_0 = cutlass.Float32(0.0); s0_1 = cutlass.Float32(0.0)
+            s0_2 = cutlass.Float32(0.0); s0_3 = cutlass.Float32(0.0)
+            s1_0 = cutlass.Float32(0.0); s1_1 = cutlass.Float32(0.0)
+            s1_2 = cutlass.Float32(0.0); s1_3 = cutlass.Float32(0.0)
+            s2_0 = cutlass.Float32(0.0); s2_1 = cutlass.Float32(0.0)
+            s2_2 = cutlass.Float32(0.0); s2_3 = cutlass.Float32(0.0)
+            s3_0 = cutlass.Float32(0.0); s3_1 = cutlass.Float32(0.0)
+            s3_2 = cutlass.Float32(0.0); s3_3 = cutlass.Float32(0.0)
+
+            for ki in range(n_k):
+                kb = ki * 8
+                a0 = bitcast_f32_to_i32(sQ_f32[gid,     kb + tip])
+                a1 = bitcast_f32_to_i32(sQ_f32[gid + 8, kb + tip])
+                a2 = bitcast_f32_to_i32(sQ_f32[gid,     kb + tip + 4])
+                a3 = bitcast_f32_to_i32(sQ_f32[gid + 8, kb + tip + 4])
+
+                b0 = bitcast_f32_to_i32(sK_f32[gid, kb + tip])
+                b1 = bitcast_f32_to_i32(sK_f32[gid, kb + tip + 4])
+                s0_0, s0_1, s0_2, s0_3 = mma_f8f6f4_m16n8k32_e4m3(
+                    a0, a1, a2, a3, b0, b1, s0_0, s0_1, s0_2, s0_3)
+
+                b0 = bitcast_f32_to_i32(sK_f32[8 + gid, kb + tip])
+                b1 = bitcast_f32_to_i32(sK_f32[8 + gid, kb + tip + 4])
+                s1_0, s1_1, s1_2, s1_3 = mma_f8f6f4_m16n8k32_e4m3(
+                    a0, a1, a2, a3, b0, b1, s1_0, s1_1, s1_2, s1_3)
+
+                b0 = bitcast_f32_to_i32(sK_f32[16 + gid, kb + tip])
+                b1 = bitcast_f32_to_i32(sK_f32[16 + gid, kb + tip + 4])
+                s2_0, s2_1, s2_2, s2_3 = mma_f8f6f4_m16n8k32_e4m3(
+                    a0, a1, a2, a3, b0, b1, s2_0, s2_1, s2_2, s2_3)
+
+                b0 = bitcast_f32_to_i32(sK_f32[24 + gid, kb + tip])
+                b1 = bitcast_f32_to_i32(sK_f32[24 + gid, kb + tip + 4])
+                s3_0, s3_1, s3_2, s3_3 = mma_f8f6f4_m16n8k32_e4m3(
+                    a0, a1, a2, a3, b0, b1, s3_0, s3_1, s3_2, s3_3)
+
+            # ---- Per-element causal mask ----
+            if self._is_causal:
+                neginf = cutlass.Float32(-3.4028235e+38)
+                q_u = m_base + gid      # upper row position
+                q_l = m_base + gid + 8  # lower row position
+                # Each sub-tile covers 8 columns: sub_base = sub*8 + tip*2
+                for sub_i, sub_off in enumerate([0, 8, 16, 24]):
+                    c0 = nb * N + sub_off + tip * 2
+                    c1 = c0 + 1
+                    if sub_i == 0:
+                        s0_0 = neginf if c0 > q_u else s0_0
+                        s0_1 = neginf if c1 > q_u else s0_1
+                        s0_2 = neginf if c0 > q_l else s0_2
+                        s0_3 = neginf if c1 > q_l else s0_3
+                    elif sub_i == 1:
+                        s1_0 = neginf if c0 > q_u else s1_0
+                        s1_1 = neginf if c1 > q_u else s1_1
+                        s1_2 = neginf if c0 > q_l else s1_2
+                        s1_3 = neginf if c1 > q_l else s1_3
+                    elif sub_i == 2:
+                        s2_0 = neginf if c0 > q_u else s2_0
+                        s2_1 = neginf if c1 > q_u else s2_1
+                        s2_2 = neginf if c0 > q_l else s2_2
+                        s2_3 = neginf if c1 > q_l else s2_3
+                    elif sub_i == 3:
+                        s3_0 = neginf if c0 > q_u else s3_0
+                        s3_1 = neginf if c1 > q_u else s3_1
+                        s3_2 = neginf if c0 > q_l else s3_2
+                        s3_3 = neginf if c1 > q_l else s3_3
+
+            # ---- Online softmax ----
+            # Row max (upper row = gid, lower row = gid+8)
+            lmu = cute.arch.fmax(cute.arch.fmax(s0_0, s0_1),
+                                  cute.arch.fmax(s1_0, s1_1))
+            lmu = cute.arch.fmax(lmu, cute.arch.fmax(
+                cute.arch.fmax(s2_0, s2_1), cute.arch.fmax(s3_0, s3_1)))
+            lmu = cute.arch.fmax(lmu, cute.arch.shuffle_sync_bfly(
+                lmu, offset=2, mask=-1, mask_and_clamp=31))
+            lmu = cute.arch.fmax(lmu, cute.arch.shuffle_sync_bfly(
+                lmu, offset=1, mask=-1, mask_and_clamp=31))
+
+            lml = cute.arch.fmax(cute.arch.fmax(s0_2, s0_3),
+                                  cute.arch.fmax(s1_2, s1_3))
+            lml = cute.arch.fmax(lml, cute.arch.fmax(
+                cute.arch.fmax(s2_2, s2_3), cute.arch.fmax(s3_2, s3_3)))
+            lml = cute.arch.fmax(lml, cute.arch.shuffle_sync_bfly(
+                lml, offset=2, mask=-1, mask_and_clamp=31))
+            lml = cute.arch.fmax(lml, cute.arch.shuffle_sync_bfly(
+                lml, offset=1, mask=-1, mask_and_clamp=31))
+
+            new_mu = cute.arch.fmax(row_max_u, lmu)
+            new_ml = cute.arch.fmax(row_max_l, lml)
+
+            # Rescale O
+            resc_u = cute.math.exp2(
+                row_max_u * scale_log2 - new_mu * scale_log2, fastmath=True)
+            resc_l = cute.math.exp2(
+                row_max_l * scale_log2 - new_ml * scale_log2, fastmath=True)
+
+            for dt in range(n_d_tiles):
+                db = dt * 8
+                o0 = mO[batch, m_base + gid,     head, db + tip*2]     * resc_u
+                o1 = mO[batch, m_base + gid,     head, db + tip*2 + 1] * resc_u
+                o2 = mO[batch, m_base + gid + 8, head, db + tip*2]     * resc_l
+                o3 = mO[batch, m_base + gid + 8, head, db + tip*2 + 1] * resc_l
+                mO[batch, m_base + gid,     head, db + tip*2]     = o0
+                mO[batch, m_base + gid,     head, db + tip*2 + 1] = o1
+                mO[batch, m_base + gid + 8, head, db + tip*2]     = o2
+                mO[batch, m_base + gid + 8, head, db + tip*2 + 1] = o3
+
+            row_sum_u = row_sum_u * resc_u
+            row_sum_l = row_sum_l * resc_l
+
+            # exp2((S - new_max) * scale_log2)
+            s0_0 = cute.math.exp2(s0_0 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s0_1 = cute.math.exp2(s0_1 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s0_2 = cute.math.exp2(s0_2 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s0_3 = cute.math.exp2(s0_3 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s1_0 = cute.math.exp2(s1_0 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s1_1 = cute.math.exp2(s1_1 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s1_2 = cute.math.exp2(s1_2 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s1_3 = cute.math.exp2(s1_3 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s2_0 = cute.math.exp2(s2_0 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s2_1 = cute.math.exp2(s2_1 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s2_2 = cute.math.exp2(s2_2 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s2_3 = cute.math.exp2(s2_3 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s3_0 = cute.math.exp2(s3_0 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s3_1 = cute.math.exp2(s3_1 * scale_log2 - new_mu * scale_log2, fastmath=True)
+            s3_2 = cute.math.exp2(s3_2 * scale_log2 - new_ml * scale_log2, fastmath=True)
+            s3_3 = cute.math.exp2(s3_3 * scale_log2 - new_ml * scale_log2, fastmath=True)
+
+            row_sum_u = row_sum_u + s0_0 + s0_1 + s1_0 + s1_1 + s2_0 + s2_1 + s3_0 + s3_1
+            row_sum_l = row_sum_l + s0_2 + s0_3 + s1_2 + s1_3 + s2_2 + s2_3 + s3_2 + s3_3
+            row_max_u = new_mu
+            row_max_l = new_ml
+
+            # ---- Write P to sP_f32 (CLayout positions) ----
+            # CLayout: sX_0 → [gid, sub*8+tip*2], sX_1 → [gid, sub*8+tip*2+1]
+            #          sX_2 → [gid+8, sub*8+tip*2], sX_3 → [gid+8, sub*8+tip*2+1]
+            sP_f32[gid,     0 + tip*2]     = s0_0
+            sP_f32[gid,     0 + tip*2 + 1] = s0_1
+            sP_f32[gid + 8, 0 + tip*2]     = s0_2
+            sP_f32[gid + 8, 0 + tip*2 + 1] = s0_3
+            sP_f32[gid,     8 + tip*2]     = s1_0
+            sP_f32[gid,     8 + tip*2 + 1] = s1_1
+            sP_f32[gid + 8, 8 + tip*2]     = s1_2
+            sP_f32[gid + 8, 8 + tip*2 + 1] = s1_3
+            sP_f32[gid,     16 + tip*2]     = s2_0
+            sP_f32[gid,     16 + tip*2 + 1] = s2_1
+            sP_f32[gid + 8, 16 + tip*2]     = s2_2
+            sP_f32[gid + 8, 16 + tip*2 + 1] = s2_3
+            sP_f32[gid,     24 + tip*2]     = s3_0
+            sP_f32[gid,     24 + tip*2 + 1] = s3_1
+            sP_f32[gid + 8, 24 + tip*2]     = s3_2
+            sP_f32[gid + 8, 24 + tip*2 + 1] = s3_3
+
+            # ---- Load V into sK (reuse), then transpose to sVt ----
+            cute.arch.sync_threads()
+            gV = cute.local_tile(
+                mV[batch, None, head, None], (N, D), (nb, 0))
+            cute.copy(g2s_tiled, thr_g2s.partition_S(gV),
+                      thr_g2s.partition_D(sK))
+            cute.arch.sync_threads()
+
+            # Transpose sK[N,D] → sVt[D,N] via element-wise copy
+            # 32 threads, N*D elements → each thread does N*D/32 copies
+            n_elems = N * D // 32
+            for i in range(n_elems):
+                flat = tidx * n_elems + i
+                vn = flat // D
+                vd = flat % D
+                sVt[vd, vn] = sK[vn, vd]
+            cute.arch.sync_threads()
+
+            # ---- PV GEMM: O += P @ V^T ----
+            # P: A-operand (16, 32), loaded from sP_f32 → FP8 on-the-fly
+            # V^T: B-operand (8, 32) per d-sub-tile, from sVt
+            sVt_f32 = cute.recast_tensor(sVt, cutlass.Float32)
+
+            # A registers from sP_f32: convert 4 consecutive FP32 → FP8x4
+            pa0 = cvt_f32_to_fp8x4(
+                sP_f32[gid,     tip*4], sP_f32[gid,     tip*4+1],
+                sP_f32[gid,     tip*4+2], sP_f32[gid,     tip*4+3])
+            pa1 = cvt_f32_to_fp8x4(
+                sP_f32[gid + 8, tip*4], sP_f32[gid + 8, tip*4+1],
+                sP_f32[gid + 8, tip*4+2], sP_f32[gid + 8, tip*4+3])
+            pa2 = cvt_f32_to_fp8x4(
+                sP_f32[gid,     tip*4+16], sP_f32[gid,     tip*4+17],
+                sP_f32[gid,     tip*4+18], sP_f32[gid,     tip*4+19])
+            pa3 = cvt_f32_to_fp8x4(
+                sP_f32[gid + 8, tip*4+16], sP_f32[gid + 8, tip*4+17],
+                sP_f32[gid + 8, tip*4+18], sP_f32[gid + 8, tip*4+19])
+
+            for dt in range(n_d_tiles):
+                db = dt * 8
+                vb0 = bitcast_f32_to_i32(sVt_f32[db + gid, tip])
+                vb1 = bitcast_f32_to_i32(sVt_f32[db + gid, tip + 4])
+
+                o0 = mO[batch, m_base + gid,     head, db + tip*2]
+                o1 = mO[batch, m_base + gid,     head, db + tip*2 + 1]
+                o2 = mO[batch, m_base + gid + 8, head, db + tip*2]
+                o3 = mO[batch, m_base + gid + 8, head, db + tip*2 + 1]
+
+                o0, o1, o2, o3 = mma_f8f6f4_m16n8k32_e4m3(
+                    pa0, pa1, pa2, pa3, vb0, vb1, o0, o1, o2, o3)
+
+                mO[batch, m_base + gid,     head, db + tip*2]     = o0
+                mO[batch, m_base + gid,     head, db + tip*2 + 1] = o1
+                mO[batch, m_base + gid + 8, head, db + tip*2]     = o2
+                mO[batch, m_base + gid + 8, head, db + tip*2 + 1] = o3
+
+            cute.arch.sync_threads()
+
+        # ---- Final normalize: O /= row_sum ----
+        row_sum_u = row_sum_u + cute.arch.shuffle_sync_bfly(
+            row_sum_u, offset=2, mask=-1, mask_and_clamp=31)
+        row_sum_u = row_sum_u + cute.arch.shuffle_sync_bfly(
+            row_sum_u, offset=1, mask=-1, mask_and_clamp=31)
+        row_sum_l = row_sum_l + cute.arch.shuffle_sync_bfly(
+            row_sum_l, offset=2, mask=-1, mask_and_clamp=31)
+        row_sum_l = row_sum_l + cute.arch.shuffle_sync_bfly(
+            row_sum_l, offset=1, mask=-1, mask_and_clamp=31)
+
+        inv_u = cutlass.Float32(1.0) / row_sum_u if row_sum_u != cutlass.Float32(0.0) else cutlass.Float32(1.0)
+        inv_l = cutlass.Float32(1.0) / row_sum_l if row_sum_l != cutlass.Float32(0.0) else cutlass.Float32(1.0)
+
+        for dt in range(n_d_tiles):
+            db = dt * 8
+            mO[batch, m_base+gid,   head, db+tip*2]   = mO[batch, m_base+gid,   head, db+tip*2]   * inv_u
+            mO[batch, m_base+gid,   head, db+tip*2+1]  = mO[batch, m_base+gid,   head, db+tip*2+1]  * inv_u
+            mO[batch, m_base+gid+8, head, db+tip*2]   = mO[batch, m_base+gid+8, head, db+tip*2]   * inv_l
+            mO[batch, m_base+gid+8, head, db+tip*2+1]  = mO[batch, m_base+gid+8, head, db+tip*2+1]  * inv_l
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Optimized: 4-warp, register O accumulation
+# /////////////////////////////////////////////////////////////////////////////
+
+class FP8FlashAttentionSm120Opt:
+    """Optimized FP8 Flash Attention for SM120.
+
+    4 warps (128 threads), M=64 (16 rows/warp), N=32.
+    Register O accumulation, CpAsync GMEM→SMEM pipeline,
+    SMEM bank-conflict-free padding, vectorized V transpose.
+    """
+
+    def __init__(self, head_dim, n_block_size=32, is_causal=False):
+        assert head_dim % 32 == 0
+        self._head_dim = head_dim
+        self._is_causal = is_causal
+        self._M = 64   # 4 warps × 16
+        self._N = n_block_size
+        self._num_warps = 4
+        self._num_threads = 128
+
+    @cute.jit
+    def __call__(self, mQ, mK, mV, mO, softmax_scale, stream):
+        fp8 = cutlass.Float8E4M3FN
+        M, N, D = self._M, self._N, self._head_dim
+
+        # Padded strides to avoid SMEM bank conflicts.
+        # Without padding, gid 0-7 all hit the same bank (8-way conflict).
+        # Padding must be 16-byte aligned for CpAsync 128-bit copies.
+        # +16 bytes per FP8 row → (D+16)/4 mod 32 != 0 → no bank conflicts.
+        D_pad = D + 16  # FP8 row stride for Q, K, V (16-byte aligned)
+        N_pad = N + 16  # FP8 row stride for Vt (transposed)
+        NP_pad = N + 4  # F32 row stride for P (4 extra F32 = 16 bytes)
+
+        sQ_layout = cute.make_layout((M, D), stride=(D_pad, 1))
+        sK_layout = cute.make_layout((N, D), stride=(D_pad, 1))
+        sVt_layout = cute.make_layout((D, N), stride=(N_pad, 1))
+        sP_layout = cute.make_layout((M, N), stride=(NP_pad, 1))
+
+        @cute.struct
+        class SharedStorage:
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sQ_layout)], 128]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sK_layout)], 128]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sK_layout)], 128]
+            sVt: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sVt_layout)], 128]
+            sP_f32: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(sP_layout)], 128]
+
+        # G→S copy: CpAsync 128-bit = 16 FP8 per copy, 128 threads
+        g2s_bits = 128
+        g2s_elems = g2s_bits // fp8.width  # 16
+        g2s_atom = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            fp8, num_bits_per_copy=g2s_bits)
+        t_dim = D // g2s_elems  # D-adaptive: threads along D
+        num_m = self._num_threads // t_dim
+        tv_layout = cute.make_layout((num_m, t_dim), stride=(t_dim, 1))
+        v_layout = cute.make_layout((1, g2s_elems))
+        g2s_tiled = cute.make_tiled_copy_tv(g2s_atom, tv_layout, v_layout)
+
+        grid = (cute.ceil_div(mQ.shape[1], M), cute.size(mQ.shape[0]),
+                cute.size(mQ.shape[2]))
+        LOG2E = 1.4426950408889634074
+
+        self.kernel(
+            mQ, mK, mV, mO, softmax_scale * LOG2E,
+            sQ_layout, sK_layout, sVt_layout, sP_layout,
+            g2s_tiled, SharedStorage,
+        ).launch(grid=grid, block=[self._num_threads, 1, 1], stream=stream,
+                 smem=SharedStorage.size_in_bytes())
+
+    @cute.kernel
+    def kernel(self, mQ: cute.Tensor, mK: cute.Tensor, mV: cute.Tensor,
+               mO: cute.Tensor, scale_log2: cutlass.Float32,
+               sQ_layout: cute.Layout, sK_layout: cute.Layout,
+               sVt_layout: cute.Layout, sP_layout: cute.Layout,
+               g2s_tiled: cute.TiledCopy, SharedStorage: cutlass.Constexpr):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_block, batch, head = cute.arch.block_idx()
+        M, N, D = self._M, self._N, self._head_dim
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(sQ_layout)
+        sK = storage.sK.get_tensor(sK_layout)
+        sV = storage.sV.get_tensor(sK_layout)
+        sVt = storage.sVt.get_tensor(sVt_layout)
+        sP_f32 = storage.sP_f32.get_tensor(sP_layout)
+
+        warp_idx = tidx // 32
+        lane_id = tidx % 32
+        gid = lane_id // 4
+        tip = lane_id % 4
+        m_warp = warp_idx * 16
+        m_base = m_block * M
+
+        n_block_max = cute.ceil_div(mK.shape[1], N)
+        if self._is_causal:
+            n_block_max = min(
+                cute.ceil_div((m_block + 1) * M, N), n_block_max)
+
+        # CpAsync load Q tile to SMEM
+        gQ = cute.local_tile(
+            mQ[batch, None, head, None], (M, D), (m_block, 0))
+        thr_g2s = g2s_tiled.get_slice(tidx)
+        cute.copy(g2s_tiled, thr_g2s.partition_S(gQ), thr_g2s.partition_D(sQ))
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        # Prefetch first K tile (CpAsync, in-flight during init)
+        n_block_first = n_block_max - 1
+        gK_pf = cute.local_tile(
+            mK[batch, None, head, None], (N, D), (n_block_first, 0))
+        cute.copy(g2s_tiled, thr_g2s.partition_S(gK_pf),
+                  thr_g2s.partition_D(sK))
+        cute.arch.cp_async_commit_group()
+
+        # Init O accumulators in registers: D/8 sub-tiles × 4 regs
+        n_d_tiles = D // 8
+        # Using flat arrays for O: o_0..o_3 per d-sub-tile
+        # Store as list of 4-tuples, indexed by d-tile
+        o_regs = [
+            [cutlass.Float32(0.0), cutlass.Float32(0.0),
+             cutlass.Float32(0.0), cutlass.Float32(0.0)]
+            for _ in range(n_d_tiles)
+        ]
+
+        row_max_u = cutlass.Float32(-3.4028235e+38)
+        row_max_l = cutlass.Float32(-3.4028235e+38)
+        row_sum_u = cutlass.Float32(0.0)
+        row_sum_l = cutlass.Float32(0.0)
+
+        sQ_f32 = cute.recast_tensor(sQ, cutlass.Float32)
+        n_k = D // 32
+        n_n_sub = N // 8  # n-sub-tiles for QK GEMM
+        n_pv_k_iters = N // 32  # k-iterations for PV GEMM
+
+        for n_tile in range(n_block_max):
+            nb = n_block_max - n_tile - 1
+
+            # ---- Wait for K (CpAsync from previous iteration or prologue) ----
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+
+            # ---- Issue async V load (overlaps with QK GEMM) ----
+            gV = cute.local_tile(
+                mV[batch, None, head, None], (N, D), (nb, 0))
+            cute.copy(g2s_tiled, thr_g2s.partition_S(gV),
+                      thr_g2s.partition_D(sV))
+            cute.arch.cp_async_commit_group()
+
+            sK_f32 = cute.recast_tensor(sK, cutlass.Float32)
+
+            # ---- QK GEMM ----
+            # S accumulators: n_n_sub sub-tiles × 4 regs
+            s_regs = [
+                [cutlass.Float32(0.0), cutlass.Float32(0.0),
+                 cutlass.Float32(0.0), cutlass.Float32(0.0)]
+                for _ in range(n_n_sub)
+            ]
+
+            for ki in cutlass.range_constexpr(n_k):
+                kb = ki * 8
+                a0 = bitcast_f32_to_i32(sQ_f32[m_warp + gid,     kb + tip])
+                a1 = bitcast_f32_to_i32(sQ_f32[m_warp + gid + 8, kb + tip])
+                a2 = bitcast_f32_to_i32(sQ_f32[m_warp + gid,     kb + tip + 4])
+                a3 = bitcast_f32_to_i32(sQ_f32[m_warp + gid + 8, kb + tip + 4])
+
+                for ni in cutlass.range_constexpr(n_n_sub):
+                    b0 = bitcast_f32_to_i32(sK_f32[ni * 8 + gid, kb + tip])
+                    b1 = bitcast_f32_to_i32(sK_f32[ni * 8 + gid, kb + tip + 4])
+                    s_regs[ni][0], s_regs[ni][1], s_regs[ni][2], s_regs[ni][3] = \
+                        mma_f8f6f4_m16n8k32_e4m3(
+                            a0, a1, a2, a3, b0, b1,
+                            s_regs[ni][0], s_regs[ni][1],
+                            s_regs[ni][2], s_regs[ni][3])
+
+            # ---- Causal mask ----
+            if self._is_causal:
+                neginf = cutlass.Float32(-3.4028235e+38)
+                q_u = m_base + m_warp + gid
+                q_l = m_base + m_warp + gid + 8
+                for ni in cutlass.range_constexpr(n_n_sub):
+                    c0 = nb * N + ni * 8 + tip * 2
+                    c1 = c0 + 1
+                    s_regs[ni][0] = neginf if c0 > q_u else s_regs[ni][0]
+                    s_regs[ni][1] = neginf if c1 > q_u else s_regs[ni][1]
+                    s_regs[ni][2] = neginf if c0 > q_l else s_regs[ni][2]
+                    s_regs[ni][3] = neginf if c1 > q_l else s_regs[ni][3]
+
+            # ---- Online softmax: row max ----
+            lmu = s_regs[0][0]
+            lml = s_regs[0][2]
+            for ni in cutlass.range_constexpr(n_n_sub):
+                lmu = cute.arch.fmax(lmu, cute.arch.fmax(s_regs[ni][0], s_regs[ni][1]))
+                lml = cute.arch.fmax(lml, cute.arch.fmax(s_regs[ni][2], s_regs[ni][3]))
+            # Thread-quad reduction for row max
+            lmu = cute.arch.fmax(lmu, cute.arch.shuffle_sync_bfly(
+                lmu, offset=2, mask=-1, mask_and_clamp=31))
+            lmu = cute.arch.fmax(lmu, cute.arch.shuffle_sync_bfly(
+                lmu, offset=1, mask=-1, mask_and_clamp=31))
+            lml = cute.arch.fmax(lml, cute.arch.shuffle_sync_bfly(
+                lml, offset=2, mask=-1, mask_and_clamp=31))
+            lml = cute.arch.fmax(lml, cute.arch.shuffle_sync_bfly(
+                lml, offset=1, mask=-1, mask_and_clamp=31))
+
+            new_mu = cute.arch.fmax(row_max_u, lmu)
+            new_ml = cute.arch.fmax(row_max_l, lml)
+
+            # Rescale O accumulators
+            resc_u = cute.math.exp2(
+                row_max_u * scale_log2 - new_mu * scale_log2, fastmath=True)
+            resc_l = cute.math.exp2(
+                row_max_l * scale_log2 - new_ml * scale_log2, fastmath=True)
+
+            for dt in cutlass.range_constexpr(n_d_tiles):
+                o_regs[dt][0] = o_regs[dt][0] * resc_u
+                o_regs[dt][1] = o_regs[dt][1] * resc_u
+                o_regs[dt][2] = o_regs[dt][2] * resc_l
+                o_regs[dt][3] = o_regs[dt][3] * resc_l
+
+            row_sum_u = row_sum_u * resc_u
+            row_sum_l = row_sum_l * resc_l
+
+            # Apply exp2 to S and accumulate row_sum
+            for ni in cutlass.range_constexpr(n_n_sub):
+                s_regs[ni][0] = cute.math.exp2(
+                    s_regs[ni][0] * scale_log2 - new_mu * scale_log2, fastmath=True)
+                s_regs[ni][1] = cute.math.exp2(
+                    s_regs[ni][1] * scale_log2 - new_mu * scale_log2, fastmath=True)
+                s_regs[ni][2] = cute.math.exp2(
+                    s_regs[ni][2] * scale_log2 - new_ml * scale_log2, fastmath=True)
+                s_regs[ni][3] = cute.math.exp2(
+                    s_regs[ni][3] * scale_log2 - new_ml * scale_log2, fastmath=True)
+                row_sum_u = row_sum_u + s_regs[ni][0] + s_regs[ni][1]
+                row_sum_l = row_sum_l + s_regs[ni][2] + s_regs[ni][3]
+
+            row_max_u = new_mu
+            row_max_l = new_ml
+
+            # ---- Write P to sP_f32 (CLayout → row-major for PV A-operand) ----
+            for ni in cutlass.range_constexpr(n_n_sub):
+                col_base = ni * 8
+                sP_f32[m_warp + gid,     col_base + tip*2]     = s_regs[ni][0]
+                sP_f32[m_warp + gid,     col_base + tip*2 + 1] = s_regs[ni][1]
+                sP_f32[m_warp + gid + 8, col_base + tip*2]     = s_regs[ni][2]
+                sP_f32[m_warp + gid + 8, col_base + tip*2 + 1] = s_regs[ni][3]
+
+            # ---- Wait for V (CpAsync), issue next K prefetch ----
+            cute.arch.cp_async_wait_group(0)
+            cute.arch.sync_threads()
+
+            # Prefetch next K (overlaps with transpose + PV GEMM)
+            if nb > 0:
+                gK_next = cute.local_tile(
+                    mK[batch, None, head, None], (N, D), (nb - 1, 0))
+                cute.copy(g2s_tiled, thr_g2s.partition_S(gK_next),
+                          thr_g2s.partition_D(sK))
+                cute.arch.cp_async_commit_group()
+
+            # Transpose sV[N,D] → sVt[D,N] using vectorized 4x4 byte blocks.
+            # Each block: load 4 i32 from 4 consecutive rows of sV (same col group),
+            # transpose 4x4 bytes in registers via prmt.b32, store 4 i32 to sVt.
+            # 4x fewer SMEM ops than element-wise (8 vs 32 per 16-byte block).
+            sV_f32_tr = cute.recast_tensor(sV, cutlass.Float32)
+            sVt_f32_tr = cute.recast_tensor(sVt, cutlass.Float32)
+            n_blocks_n = N // 4
+            n_blocks_d = D // 4
+            n_total_blocks = n_blocks_n * n_blocks_d
+            n_blocks_per_thread = n_total_blocks // self._num_threads
+            for bi in cutlass.range_constexpr(n_blocks_per_thread):
+                block_idx = tidx * n_blocks_per_thread + bi
+                bn = block_idx // n_blocks_d
+                bd = block_idx % n_blocks_d
+                r0 = bitcast_f32_to_i32(sV_f32_tr[bn * 4 + 0, bd])
+                r1 = bitcast_f32_to_i32(sV_f32_tr[bn * 4 + 1, bd])
+                r2 = bitcast_f32_to_i32(sV_f32_tr[bn * 4 + 2, bd])
+                r3 = bitcast_f32_to_i32(sV_f32_tr[bn * 4 + 3, bd])
+                t0, t1, t2, t3 = transpose_4x4_bytes(r0, r1, r2, r3)
+                sVt_f32_tr[bd * 4 + 0, bn] = bitcast_i32_to_f32(t0)
+                sVt_f32_tr[bd * 4 + 1, bn] = bitcast_i32_to_f32(t1)
+                sVt_f32_tr[bd * 4 + 2, bn] = bitcast_i32_to_f32(t2)
+                sVt_f32_tr[bd * 4 + 3, bn] = bitcast_i32_to_f32(t3)
+            cute.arch.sync_threads()
+
+            sVt_f32 = cute.recast_tensor(sVt, cutlass.Float32)
+
+            # ---- PV GEMM: O += P × V^T (register-accumulated) ----
+            for pv_ki in cutlass.range_constexpr(n_pv_k_iters):
+                pk_base = pv_ki * 32
+                # Load A (P) from sP_f32, convert to FP8
+                pa0 = cvt_f32_to_fp8x4(
+                    sP_f32[m_warp + gid, pk_base + tip*4],
+                    sP_f32[m_warp + gid, pk_base + tip*4 + 1],
+                    sP_f32[m_warp + gid, pk_base + tip*4 + 2],
+                    sP_f32[m_warp + gid, pk_base + tip*4 + 3])
+                pa1 = cvt_f32_to_fp8x4(
+                    sP_f32[m_warp + gid + 8, pk_base + tip*4],
+                    sP_f32[m_warp + gid + 8, pk_base + tip*4 + 1],
+                    sP_f32[m_warp + gid + 8, pk_base + tip*4 + 2],
+                    sP_f32[m_warp + gid + 8, pk_base + tip*4 + 3])
+                pa2 = cvt_f32_to_fp8x4(
+                    sP_f32[m_warp + gid, pk_base + 16 + tip*4],
+                    sP_f32[m_warp + gid, pk_base + 16 + tip*4 + 1],
+                    sP_f32[m_warp + gid, pk_base + 16 + tip*4 + 2],
+                    sP_f32[m_warp + gid, pk_base + 16 + tip*4 + 3])
+                pa3 = cvt_f32_to_fp8x4(
+                    sP_f32[m_warp + gid + 8, pk_base + 16 + tip*4],
+                    sP_f32[m_warp + gid + 8, pk_base + 16 + tip*4 + 1],
+                    sP_f32[m_warp + gid + 8, pk_base + 16 + tip*4 + 2],
+                    sP_f32[m_warp + gid + 8, pk_base + 16 + tip*4 + 3])
+
+                vt_k_offset = pv_ki * 8  # offset in sVt_f32 second dim
+                for dt in cutlass.range_constexpr(n_d_tiles):
+                    db = dt * 8
+                    vb0 = bitcast_f32_to_i32(
+                        sVt_f32[db + gid, vt_k_offset + tip])
+                    vb1 = bitcast_f32_to_i32(
+                        sVt_f32[db + gid, vt_k_offset + tip + 4])
+                    o_regs[dt][0], o_regs[dt][1], o_regs[dt][2], o_regs[dt][3] = \
+                        mma_f8f6f4_m16n8k32_e4m3(
+                            pa0, pa1, pa2, pa3, vb0, vb1,
+                            o_regs[dt][0], o_regs[dt][1],
+                            o_regs[dt][2], o_regs[dt][3])
+
+            cute.arch.sync_threads()
+
+        # ---- Final normalize: O /= row_sum ----
+        row_sum_u = row_sum_u + cute.arch.shuffle_sync_bfly(
+            row_sum_u, offset=2, mask=-1, mask_and_clamp=31)
+        row_sum_u = row_sum_u + cute.arch.shuffle_sync_bfly(
+            row_sum_u, offset=1, mask=-1, mask_and_clamp=31)
+        row_sum_l = row_sum_l + cute.arch.shuffle_sync_bfly(
+            row_sum_l, offset=2, mask=-1, mask_and_clamp=31)
+        row_sum_l = row_sum_l + cute.arch.shuffle_sync_bfly(
+            row_sum_l, offset=1, mask=-1, mask_and_clamp=31)
+
+        inv_u = cutlass.Float32(1.0) / row_sum_u if row_sum_u != cutlass.Float32(0.0) else cutlass.Float32(1.0)
+        inv_l = cutlass.Float32(1.0) / row_sum_l if row_sum_l != cutlass.Float32(0.0) else cutlass.Float32(1.0)
+
+        # Write normalized O to GMEM
+        for dt in cutlass.range_constexpr(n_d_tiles):
+            db = dt * 8
+            mO[batch, m_base + m_warp + gid,     head, db + tip*2]     = o_regs[dt][0] * inv_u
+            mO[batch, m_base + m_warp + gid,     head, db + tip*2 + 1] = o_regs[dt][1] * inv_u
+            mO[batch, m_base + m_warp + gid + 8, head, db + tip*2]     = o_regs[dt][2] * inv_l
+            mO[batch, m_base + m_warp + gid + 8, head, db + tip*2 + 1] = o_regs[dt][3] * inv_l
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Test
+# /////////////////////////////////////////////////////////////////////////////
+
+def make_cute_fp8(t):
+    fp8 = cutlass.Float8E4M3FN
+    u8 = t.view(torch.uint8)
+    ct = from_dlpack(u8, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=u8.dim_order(), divisibility=(128 // fp8.width))
+    ct.element_type = fp8
+    return ct
+
+def make_cute_f32(t):
+    return from_dlpack(t, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=t.dim_order(), divisibility=4)
+
+
+def run_test(B, Sq, Sk, H, D, is_causal=False, desc="", use_opt=False):
+    scale = 1.0 / (D ** 0.5)
+    torch.manual_seed(42)
+    q = (torch.randn(B, Sq, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    k = (torch.randn(B, Sk, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    v = (torch.randn(B, Sk, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
+
+    # Reference
+    qf = q.float().view(B * H, Sq, D)
+    kf = k.float().view(B * H, Sk, D)
+    vf = v.float().view(B * H, Sk, D)
+    s = torch.bmm(qf, kf.transpose(1, 2)) * scale
+    if is_causal:
+        mask = torch.triu(torch.ones(Sq, Sk, device='cuda'), diagonal=1).bool()
+        s.masked_fill_(mask.unsqueeze(0), float('-inf'))
+    p = torch.softmax(s, dim=-1)
+    ref = torch.bmm(p, vf).view(B, Sq, H, D)
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    o_f32 = torch.zeros(B, Sq, H, D, dtype=torch.float32, device='cuda')
+
+    if use_opt:
+        kern = FP8FlashAttentionSm120Opt(D, is_causal=is_causal)
+    else:
+        kern = FP8FlashAttentionSm120(D, is_causal=is_causal)
+    compiled = cute.compile(kern, make_cute_fp8(q), make_cute_fp8(k),
+                            make_cute_fp8(v), make_cute_f32(o_f32),
+                            scale, stream)
+    compiled(make_cute_fp8(q), make_cute_fp8(k), make_cute_fp8(v),
+             make_cute_f32(o_f32), scale, stream)
+    torch.cuda.synchronize()
+
+    diff = (o_f32 - ref).abs()
+    max_d = diff.max().item()
+    mean_d = diff.mean().item()
+    ok = max_d < 0.1
+    tag = ("opt" if use_opt else "poc") + (" causal" if is_causal else "")
+    print(f"{'PASS' if ok else 'FAIL'} | {desc:30s} | B={B} Sq={Sq:3d} Sk={Sk:3d} "
+          f"H={H} D={D:3d} {tag:12s} | max={max_d:.6f} mean={mean_d:.6f}")
+    return ok
+
+
+def run_benchmark(
+    batch_size, seqlen_q, seqlen_k, num_head, head_dim,
+    softmax_scale=None, is_causal=False,
+    warmup_iterations=10, iterations=50,
+    skip_ref_check=False, use_opt=True,
+):
+    """Benchmark FP8 flash attention. Returns avg time in microseconds."""
+    import cutlass.cute.testing as testing
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / (head_dim ** 0.5)
+
+    tag = "opt" if use_opt else "poc"
+    print(f"Running FP8 FA ({tag}): B={batch_size} Sq={seqlen_q} "
+          f"Sk={seqlen_k} H={num_head} D={head_dim} causal={is_causal}")
+
+    torch.manual_seed(42)
+    q_torch = (torch.randn(batch_size, seqlen_q, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    k_torch = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    v_torch = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    o_torch = torch.zeros(batch_size, seqlen_q, num_head, head_dim,
+                          dtype=torch.float32, device='cuda')
+
+    q = make_cute_fp8(q_torch)
+    k = make_cute_fp8(k_torch)
+    v = make_cute_fp8(v_torch)
+    o = make_cute_f32(o_torch)
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    if use_opt:
+        kern = FP8FlashAttentionSm120Opt(head_dim, is_causal=is_causal)
+    else:
+        kern = FP8FlashAttentionSm120(head_dim, is_causal=is_causal)
+    compiled = cute.compile(kern, q, k, v, o, softmax_scale, stream)
+
+    if not skip_ref_check:
+        compiled(q, k, v, o, softmax_scale, stream)
+        torch.cuda.synchronize()
+        qf = q_torch.float().view(batch_size * num_head, seqlen_q, head_dim)
+        kf = k_torch.float().view(batch_size * num_head, seqlen_k, head_dim)
+        vf = v_torch.float().view(batch_size * num_head, seqlen_k, head_dim)
+        s = torch.bmm(qf, kf.transpose(1, 2)) * softmax_scale
+        if is_causal:
+            mask = torch.triu(torch.ones(seqlen_q, seqlen_k, device='cuda'),
+                              diagonal=1).bool()
+            s.masked_fill_(mask.unsqueeze(0), float('-inf'))
+        p = torch.softmax(s, dim=-1)
+        ref = torch.bmm(p, vf).view(batch_size, seqlen_q, num_head, head_dim)
+        diff = (o_torch - ref).abs().max().item()
+        assert diff < 0.1, f"Reference check failed: max_diff={diff}"
+        print(f"  Reference check passed (max_diff={diff:.6f})")
+        o_torch.zero_()
+
+    def generate_tensors():
+        q_w = (torch.randn(batch_size, seqlen_q, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+        k_w = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+        v_w = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+        o_w = torch.zeros(batch_size, seqlen_q, num_head, head_dim,
+                          dtype=torch.float32, device='cuda')
+        jit_args = testing.JitArguments(
+            make_cute_fp8(q_w), make_cute_fp8(k_w), make_cute_fp8(v_w),
+            make_cute_f32(o_w), softmax_scale, stream,
+        )
+        jit_args.add_to_scope([q_w, k_w, v_w, o_w])
+        return jit_args
+
+    avg_time_us = testing.benchmark(
+        compiled,
+        workspace_generator=generate_tensors,
+        workspace_count=1,
+        stream=stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+    )
+
+    return avg_time_us
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="FP8 Flash Attention v2 for SM120 (Blackwell GeForce)")
+    parser.add_argument("--quick", action="store_true", help="Run minimal tests")
+    parser.add_argument("--benchmark", action="store_true",
+                        help="Run benchmarks instead of correctness tests")
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--seqlen", type=int, default=512)
+    parser.add_argument("--num_head", type=int, default=16)
+    parser.add_argument("--head_dim", type=int, default=128)
+    parser.add_argument("--is_causal", action="store_true")
+    parser.add_argument("--warmup_iterations", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--skip_ref_check", action="store_true")
+    args = parser.parse_args()
+
+    if args.benchmark:
+        avg_us = run_benchmark(
+            args.batch_size, args.seqlen, args.seqlen, args.num_head,
+            args.head_dim, is_causal=args.is_causal,
+            warmup_iterations=args.warmup_iterations,
+            iterations=args.iterations,
+            skip_ref_check=args.skip_ref_check,
+            use_opt=True,
+        )
+        flops = 4 * args.batch_size * args.num_head * args.seqlen * args.seqlen * args.head_dim
+        if args.is_causal:
+            flops //= 2
+        tflops = flops / (avg_us * 1e-6) / 1e12
+        print(f"avg time: {avg_us:.2f} us, {tflops:.2f} TFLOPS")
+        print("PASS")
+    else:
+        all_pass = True
+
+        # POC kernel tests (single-warp, M=16)
+        poc_configs = [
+            (1, 16, 32, 1, 128, False, "POC: single tile"),
+            (1, 16, 64, 1, 128, False, "POC: Sq=16 Sk=64"),
+            (1, 16, 128, 1, 128, False, "POC: Sq=16 Sk=128"),
+            (1, 32, 64, 1, 128, False, "POC: multi M-tile"),
+            (1, 64, 128, 1, 128, False, "POC: Sq=64 Sk=128"),
+        ]
+        if not args.quick:
+            poc_configs += [
+                (1, 16, 32, 1, 64, False, "POC: D=64"),
+                (1, 16, 32, 1, 256, False, "POC: D=256"),
+                (2, 32, 64, 1, 128, False, "POC: batch=2"),
+                (1, 32, 64, 4, 128, False, "POC: heads=4"),
+                (1, 32, 32, 1, 128, True, "POC: causal 32"),
+                (1, 64, 64, 1, 128, True, "POC: causal 64"),
+            ]
+
+        for B, Sq, Sk, H, D, causal, desc in poc_configs:
+            ok = run_test(B, Sq, Sk, H, D, is_causal=causal, desc=desc)
+            if not ok:
+                all_pass = False
+
+        # Optimized kernel tests (4-warp, M=64, register O)
+        opt_configs = [
+            (1, 64, 64, 1, 128, False, "Opt: single tile"),
+            (1, 64, 128, 1, 128, False, "Opt: Sq=64 Sk=128"),
+            (1, 128, 256, 1, 128, False, "Opt: multi M-tile"),
+            (1, 64, 64, 1, 64, False, "Opt: D=64"),
+        ]
+        if not args.quick:
+            opt_configs += [
+                (2, 128, 128, 1, 128, False, "Opt: batch=2"),
+                (1, 128, 128, 4, 128, False, "Opt: heads=4"),
+                (1, 64, 64, 1, 128, True, "Opt: causal 64"),
+                (1, 128, 128, 1, 128, True, "Opt: causal 128"),
+                (1, 256, 256, 1, 128, True, "Opt: causal 256"),
+            ]
+
+        for B, Sq, Sk, H, D, causal, desc in opt_configs:
+            ok = run_test(B, Sq, Sk, H, D, is_causal=causal, desc=desc,
+                          use_opt=True)
+            if not ok:
+                all_pass = False
+
+        print(f"\n{'ALL TESTS PASSED!' if all_pass else 'SOME TESTS FAILED!'}")

--- a/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention.py
@@ -1,17 +1,20 @@
 # Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-#
+
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
+
 # 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer.
+# list of conditions and the following disclaimer.
+
 # 2. Redistributions in binary form must reproduce the above copyright notice,
-#    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution.
-# 3. Neither the name of the copyright holder nor the names of its contributors
-#    may be used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention.py
@@ -887,16 +887,19 @@ def run_test(B, Sq, Sk, H, D, is_causal=False, desc="", use_opt=False):
     k = (torch.randn(B, Sk, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
     v = (torch.randn(B, Sk, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
 
-    # Reference
-    qf = q.float().view(B * H, Sq, D)
-    kf = k.float().view(B * H, Sk, D)
-    vf = v.float().view(B * H, Sk, D)
+    # Reference: must permute (B, S, H, D) -> (B, H, S, D) before flattening to
+    # (B*H, S, D); a plain view would interleave seq and head, scrambling per-head
+    # data for H >= 2 and silently failing the comparison even when the kernel is
+    # correct.
+    qf = q.float().permute(0, 2, 1, 3).contiguous().view(B * H, Sq, D)
+    kf = k.float().permute(0, 2, 1, 3).contiguous().view(B * H, Sk, D)
+    vf = v.float().permute(0, 2, 1, 3).contiguous().view(B * H, Sk, D)
     s = torch.bmm(qf, kf.transpose(1, 2)) * scale
     if is_causal:
         mask = torch.triu(torch.ones(Sq, Sk, device='cuda'), diagonal=1).bool()
         s.masked_fill_(mask.unsqueeze(0), float('-inf'))
     p = torch.softmax(s, dim=-1)
-    ref = torch.bmm(p, vf).view(B, Sq, H, D)
+    ref = torch.bmm(p, vf).view(B, H, Sq, D).permute(0, 2, 1, 3).contiguous()
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
     o_f32 = torch.zeros(B, Sq, H, D, dtype=torch.float32, device='cuda')
@@ -964,16 +967,19 @@ def run_benchmark(
     if not skip_ref_check:
         compiled(q, k, v, o, softmax_scale, stream)
         torch.cuda.synchronize()
-        qf = q_torch.float().view(batch_size * num_head, seqlen_q, head_dim)
-        kf = k_torch.float().view(batch_size * num_head, seqlen_k, head_dim)
-        vf = v_torch.float().view(batch_size * num_head, seqlen_k, head_dim)
+        # See note in run_test: must permute (B, S, H, D) -> (B, H, S, D) before
+        # flattening; plain view interleaves seq and head and gives a wrong
+        # reference for H >= 2.
+        qf = q_torch.float().permute(0, 2, 1, 3).contiguous().view(batch_size * num_head, seqlen_q, head_dim)
+        kf = k_torch.float().permute(0, 2, 1, 3).contiguous().view(batch_size * num_head, seqlen_k, head_dim)
+        vf = v_torch.float().permute(0, 2, 1, 3).contiguous().view(batch_size * num_head, seqlen_k, head_dim)
         s = torch.bmm(qf, kf.transpose(1, 2)) * softmax_scale
         if is_causal:
             mask = torch.triu(torch.ones(seqlen_q, seqlen_k, device='cuda'),
                               diagonal=1).bool()
             s.masked_fill_(mask.unsqueeze(0), float('-inf'))
         p = torch.softmax(s, dim=-1)
-        ref = torch.bmm(p, vf).view(batch_size, seqlen_q, num_head, head_dim)
+        ref = torch.bmm(p, vf).view(batch_size, num_head, seqlen_q, head_dim).permute(0, 2, 1, 3).contiguous()
         diff = (o_torch - ref).abs().max().item()
         assert diff < 0.1, f"Reference check failed: max_diff={diff}"
         print(f"  Reference check passed (max_diff={diff:.6f})")

--- a/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention_tma.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention_tma.py
@@ -37,22 +37,35 @@ Key differences from FP8FlashAttentionSm120Opt (CpAsync):
   - 1 dedicated DMA warp + 4 MMA warps (warp specialization)
   - kv_stages=2 double-buffered K/V SMEM via PipelineTmaAsync
   - mbarrier-based producer/consumer sync
-  - Default tile sizing M=128, N=64 (canonical for SM120 TMA), vs M=64, N=32
+  - Default tile sizing M=128, N=32 (canonical for SM120 TMA + FP8), vs M=64, N=32
 
 Key differences from BF16 TMA (FlashAttentionForwardSm120Tma):
   - FP8 e4m3 MMA via inline PTX kind::f8f6f4.m16n8k32 (no atom in cutlass-dsl 4.4.2)
-  - Per-thread SMEM arithmetic for register fragment load (no ldmatrix path —
-    deferred until LdMatrix8x8x16bOp is wired for FP8)
-  - 4×4 byte register transpose for V (no LdMatrix(transpose=True) path)
-  - sP staged in F32 SMEM (not in registers) — same as FP8 Opt
+  - All Q/K/V via inline-PTX ldmatrix.x4(.trans) on swizzled SMEM (manual
+    swizzle bit-math: addr ^ (((addr >> 7) & ((1<<B)-1)) << 4))
+  - Register-resident P via warp-shuffle redistribution (no sP_f32 SMEM)
+  - Per-thread bridge required: gid/tip swap in f8f6f4 B operand layout means
+    ldmatrix output doesn't directly produce B-operand register layout (Q: 4
+    shuffles/call; K: 8 shuffles + 4 prmt; V: 16 shuffles + 8 selp + 4 prmt)
 
-Perf (DGX Spark / SM121a, sum-time over the 16-config Aneureka matrix):
-  - 1.02x vs FP8FlashAttentionSm120Opt   (roughly tied)
-  - 0.84x vs FlashAttentionForwardSm120Tma (BF16 TMA)  (slower)
-  - Wins on the bigger D=128 shapes (B=4 S=1024 D=128: 1.35x of FP8 Opt;
-    B=1 S=512 D=128 causal: 1.24x), loses on small D=64 shapes.
-  Path A (FP8 ldmatrix.trans) and register-resident P remain the levers needed
-  to beat the BF16 TMA kernel.
+Output dtype:
+  - FP32 (default): pass torch.float32 output tensor (use make_cute_f32)
+  - BF16:           pass torch.bfloat16 output (use make_cute_bf16) — single-
+    instruction cvt.rn.bf16x2.f32 + packed Int32 store. Matches the production
+    FP8 attention pattern (FP8 in, BF16 out).
+
+Perf (DGX Spark / SM121a, sum-time over the 16-config Aneureka matrix,
+median of 50 iters per config, F32 output, N=32 default):
+  - 1.10x vs FP8FlashAttentionSm120Opt
+  - 0.91x vs FlashAttentionForwardSm120Tma (BF16 TMA, BF16 output)
+  - With per-shape N picked by `benchmark_fp8_vs_bf16.py` (N=64 only on
+    non-causal D=128 high-CTA shapes): 0.93x of BF16 TMA sum-time, with
+    multiple configs ≥1.0x of BF16 (e.g. B=1 S=512 D=64: 1.04x; B=1 S=2048
+    D=64: 1.06x; B=4 S=512 D=64: 1.03x).
+  - Decisive peak on B=4 S=1024 D=128 non-causal: 1.47x of FP8 Opt at N=64.
+  - Remaining gap to BF16 TMA is structural — the f8f6f4 layout's bridge
+    cost (esp. PV's V bridge: 16 shuffles + 8 selp + 4 prmt per ldmatrix call)
+    can't be eliminated without an FP8 m16n8k32 TiledMma atom (CUTLASS #3044).
 """
 
 import argparse
@@ -227,6 +240,21 @@ def ldmatrix_x4_b16(smem_addr, *, loc=None, ip=None):
 
 
 @dsl_user_op
+def cvt_f32x2_to_bf16x2(v0, v1, *, loc=None, ip=None):
+    """Pack 2 FP32 → 2 BF16 in a 32-bit register (low: v0, high: v1).
+
+    Uses cvt.rn.bf16x2.f32 — single PTX instruction, no rounding penalty.
+    """
+    args = [Float32(x).ir_value(loc=loc, ip=ip) for x in [v0, v1]]
+    return Int32(llvm.inline_asm(
+        T.i32(), args,
+        "cvt.rn.bf16x2.f32 $0, $2, $1;",
+        "=r,f,f",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    ))
+
+
+@dsl_user_op
 def cvt_f32_to_fp8x4(v0, v1, v2, v3, *, loc=None, ip=None):
     """Pack 4 FP32 → 4 FP8 e4m3 bytes in uint32."""
     args = [Float32(x).ir_value(loc=loc, ip=ip) for x in [v0, v1, v2, v3]]
@@ -261,25 +289,31 @@ class FP8FlashAttentionSm120Tma:
 
     Tile config (defaults — `can_implement` checks alternates):
       - m_block_size=128 (4 MMA warps × 32 rows/warp = 2 m16 row groups)
-      - n_block_size=64
+      - n_block_size=32 (default; N=64 wins on B*H≥64 D=128 non-causal)
       - kv_stages=2 (K/V double-buffered via PipelineTmaAsync)
       - 1 DMA warp + 4 MMA warps = 160 threads/block
+
+    Per-shape N choice: empirically, N=32 wins on causal cases (smaller per-K-
+    iter overhead matters when causal halves the work) and small/medium D=64
+    shapes. N=64 wins on big-batch non-causal D=128 (more work per iter
+    amortizes the bridge cost). The kernel exposes n_block_size; the bench
+    `benchmark_fp8_vs_bf16.py` picks per shape automatically.
 
     SMEM budget at M=128, N=64, D=128, kv_stages=2:
       - sQ FP8: 128*128 = 16 KB
       - sK FP8: 64*128*2 = 16 KB
       - sV FP8: 64*128*2 = 16 KB
-      - sVt FP8: 128*80 = 10 KB (single stage; +16 byte row pad)
-      - sP: NONE (P held in registers via warp shuffles — `_compute_pa_quad`)
+      - sP / sVt: NONE — P is held in registers via warp shuffles, V is loaded
+        directly from sV via ldmatrix.x4.trans (no transpose-staging buffer).
       - mbar arrays + 1024-byte alignments: ~5 KB
-      - Total: ~63 KB (well under 99 KB SM120 budget; allows kv_stages=3)
+      - Total: ~53 KB (well under 99 KB SM120 budget)
     """
 
     def __init__(
         self,
         head_dim: int,
         m_block_size: int = 128,
-        n_block_size: int = 64,
+        n_block_size: int = 32,
         num_mma_warps: int = 4,
         kv_stages: int = 2,
         is_causal: bool = False,
@@ -321,14 +355,14 @@ class FP8FlashAttentionSm120Tma:
             # Per-warp masking + transpose work split currently assume 4 MMA warps.
             return False
         head_dim_padded = (head_dim + 31) // 32 * 32
-        # SMEM bytes: sQ + sK + sV + sVt + mbar arrays.  sP is no longer
-        # allocated since P is held in registers via warp shuffles.
+        # SMEM bytes: sQ + sK + sV + mbar arrays.  sP and sVt are not
+        # allocated: P is held in registers via warp shuffles; V is loaded
+        # directly via ldmatrix.x4.trans from sV (no transpose staging).
         smem_q = m_block_size * head_dim_padded
         smem_kv = n_block_size * head_dim_padded * kv_stages
-        smem_vt = head_dim_padded * (n_block_size + 16)
         smem_mbar = (1 + 2 * kv_stages * 2) * 8
-        align_pad = 1024 * 3 + 1024
-        smem_total = smem_q + smem_kv * 2 + smem_vt + smem_mbar + align_pad
+        align_pad = 1024 * 3
+        smem_total = smem_q + smem_kv * 2 + smem_mbar + align_pad
         smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
         if smem_total > smem_capacity:
             return False
@@ -372,10 +406,6 @@ class FP8FlashAttentionSm120Tma:
         sKV_one_layout = cute.slice_(sKV_layout_staged, (None, None, 0))
         sV_layout_staged = sKV_layout_staged
         sV_one_layout = sKV_one_layout
-        # sVt does NOT use TMA — keep row padding for bank conflicts.
-        # sP is no longer needed (P is held in registers via warp shuffles).
-        N_pad_vt = N + 16       # FP8 row stride for sVt
-        sVt_one_layout = cute.make_layout((D, N), stride=(N_pad_vt, 1))
 
         # /////////////////////////////////////////////////////////////////////
         # Reshape tensors for TMA: (batch, seq, head, dim) → (seq, dim, head, batch)
@@ -437,9 +467,6 @@ class FP8FlashAttentionSm120Tma:
             sV: cute.struct.Align[
                 cute.struct.MemRange[fp8, cute.cosize(sV_layout_staged)], 1024
             ]
-            sVt: cute.struct.Align[
-                cute.struct.MemRange[fp8, cute.cosize(sVt_one_layout)], 128
-            ]
 
         # Grid: (m_blocks, head*batch, 1)
         num_heads = cute.size(mQ.shape[2])
@@ -463,7 +490,6 @@ class FP8FlashAttentionSm120Tma:
             sQ_layout_staged,
             sKV_layout_staged,
             sV_layout_staged,
-            sVt_one_layout,
             SharedStorage,
             num_heads,
         ).launch(
@@ -493,7 +519,6 @@ class FP8FlashAttentionSm120Tma:
         sQ_layout_staged: cute.ComposedLayout,
         sKV_layout_staged: cute.ComposedLayout,
         sV_layout_staged: cute.ComposedLayout,
-        sVt_one_layout: cute.Layout,
         SharedStorage: cutlass.Constexpr,
         num_heads: cutlass.Int32,
     ):
@@ -528,7 +553,6 @@ class FP8FlashAttentionSm120Tma:
         sV = storage.sV.get_tensor(
             sV_layout_staged.outer, swizzle=sV_layout_staged.inner
         )
-        sVt = storage.sVt.get_tensor(sVt_one_layout)
 
         # /////////////////////////////////////////////////////////////////////
         # TMA partition: GMEM tile mapping
@@ -1092,16 +1116,34 @@ class FP8FlashAttentionSm120Tma:
                 inv_l = cutlass.Float32(1.0) / rsl if rsl != cutlass.Float32(0.0) else cutlass.Float32(1.0)
 
                 rg = m_warp_base + g * 16
-                for dt in cutlass.range_constexpr(n_d_tiles):
-                    db = dt * 8
-                    row_u = m_base + rg + gid
-                    row_l = m_base + rg + gid + 8
-                    if row_u < seq_lim:
-                        mO[batch_idx, row_u, head_idx, db + tip*2]     = o_regs[g][dt][0] * inv_u
-                        mO[batch_idx, row_u, head_idx, db + tip*2 + 1] = o_regs[g][dt][1] * inv_u
-                    if row_l < seq_lim:
-                        mO[batch_idx, row_l, head_idx, db + tip*2]     = o_regs[g][dt][2] * inv_l
-                        mO[batch_idx, row_l, head_idx, db + tip*2 + 1] = o_regs[g][dt][3] * inv_l
+                row_u = m_base + rg + gid
+                row_l = m_base + rg + gid + 8
+                if cutlass.const_expr(mO.element_type == cutlass.BFloat16):
+                    # BF16 output: pack 2 BF16 (= 4 bytes) per st via Int32 recast.
+                    # Halves bytes vs F32 and halves store instruction count.
+                    mO_i32 = cute.recast_tensor(mO, cutlass.Int32)
+                    for dt in cutlass.range_constexpr(n_d_tiles):
+                        if row_u < seq_lim:
+                            packed_u = cvt_f32x2_to_bf16x2(
+                                o_regs[g][dt][0] * inv_u,
+                                o_regs[g][dt][1] * inv_u,
+                            )
+                            mO_i32[batch_idx, row_u, head_idx, dt*4 + tip] = packed_u
+                        if row_l < seq_lim:
+                            packed_l = cvt_f32x2_to_bf16x2(
+                                o_regs[g][dt][2] * inv_l,
+                                o_regs[g][dt][3] * inv_l,
+                            )
+                            mO_i32[batch_idx, row_l, head_idx, dt*4 + tip] = packed_l
+                else:
+                    for dt in cutlass.range_constexpr(n_d_tiles):
+                        db = dt * 8
+                        if row_u < seq_lim:
+                            mO[batch_idx, row_u, head_idx, db + tip*2]     = o_regs[g][dt][0] * inv_u
+                            mO[batch_idx, row_u, head_idx, db + tip*2 + 1] = o_regs[g][dt][1] * inv_u
+                        if row_l < seq_lim:
+                            mO[batch_idx, row_l, head_idx, db + tip*2]     = o_regs[g][dt][2] * inv_l
+                            mO[batch_idx, row_l, head_idx, db + tip*2 + 1] = o_regs[g][dt][3] * inv_l
 
         elif warp_idx == self._num_mma_warps:
             # === DMA warp (producer) ===
@@ -1164,8 +1206,16 @@ def make_cute_f32(t):
         mode=3, stride_order=t.dim_order(), divisibility=4)
 
 
+def make_cute_bf16(t):
+    """Wrap a torch.bfloat16 tensor for BF16 output mode (2-byte elements,
+    matches BF16 TMA's output bandwidth)."""
+    return from_dlpack(t, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=t.dim_order(), divisibility=8)
+
+
 def run_test(B, Sq, Sk, H, D, is_causal=False, desc="",
-             m_block_size=128, n_block_size=64, kv_stages=2):
+             m_block_size=128, n_block_size=32, kv_stages=2):
     """Correctness test against an FP32 reference.
 
     Returns True on PASS (max_diff < 0.1).
@@ -1221,7 +1271,7 @@ def run_test(B, Sq, Sk, H, D, is_causal=False, desc="",
 def run_benchmark(
     batch_size, seqlen_q, seqlen_k, num_head, head_dim,
     softmax_scale=None, is_causal=False,
-    m_block_size=128, n_block_size=64, kv_stages=2,
+    m_block_size=128, n_block_size=32, kv_stages=2,
     warmup_iterations=10, iterations=50,
     skip_ref_check=False,
 ):
@@ -1320,7 +1370,7 @@ if __name__ == "__main__":
     parser.add_argument("--head_dim", type=int, default=128)
     parser.add_argument("--is_causal", action="store_true")
     parser.add_argument("--m_block_size", type=int, default=128)
-    parser.add_argument("--n_block_size", type=int, default=64)
+    parser.add_argument("--n_block_size", type=int, default=32)
     parser.add_argument("--kv_stages", type=int, default=2)
     parser.add_argument("--warmup_iterations", type=int, default=10)
     parser.add_argument("--iterations", type=int, default=50)

--- a/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention_tma.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/fp8_flash_attention_tma.py
@@ -1,0 +1,1371 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+FP8 Flash Attention v2 for SM120 — TMA + warp specialization variant.
+
+Combines the BF16 TMA kernel's infrastructure (TMA loads, warp specialization,
+multi-stage KV pipeline, mbarrier sync) with the FP8 inline-PTX MMA path.
+
+Key differences from FP8FlashAttentionSm120Opt (CpAsync):
+  - TMA (cp.async.bulk) instead of CpAsync for GMEM→SMEM
+  - 1 dedicated DMA warp + 4 MMA warps (warp specialization)
+  - kv_stages=2 double-buffered K/V SMEM via PipelineTmaAsync
+  - mbarrier-based producer/consumer sync
+  - Default tile sizing M=128, N=64 (canonical for SM120 TMA), vs M=64, N=32
+
+Key differences from BF16 TMA (FlashAttentionForwardSm120Tma):
+  - FP8 e4m3 MMA via inline PTX kind::f8f6f4.m16n8k32 (no atom in cutlass-dsl 4.4.2)
+  - Per-thread SMEM arithmetic for register fragment load (no ldmatrix path —
+    deferred until LdMatrix8x8x16bOp is wired for FP8)
+  - 4×4 byte register transpose for V (no LdMatrix(transpose=True) path)
+  - sP staged in F32 SMEM (not in registers) — same as FP8 Opt
+
+Perf (DGX Spark / SM121a, sum-time over the 16-config Aneureka matrix):
+  - 1.02x vs FP8FlashAttentionSm120Opt   (roughly tied)
+  - 0.84x vs FlashAttentionForwardSm120Tma (BF16 TMA)  (slower)
+  - Wins on the bigger D=128 shapes (B=4 S=1024 D=128: 1.35x of FP8 Opt;
+    B=1 S=512 D=128 causal: 1.24x), loses on small D=64 shapes.
+  Path A (FP8 ldmatrix.trans) and register-resident P remain the levers needed
+  to beat the BF16 TMA kernel.
+"""
+
+import argparse
+from typing import Type
+
+import torch
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.testing as testing
+import cutlass.torch as cutlass_torch
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int32, Float32
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Inline PTX helpers (copied from fp8_flash_attention.py)
+# /////////////////////////////////////////////////////////////////////////////
+
+@dsl_user_op
+def mma_f8f6f4_m16n8k32_e4m3(
+    a0, a1, a2, a3, b0, b1, c0, c1, c2, c3,
+    *, loc=None, ip=None,
+):
+    """kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32"""
+    vals = [Int32(x).ir_value(loc=loc, ip=ip) for x in [a0, a1, a2, a3, b0, b1]]
+    accs = [Float32(x).ir_value(loc=loc, ip=ip) for x in [c0, c1, c2, c3]]
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32,f32,f32,f32)>"),
+        vals + accs,
+        "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        "{$0,$1,$2,$3},{$4,$5,$6,$7},{$8,$9},{$10,$11,$12,$13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=True, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return tuple(
+        Float32(llvm.extractvalue(T.f32(), ret, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def bitcast_f32_to_i32(val, *, loc=None, ip=None):
+    f32_ir = Float32(val).ir_value(loc=loc, ip=ip)
+    return Int32(llvm.bitcast(T.i32(), f32_ir, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def bitcast_i32_to_f32(val, *, loc=None, ip=None):
+    i32_ir = Int32(val).ir_value(loc=loc, ip=ip)
+    return Float32(llvm.bitcast(T.f32(), i32_ir, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def transpose_4x4_bytes(r0, r1, r2, r3, *, loc=None, ip=None):
+    """Transpose a 4x4 byte matrix in registers using prmt.b32."""
+    args = [Int32(x).ir_value(loc=loc, ip=ip) for x in [r0, r1, r2, r3]]
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32,i32,i32,i32)>"),
+        args,
+        "{\n\t"
+        ".reg .b32 lo01, hi01, lo23, hi23;\n\t"
+        "prmt.b32 lo01, $4, $5, 0x5140;\n\t"
+        "prmt.b32 hi01, $4, $5, 0x7362;\n\t"
+        "prmt.b32 lo23, $6, $7, 0x5140;\n\t"
+        "prmt.b32 hi23, $6, $7, 0x7362;\n\t"
+        "prmt.b32 $0, lo01, lo23, 0x5410;\n\t"
+        "prmt.b32 $1, lo01, lo23, 0x7632;\n\t"
+        "prmt.b32 $2, hi01, hi23, 0x5410;\n\t"
+        "prmt.b32 $3, hi01, hi23, 0x7632;\n\t"
+        "}",
+        "=r,=r,=r,=r,r,r,r,r",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return tuple(
+        Int32(llvm.extractvalue(T.i32(), ret, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def prmt_b32(a, b, selector, *, loc=None, ip=None):
+    """prmt.b32: per-byte permutation between two i32 sources.
+
+    Each of the 4 output bytes is selected by 4 bits of `selector` (low 16 bits):
+    bits [3:0] → out[0], [7:4] → out[1], [11:8] → out[2], [15:12] → out[3].
+    A nibble value 0..3 picks bytes 0..3 of `a`; 4..7 picks bytes 0..3 of `b`.
+    """
+    args = [Int32(x).ir_value(loc=loc, ip=ip) for x in [a, b, selector]]
+    return Int32(llvm.inline_asm(
+        T.i32(), args,
+        "prmt.b32 $0, $1, $2, $3;",
+        "=r,r,r,r",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    ))
+
+
+@dsl_user_op
+def selp_b32(a, b, cond_i32, *, loc=None, ip=None):
+    """selp.b32: result = (cond != 0) ? a : b. Inline-PTX bypasses any DSL
+    ternary issues with Int32 selection (notably: post-selection values get
+    read by `shuffle_sync` from the SOURCE lane's post-selection state, which
+    differs by source thread's q).  Pattern is shuffle-r0/r2-individually
+    then select locally."""
+    args = [Int32(x).ir_value(loc=loc, ip=ip) for x in [a, b, cond_i32]]
+    return Int32(llvm.inline_asm(
+        T.i32(), args,
+        "{ .reg .pred p; setp.ne.s32 p, $3, 0; selp.b32 $0, $1, $2, p; }",
+        "=r,r,r,r",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    ))
+
+
+@dsl_user_op
+def cvta_to_shared_u32(ptr, *, loc=None, ip=None):
+    """Convert a CuTe SMEM Pointer to a u32 in PTX shared address space.
+
+    PTX `ldmatrix` and friends take a u32 SMEM-space address ([..r..] operand).
+    The cutlass-dsl `Pointer.llvm_ptr` returns an LLVM ptr already in
+    addrspace(3) for SMEM tensors; ptrtoint to i32 truncates that to the
+    32-bit shared address.
+    """
+    return Int32(llvm.ptrtoint(T.i32(), ptr.llvm_ptr, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def ldmatrix_x4_trans_b16(smem_addr, *, loc=None, ip=None):
+    """ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 — load 4 transposed 8x8
+    b16 matrices.  Each lane provides one 16-byte-aligned shared-space u32
+    address pointing to an 8-b16 row.  Returns 4 i32 per thread (8 b16 = 8 FP8
+    pairs total).  Lane mapping: lane t supplies addr for matrix `t/8`, row `t%8`.
+    """
+    addr_ir = Int32(smem_addr).ir_value(loc=loc, ip=ip)
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32,i32,i32,i32)>"),
+        [addr_ir],
+        "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {$0,$1,$2,$3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return tuple(
+        Int32(llvm.extractvalue(T.i32(), ret, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def ldmatrix_x4_b16(smem_addr, *, loc=None, ip=None):
+    """ldmatrix.sync.aligned.m8n8.x4.shared.b16 (NO trans) — load 4 b16
+    matrices in natural row-major order. Used for Q loading where sQ's
+    [m, d] layout already matches MMA A operand's m × k orientation.
+    """
+    addr_ir = Int32(smem_addr).ir_value(loc=loc, ip=ip)
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32,i32,i32,i32)>"),
+        [addr_ir],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {$0,$1,$2,$3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return tuple(
+        Int32(llvm.extractvalue(T.i32(), ret, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def cvt_f32_to_fp8x4(v0, v1, v2, v3, *, loc=None, ip=None):
+    """Pack 4 FP32 → 4 FP8 e4m3 bytes in uint32."""
+    args = [Float32(x).ir_value(loc=loc, ip=ip) for x in [v0, v1, v2, v3]]
+    return Int32(llvm.inline_asm(
+        T.i32(), args,
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, $2, $1;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, $4, $3;\n\t"
+        "mov.b32 $0, {lo, hi};\n\t"
+        "}",
+        "=r,f,f,f,f",
+        has_side_effects=False, asm_dialect=0, loc=loc, ip=ip,
+    ))
+
+
+# Register-resident P uses warp shuffles that redistribute the m16n8k32 C-layout
+# (per-thread QK output) into the m16n8k32 A-layout (per-thread PV input),
+# skipping the sP_f32 SMEM round-trip.  See `fp8_mma_layout.md` for derivation
+# of the source-lane formula `src_lane_a = gid*4 + (tip%2)*2`.
+# The pattern is inlined in the kernel rather than factored into a helper
+# because cutlass-dsl's preprocessing of dynamic Boolean ternaries doesn't
+# compose cleanly across function-call boundaries.
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# FP8 Flash Attention with TMA + warp specialization
+# /////////////////////////////////////////////////////////////////////////////
+
+class FP8FlashAttentionSm120Tma:
+    """FP8 Flash Attention for SM120 using TMA + warp specialization.
+
+    Tile config (defaults — `can_implement` checks alternates):
+      - m_block_size=128 (4 MMA warps × 32 rows/warp = 2 m16 row groups)
+      - n_block_size=64
+      - kv_stages=2 (K/V double-buffered via PipelineTmaAsync)
+      - 1 DMA warp + 4 MMA warps = 160 threads/block
+
+    SMEM budget at M=128, N=64, D=128, kv_stages=2:
+      - sQ FP8: 128*128 = 16 KB
+      - sK FP8: 64*128*2 = 16 KB
+      - sV FP8: 64*128*2 = 16 KB
+      - sVt FP8: 128*80 = 10 KB (single stage; +16 byte row pad)
+      - sP: NONE (P held in registers via warp shuffles — `_compute_pa_quad`)
+      - mbar arrays + 1024-byte alignments: ~5 KB
+      - Total: ~63 KB (well under 99 KB SM120 budget; allows kv_stages=3)
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        m_block_size: int = 128,
+        n_block_size: int = 64,
+        num_mma_warps: int = 4,
+        kv_stages: int = 2,
+        is_causal: bool = False,
+    ):
+        assert head_dim % 32 == 0
+        assert m_block_size % (num_mma_warps * 16) == 0, \
+            "m_block_size must be a multiple of num_mma_warps * 16"
+        self._head_dim = head_dim
+        self._head_dim_padded = (head_dim + 31) // 32 * 32
+        self._m_block_size = m_block_size
+        self._n_block_size = n_block_size
+        self._num_mma_warps = num_mma_warps
+        self._kv_stages = kv_stages
+        self._is_causal = is_causal
+        self._num_threads = (num_mma_warps + 1) * 32  # +1 DMA warp
+
+        self.mma_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1, num_threads=num_mma_warps * 32
+        )
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+
+    @staticmethod
+    def can_implement(
+        head_dim, m_block_size, n_block_size, num_mma_warps, kv_stages, is_causal,
+    ) -> bool:
+        """Returns True if the (head_dim, tile sizes, stages) config fits SM120.
+
+        Checks: head_dim multiple of 32; m_block_size compatible with the warp
+        tiling (each warp owns 16 rows); SMEM total fits SM120's 99 KB budget.
+        """
+        if head_dim % 32 != 0:
+            return False
+        if m_block_size % (num_mma_warps * 16) != 0:
+            return False
+        if n_block_size % 8 != 0:
+            return False
+        if num_mma_warps != 4:
+            # Per-warp masking + transpose work split currently assume 4 MMA warps.
+            return False
+        head_dim_padded = (head_dim + 31) // 32 * 32
+        # SMEM bytes: sQ + sK + sV + sVt + mbar arrays.  sP is no longer
+        # allocated since P is held in registers via warp shuffles.
+        smem_q = m_block_size * head_dim_padded
+        smem_kv = n_block_size * head_dim_padded * kv_stages
+        smem_vt = head_dim_padded * (n_block_size + 16)
+        smem_mbar = (1 + 2 * kv_stages * 2) * 8
+        align_pad = 1024 * 3 + 1024
+        smem_total = smem_q + smem_kv * 2 + smem_vt + smem_mbar + align_pad
+        smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        if smem_total > smem_capacity:
+            return False
+        return True
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        softmax_scale: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        fp8 = cutlass.Float8E4M3FN
+        D = self._head_dim_padded
+        M = self._m_block_size
+        N = self._n_block_size
+
+        # /////////////////////////////////////////////////////////////////////
+        # SMEM layouts.  All ldmatrix-based: sQ, sK, sV all use TMA-compatible
+        # swizzled layout. sQ used by Q register cache load (ldmatrix.x4 no trans),
+        # sK and sV used by ldmatrix.x4.trans in QK and PV GEMMs.
+        # /////////////////////////////////////////////////////////////////////
+        smem_k_block_size_kv, swizzle_bits_kv = (
+            (128, 3) if D >= 128 else (64, 2) if D >= 64 else (32, 1)
+        )
+        sQKV_layout_atom = cute.make_composed_layout(
+            cute.make_swizzle(swizzle_bits_kv, 4, 3),
+            0,
+            cute.make_layout((8, smem_k_block_size_kv), stride=(smem_k_block_size_kv, 1)),
+        )
+        sQ_layout_staged = cute.tile_to_shape(
+            sQKV_layout_atom, (M, D, 1), (0, 1, 2),
+        )
+        sQ_one_layout = cute.slice_(sQ_layout_staged, (None, None, 0))
+        sKV_layout_staged = cute.tile_to_shape(
+            sQKV_layout_atom, (N, D, self._kv_stages), (0, 1, 2),
+        )
+        sKV_one_layout = cute.slice_(sKV_layout_staged, (None, None, 0))
+        sV_layout_staged = sKV_layout_staged
+        sV_one_layout = sKV_one_layout
+        # sVt does NOT use TMA — keep row padding for bank conflicts.
+        # sP is no longer needed (P is held in registers via warp shuffles).
+        N_pad_vt = N + 16       # FP8 row stride for sVt
+        sVt_one_layout = cute.make_layout((D, N), stride=(N_pad_vt, 1))
+
+        # /////////////////////////////////////////////////////////////////////
+        # Reshape tensors for TMA: (batch, seq, head, dim) → (seq, dim, head, batch)
+        # /////////////////////////////////////////////////////////////////////
+        mQ_for_tma = cute.make_tensor(
+            mQ.iterator,
+            cute.make_layout(
+                (mQ.shape[1], mQ.shape[3], mQ.shape[2], mQ.shape[0]),
+                stride=(mQ.stride[1], mQ.stride[3], mQ.stride[2], mQ.stride[0]),
+            ),
+        )
+        mK_for_tma = cute.make_tensor(
+            mK.iterator,
+            cute.make_layout(
+                (mK.shape[1], mK.shape[3], mK.shape[2], mK.shape[0]),
+                stride=(mK.stride[1], mK.stride[3], mK.stride[2], mK.stride[0]),
+            ),
+        )
+        mV_for_tma = cute.make_tensor(
+            mV.iterator,
+            cute.make_layout(
+                (mV.shape[1], mV.shape[3], mV.shape[2], mV.shape[0]),
+                stride=(mV.stride[1], mV.stride[3], mV.stride[2], mV.stride[0]),
+            ),
+        )
+
+        # TMA atoms
+        tma_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
+            tma_op, mQ_for_tma, sQ_one_layout,
+            (M, D), num_multicast=1,
+        )
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_op, mK_for_tma, sKV_one_layout,
+            (N, D), num_multicast=1,
+        )
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
+            tma_op, mV_for_tma, sV_one_layout,
+            (N, D), num_multicast=1,
+        )
+
+        q_copy_bytes = cute.size_in_bytes(fp8, sQ_one_layout)
+        kv_copy_bytes = cute.size_in_bytes(fp8, sKV_one_layout)
+
+        # /////////////////////////////////////////////////////////////////////
+        # Shared storage
+        # /////////////////////////////////////////////////////////////////////
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 1 * 2]
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self._kv_stages * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self._kv_stages * 2]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sQ_layout_staged)], 1024
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sKV_layout_staged)], 1024
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sV_layout_staged)], 1024
+            ]
+            sVt: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sVt_one_layout)], 128
+            ]
+
+        # Grid: (m_blocks, head*batch, 1)
+        num_heads = cute.size(mQ.shape[2])
+        num_batches = cute.size(mQ.shape[0])
+        grid_dim = (
+            cute.ceil_div(mQ.shape[1], M),
+            num_heads * num_batches,
+            1,
+        )
+        LOG2_E = 1.4426950408889634074
+        softmax_scale_log2 = softmax_scale * LOG2_E
+
+        self.kernel(
+            tma_atom_q, tma_tensor_q,
+            tma_atom_k, tma_tensor_k,
+            tma_atom_v, tma_tensor_v,
+            mQ, mK, mV, mO,
+            softmax_scale_log2,
+            q_copy_bytes,
+            kv_copy_bytes,
+            sQ_layout_staged,
+            sKV_layout_staged,
+            sV_layout_staged,
+            sVt_one_layout,
+            SharedStorage,
+            num_heads,
+        ).launch(
+            grid=grid_dim,
+            block=[self._num_threads, 1, 1],
+            cluster=[1, 1, 1],
+            smem=SharedStorage.size_in_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_q: cute.CopyAtom,
+        mQ_tma: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_tma: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_tma: cute.Tensor,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        softmax_scale_log2: cutlass.Float32,
+        q_copy_bytes: cutlass.Constexpr,
+        kv_copy_bytes: cutlass.Constexpr,
+        sQ_layout_staged: cute.ComposedLayout,
+        sKV_layout_staged: cute.ComposedLayout,
+        sV_layout_staged: cute.ComposedLayout,
+        sVt_one_layout: cute.Layout,
+        SharedStorage: cutlass.Constexpr,
+        num_heads: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_block, hb_idx, _ = cute.arch.block_idx()
+        head_idx = hb_idx % num_heads
+        batch_idx = hb_idx // num_heads
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        M = self._m_block_size
+        N = self._n_block_size
+        D = self._head_dim_padded
+
+        n_block_max = cute.ceil_div(mK.shape[1], N)
+        if self._is_causal:
+            n_block_max = min(
+                cute.ceil_div((m_block + 1) * M, N), n_block_max,
+            )
+
+        # /////////////////////////////////////////////////////////////////////
+        # SMEM allocation
+        # /////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(
+            sQ_layout_staged.outer, swizzle=sQ_layout_staged.inner
+        )
+        sK = storage.sK.get_tensor(
+            sKV_layout_staged.outer, swizzle=sKV_layout_staged.inner
+        )
+        sV = storage.sV.get_tensor(
+            sV_layout_staged.outer, swizzle=sV_layout_staged.inner
+        )
+        sVt = storage.sVt.get_tensor(sVt_one_layout)
+
+        # /////////////////////////////////////////////////////////////////////
+        # TMA partition: GMEM tile mapping
+        # /////////////////////////////////////////////////////////////////////
+        gQ = cute.local_tile(
+            mQ_tma, (M, D), (None, 0, None, None),
+        )
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_atom_q, 0, cute.make_layout(1),
+            cute.group_modes(sQ, 0, 2),
+            cute.group_modes(gQ, 0, 2),
+        )
+
+        gK = cute.local_tile(
+            mK_tma, (N, D), (None, 0, None, None),
+        )
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_atom_k, 0, cute.make_layout(1),
+            cute.group_modes(sK, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+
+        gV = cute.local_tile(
+            mV_tma, (N, D), (None, 0, None, None),
+        )
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_atom_v, 0, cute.make_layout(1),
+            cute.group_modes(sV, 0, 2),
+            cute.group_modes(gV, 0, 2),
+        )
+
+        tQgQ_block = tQgQ[(None, m_block, head_idx, batch_idx)]
+        tKgK_block = tKgK[(None, None, head_idx, batch_idx)]
+        tVgV_block = tVgV[(None, None, head_idx, batch_idx)]
+
+        # /////////////////////////////////////////////////////////////////////
+        # Pipelines
+        # /////////////////////////////////////////////////////////////////////
+        q_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self._num_mma_warps
+            ),
+            tx_count=q_copy_bytes,
+            barrier_storage=storage.q_mbar_ptr.data_ptr(),
+        )
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self._kv_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self._num_mma_warps
+            ),
+            tx_count=kv_copy_bytes,
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self._kv_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self._num_mma_warps
+            ),
+            tx_count=kv_copy_bytes,
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+        )
+
+        pipeline.sync(barrier_id=0)
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+
+        # /////////////////////////////////////////////////////////////////////
+        # Pipeline states
+        # /////////////////////////////////////////////////////////////////////
+        q_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, 1
+        )
+        k_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self._kv_stages
+        )
+        v_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self._kv_stages
+        )
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._kv_stages
+        )
+        v_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._kv_stages
+        )
+
+        # /////////////////////////////////////////////////////////////////////
+        # Warp specialization
+        # /////////////////////////////////////////////////////////////////////
+        if warp_idx < self._num_mma_warps:
+            # === MMA warps (consumer) ===
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            lane_id = tidx % 32
+            gid = lane_id // 4
+            tip = lane_id % 4
+            # Each warp owns M / num_mma_warps contiguous rows, divided into
+            # n_warp_groups m16 row groups.  E.g. M=128, num_warps=4:
+            # n_warp_groups=2, each warp covers 32 rows split into two m16
+            # groups (rows m_warp_base + 0..15 and m_warp_base + 16..31).
+            n_warp_groups = M // (self._num_mma_warps * 16)
+            m_warp_base = warp_idx * (M // self._num_mma_warps)
+            m_base = m_block * M
+
+            n_k = D // 32         # k-iterations for QK GEMM (32 FP8 per k)
+            n_n_sub = N // 8      # n-sub-tiles for QK GEMM (m16n8)
+            n_d_tiles = D // 8    # d-tiles for PV register output (m16n8)
+            n_pv_k_iters = N // 32  # k-iterations for PV GEMM
+
+            # O accumulators in registers: per row group, n_d_tiles × 4 F32
+            o_regs = [
+                [[cutlass.Float32(0.0), cutlass.Float32(0.0),
+                  cutlass.Float32(0.0), cutlass.Float32(0.0)]
+                 for _ in range(n_d_tiles)]
+                for _ in range(n_warp_groups)
+            ]
+            # Per-row-group softmax state.  Within each m16 group, "u" = upper
+            # 8 rows (gid), "l" = lower 8 rows (gid+8).
+            row_max_u = [cutlass.Float32(-3.4028235e+38) for _ in range(n_warp_groups)]
+            row_max_l = [cutlass.Float32(-3.4028235e+38) for _ in range(n_warp_groups)]
+            row_sum_u = [cutlass.Float32(0.0) for _ in range(n_warp_groups)]
+            row_sum_l = [cutlass.Float32(0.0) for _ in range(n_warp_groups)]
+
+            # Wait for Q
+            q_pipeline.consumer_wait(
+                pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, 1
+                )
+            )
+
+            # ---- Q caching via ldmatrix.x4 (NO trans) on swizzled sQ.
+            # sQ row-major [m, d] matches MMA A operand m × k orientation, so
+            # no transpose. Custom matrix layout:
+            #   matrix 0: m=m_warp_base + g*16 + 0..7,  d=ki*32 + 0..15
+            #   matrix 1: m=m_warp_base + g*16 + 0..7,  d=ki*32 + 16..31
+            #   matrix 2: m=m_warp_base + g*16 + 8..15, d=ki*32 + 0..15
+            #   matrix 3: m=m_warp_base + g*16 + 8..15, d=ki*32 + 16..31
+            # Per thread reg i has 4 FP8 at (m=t%8, d=4*(t/8)..+3) within matrix's range.
+            # Bridge to per-thread A operand (gid, tip) = (m=gid, d=tip*4..+3 etc):
+            #   src_lane_q = 8*tip + gid
+            #   a0 = shfl(reg 0, src_lane_q)  # m=gid, d=tip*4..+3 (K-first-half)
+            #   a1 = shfl(reg 2, src_lane_q)  # m=gid+8 (matrix 2)
+            #   a2 = shfl(reg 1, src_lane_q)  # m=gid, d=tip*4+16..+19 (K-second-half)
+            #   a3 = shfl(reg 3, src_lane_q)  # m=gid+8, K-second-half
+            # Q is constant across attention iters → cache the bridge results in registers.
+            q_cache = [
+                [[None, None, None, None]
+                 for _ in range(n_k)]
+                for _ in range(n_warp_groups)
+            ]
+            # Per-lane (m, d_offset) mapping for ldmatrix custom address pattern
+            q_warp_lane = tidx % 32
+            q_m_high = (q_warp_lane >> 4) & 1   # 0/1: which 8-m-row half
+            q_d_high = (q_warp_lane >> 3) & 1   # 0/1: K-first/second-half d
+            q_m_in_8 = q_warp_lane & 7
+            q_src_lane = 8 * tip + gid
+            Q_SWIZZLE_BMASK = cutlass.Int32(
+                7 if D >= 128 else 3 if D >= 64 else 1
+            )
+            for g in cutlass.range_constexpr(n_warp_groups):
+                rg = m_warp_base + g * 16
+                for ki in cutlass.range_constexpr(n_k):
+                    # Per-lane address into sQ
+                    m_for_lane = rg + q_m_high * 8 + q_m_in_8
+                    d_offset_FP8 = ki * 32 + q_d_high * 16
+                    elem_off_Q = m_for_lane * D + d_offset_FP8
+                    swizzled_Q = elem_off_Q ^ (((elem_off_Q >> 7) & Q_SWIZZLE_BMASK) << 4)
+                    my_ptr_Q = sQ.iterator + swizzled_Q
+                    addr_u32_Q = cvta_to_shared_u32(my_ptr_Q)
+                    qlm_r0, qlm_r1, qlm_r2, qlm_r3 = ldmatrix_x4_b16(addr_u32_Q)
+                    # Bridge: single shuffle per a-register
+                    q_cache[g][ki][0] = cute.arch.shuffle_sync(qlm_r0, q_src_lane)
+                    q_cache[g][ki][1] = cute.arch.shuffle_sync(qlm_r2, q_src_lane)
+                    q_cache[g][ki][2] = cute.arch.shuffle_sync(qlm_r1, q_src_lane)
+                    q_cache[g][ki][3] = cute.arch.shuffle_sync(qlm_r3, q_src_lane)
+
+            # Main attention loop
+            for n_tile in range(0, n_block_max, 1, unroll=1):
+                nb = n_block_max - n_tile - 1
+
+                # ---- Wait for K ready ----
+                k_pipeline.consumer_wait(k_consumer_state)
+                k_stage = k_consumer_state.index
+
+                # ---- QK GEMM: K loaded via ldmatrix.x4.trans on swizzled sK ----
+                # Custom address pattern (analogous to Path A V loading):
+                #   matrix 0: seqs (kc*16..kc*16+7),    d=ki*32 + 0..15  (K-first-half)
+                #   matrix 1: seqs (kc*16..kc*16+7),    d=ki*32 + 16..31 (K-second-half)
+                #   matrix 2: seqs (kc*16+8..kc*16+15), d=ki*32 + 0..15
+                #   matrix 3: seqs (kc*16+8..kc*16+15), d=ki*32 + 16..31
+                # After ldmatrix.x4.trans, regs 0/2 hold K-first-half data,
+                # regs 1/3 hold K-second-half. Bridge: per-thread shuffle r_n
+                # from src_la/src_lb, then prmt to byte-extract by g_parity.
+                # No selp needed (ni is constexpr → which reg pair to use is
+                # known at compile time).
+                s_regs = [
+                    [[cutlass.Float32(0.0), cutlass.Float32(0.0),
+                      cutlass.Float32(0.0), cutlass.Float32(0.0)]
+                     for _ in range(n_n_sub)]
+                    for _ in range(n_warp_groups)
+                ]
+                # Lane-to-(seq, d) mapping for the custom ldmatrix address pattern
+                k_warp_lane = tidx % 32
+                k_seq_high = (k_warp_lane >> 4) & 1   # 0 or 1: which 8-seq half within kc's 16
+                k_d_high = (k_warp_lane >> 3) & 1     # 0 or 1: K-first/second-half
+                k_seq_in_8 = k_warp_lane & 7
+                # Per ki and kc: lane provides addr to (seq, d_offset) within current K-tile.
+                #   seq = kc*16 + k_seq_high*8 + k_seq_in_8
+                #   d_offset = ki*32 + k_d_high*16 (for d_b16_base, but we use FP8 byte offsets)
+                # Source lanes for per-thread bridge (analogous to PV's src_la/src_lb)
+                k_src_la = (gid // 2) * 4 + (tip & 1) * 2
+                k_src_lb = k_src_la + 1
+                # prmt selector: 0x6420 if g_parity 0, 0x7531 if g_parity 1
+                k_prmt_sel = cutlass.Int32(0x6420) + (gid & 1) * cutlass.Int32(0x1111)
+                # Swizzle bit-mask (same as Path A V loading)
+                K_SWIZZLE_BMASK = cutlass.Int32(
+                    7 if D >= 128 else 3 if D >= 64 else 1
+                )
+                # n_n_sub seqs per ki = N/8. ldmatrix covers 16 seqs (2 m16n8) per call.
+                qk_n_seq_chunks = n_n_sub // 2  # = N // 16
+                for ki in cutlass.range_constexpr(n_k):
+                    for kc in cutlass.range_constexpr(qk_n_seq_chunks):
+                        # Per-lane address
+                        seq_for_lane = kc * 16 + k_seq_high * 8 + k_seq_in_8
+                        d_offset_FP8 = ki * 32 + k_d_high * 16
+                        # K stage offset within sK
+                        k_stage_off = k_stage * N * D
+                        elem_off_K = seq_for_lane * D + d_offset_FP8
+                        swizzled_K = elem_off_K ^ (((elem_off_K >> 7) & K_SWIZZLE_BMASK) << 4)
+                        my_ptr_K = sK.iterator + (k_stage_off + swizzled_K)
+                        addr_u32_K = cvta_to_shared_u32(my_ptr_K)
+                        klm_r0, klm_r1, klm_r2, klm_r3 = ldmatrix_x4_trans_b16(addr_u32_K)
+
+                        # Bridge for ni = 2*kc (uses regs 0+1)
+                        sh_r0_la = cute.arch.shuffle_sync(klm_r0, k_src_la)
+                        sh_r0_lb = cute.arch.shuffle_sync(klm_r0, k_src_lb)
+                        b0_ni0 = prmt_b32(sh_r0_la, sh_r0_lb, k_prmt_sel)
+                        sh_r1_la = cute.arch.shuffle_sync(klm_r1, k_src_la)
+                        sh_r1_lb = cute.arch.shuffle_sync(klm_r1, k_src_lb)
+                        b1_ni0 = prmt_b32(sh_r1_la, sh_r1_lb, k_prmt_sel)
+                        # Bridge for ni = 2*kc + 1 (uses regs 2+3)
+                        sh_r2_la = cute.arch.shuffle_sync(klm_r2, k_src_la)
+                        sh_r2_lb = cute.arch.shuffle_sync(klm_r2, k_src_lb)
+                        b0_ni1 = prmt_b32(sh_r2_la, sh_r2_lb, k_prmt_sel)
+                        sh_r3_la = cute.arch.shuffle_sync(klm_r3, k_src_la)
+                        sh_r3_lb = cute.arch.shuffle_sync(klm_r3, k_src_lb)
+                        b1_ni1 = prmt_b32(sh_r3_la, sh_r3_lb, k_prmt_sel)
+
+                        # MMAs for ni = 2*kc and 2*kc+1, each across n_warp_groups
+                        for g in cutlass.range_constexpr(n_warp_groups):
+                            a0 = q_cache[g][ki][0]
+                            a1 = q_cache[g][ki][1]
+                            a2 = q_cache[g][ki][2]
+                            a3 = q_cache[g][ki][3]
+                            s_regs[g][2*kc][0], s_regs[g][2*kc][1], s_regs[g][2*kc][2], s_regs[g][2*kc][3] = \
+                                mma_f8f6f4_m16n8k32_e4m3(
+                                    a0, a1, a2, a3, b0_ni0, b1_ni0,
+                                    s_regs[g][2*kc][0], s_regs[g][2*kc][1],
+                                    s_regs[g][2*kc][2], s_regs[g][2*kc][3])
+                            s_regs[g][2*kc+1][0], s_regs[g][2*kc+1][1], s_regs[g][2*kc+1][2], s_regs[g][2*kc+1][3] = \
+                                mma_f8f6f4_m16n8k32_e4m3(
+                                    a0, a1, a2, a3, b0_ni1, b1_ni1,
+                                    s_regs[g][2*kc+1][0], s_regs[g][2*kc+1][1],
+                                    s_regs[g][2*kc+1][2], s_regs[g][2*kc+1][3])
+
+                k_pipeline.consumer_release(k_consumer_state)
+                k_consumer_state.advance()
+
+                # ---- Mask: OOB (Sk % N != 0) + causal ----
+                # OOB applies to all warps/groups uniformly.  Causal additionally
+                # masks col > query_pos; query_pos depends on the row group.
+                neginf = cutlass.Float32(-3.4028235e+38)
+                k_lim = mK.shape[1]
+                if cutlass.const_expr(self._is_causal):
+                    for g in cutlass.range_constexpr(n_warp_groups):
+                        rg = m_base + m_warp_base + g * 16
+                        q_u = rg + gid
+                        q_l = rg + gid + 8
+                        for ni in cutlass.range_constexpr(n_n_sub):
+                            c0 = nb * N + ni * 8 + tip * 2
+                            c1 = c0 + 1
+                            s_regs[g][ni][0] = neginf if c0 > q_u else (
+                                neginf if c0 >= k_lim else s_regs[g][ni][0])
+                            s_regs[g][ni][1] = neginf if c1 > q_u else (
+                                neginf if c1 >= k_lim else s_regs[g][ni][1])
+                            s_regs[g][ni][2] = neginf if c0 > q_l else (
+                                neginf if c0 >= k_lim else s_regs[g][ni][2])
+                            s_regs[g][ni][3] = neginf if c1 > q_l else (
+                                neginf if c1 >= k_lim else s_regs[g][ni][3])
+                else:
+                    for g in cutlass.range_constexpr(n_warp_groups):
+                        for ni in cutlass.range_constexpr(n_n_sub):
+                            c0 = nb * N + ni * 8 + tip * 2
+                            c1 = c0 + 1
+                            s_regs[g][ni][0] = neginf if c0 >= k_lim else s_regs[g][ni][0]
+                            s_regs[g][ni][1] = neginf if c1 >= k_lim else s_regs[g][ni][1]
+                            s_regs[g][ni][2] = neginf if c0 >= k_lim else s_regs[g][ni][2]
+                            s_regs[g][ni][3] = neginf if c1 >= k_lim else s_regs[g][ni][3]
+
+                # ---- Online softmax (per row group) ----
+                for g in cutlass.range_constexpr(n_warp_groups):
+                    lmu = s_regs[g][0][0]
+                    lml = s_regs[g][0][2]
+                    for ni in cutlass.range_constexpr(n_n_sub):
+                        lmu = cute.arch.fmax(lmu, cute.arch.fmax(s_regs[g][ni][0], s_regs[g][ni][1]))
+                        lml = cute.arch.fmax(lml, cute.arch.fmax(s_regs[g][ni][2], s_regs[g][ni][3]))
+                    lmu = cute.arch.fmax(lmu, cute.arch.shuffle_sync_bfly(
+                        lmu, offset=2, mask=-1, mask_and_clamp=31))
+                    lmu = cute.arch.fmax(lmu, cute.arch.shuffle_sync_bfly(
+                        lmu, offset=1, mask=-1, mask_and_clamp=31))
+                    lml = cute.arch.fmax(lml, cute.arch.shuffle_sync_bfly(
+                        lml, offset=2, mask=-1, mask_and_clamp=31))
+                    lml = cute.arch.fmax(lml, cute.arch.shuffle_sync_bfly(
+                        lml, offset=1, mask=-1, mask_and_clamp=31))
+
+                    new_mu = cute.arch.fmax(row_max_u[g], lmu)
+                    new_ml = cute.arch.fmax(row_max_l[g], lml)
+                    if cutlass.const_expr(self._is_causal):
+                        new_mu = cutlass.Float32(0.0) if new_mu == cutlass.Float32(-3.4028235e+38) else new_mu
+                        new_ml = cutlass.Float32(0.0) if new_ml == cutlass.Float32(-3.4028235e+38) else new_ml
+
+                    resc_u = cute.math.exp2(
+                        row_max_u[g] * softmax_scale_log2 - new_mu * softmax_scale_log2,
+                        fastmath=True)
+                    resc_l = cute.math.exp2(
+                        row_max_l[g] * softmax_scale_log2 - new_ml * softmax_scale_log2,
+                        fastmath=True)
+
+                    for dt in cutlass.range_constexpr(n_d_tiles):
+                        o_regs[g][dt][0] = o_regs[g][dt][0] * resc_u
+                        o_regs[g][dt][1] = o_regs[g][dt][1] * resc_u
+                        o_regs[g][dt][2] = o_regs[g][dt][2] * resc_l
+                        o_regs[g][dt][3] = o_regs[g][dt][3] * resc_l
+
+                    row_sum_u[g] = row_sum_u[g] * resc_u
+                    row_sum_l[g] = row_sum_l[g] * resc_l
+
+                    for ni in cutlass.range_constexpr(n_n_sub):
+                        s_regs[g][ni][0] = cute.math.exp2(
+                            s_regs[g][ni][0] * softmax_scale_log2 - new_mu * softmax_scale_log2,
+                            fastmath=True)
+                        s_regs[g][ni][1] = cute.math.exp2(
+                            s_regs[g][ni][1] * softmax_scale_log2 - new_mu * softmax_scale_log2,
+                            fastmath=True)
+                        s_regs[g][ni][2] = cute.math.exp2(
+                            s_regs[g][ni][2] * softmax_scale_log2 - new_ml * softmax_scale_log2,
+                            fastmath=True)
+                        s_regs[g][ni][3] = cute.math.exp2(
+                            s_regs[g][ni][3] * softmax_scale_log2 - new_ml * softmax_scale_log2,
+                            fastmath=True)
+                        row_sum_u[g] = row_sum_u[g] + s_regs[g][ni][0] + s_regs[g][ni][1]
+                        row_sum_l[g] = row_sum_l[g] + s_regs[g][ni][2] + s_regs[g][ni][3]
+
+                    row_max_u[g] = new_mu
+                    row_max_l[g] = new_ml
+
+                # ---- Register-resident P: shuffle-redistribute s_regs into
+                # pa registers for PV — no sP_f32 SMEM round-trip.
+                # pa_reg[g][pv_ki][i] holds packed FP8 for warp_group g,
+                # pv K-iter pv_ki, position i (0=upper left, 1=lower left,
+                # 2=upper right, 3=lower right of the m16n8k32 A operand).
+                src_lane_a = gid * 4 + (tip % 2) * 2
+                src_lane_b = src_lane_a + 1
+                tip_lo = (tip < 2)
+                pa_reg = [[[None, None, None, None]
+                           for _ in range(n_pv_k_iters)]
+                          for _ in range(n_warp_groups)]
+                for g in cutlass.range_constexpr(n_warp_groups):
+                    for pv_ki in cutlass.range_constexpr(n_pv_k_iters):
+                        ni0 = pv_ki * 4
+                        # pa0: upper rows (s_regs[ni][0,1]), ni=ni0/ni0+1
+                        sh_a0_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][0], src_lane_a)
+                        sh_a1_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][1], src_lane_a)
+                        sh_a0_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][0], src_lane_a)
+                        sh_a1_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][1], src_lane_a)
+                        sh_b0_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][0], src_lane_b)
+                        sh_b1_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][1], src_lane_b)
+                        sh_b0_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][0], src_lane_b)
+                        sh_b1_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][1], src_lane_b)
+                        pa0 = cvt_f32_to_fp8x4(
+                            sh_a0_n0 if tip_lo else sh_a0_n1,
+                            sh_a1_n0 if tip_lo else sh_a1_n1,
+                            sh_b0_n0 if tip_lo else sh_b0_n1,
+                            sh_b1_n0 if tip_lo else sh_b1_n1,
+                        )
+                        # pa1: lower rows (s_regs[ni][2,3]), ni=ni0/ni0+1
+                        sh_a2_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][2], src_lane_a)
+                        sh_a3_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][3], src_lane_a)
+                        sh_a2_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][2], src_lane_a)
+                        sh_a3_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][3], src_lane_a)
+                        sh_b2_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][2], src_lane_b)
+                        sh_b3_n0 = cute.arch.shuffle_sync(s_regs[g][ni0  ][3], src_lane_b)
+                        sh_b2_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][2], src_lane_b)
+                        sh_b3_n1 = cute.arch.shuffle_sync(s_regs[g][ni0+1][3], src_lane_b)
+                        pa1 = cvt_f32_to_fp8x4(
+                            sh_a2_n0 if tip_lo else sh_a2_n1,
+                            sh_a3_n0 if tip_lo else sh_a3_n1,
+                            sh_b2_n0 if tip_lo else sh_b2_n1,
+                            sh_b3_n0 if tip_lo else sh_b3_n1,
+                        )
+                        # pa2: upper rows, ni=ni0+2/ni0+3
+                        sh_a0_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][0], src_lane_a)
+                        sh_a1_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][1], src_lane_a)
+                        sh_a0_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][0], src_lane_a)
+                        sh_a1_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][1], src_lane_a)
+                        sh_b0_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][0], src_lane_b)
+                        sh_b1_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][1], src_lane_b)
+                        sh_b0_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][0], src_lane_b)
+                        sh_b1_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][1], src_lane_b)
+                        pa2 = cvt_f32_to_fp8x4(
+                            sh_a0_n2 if tip_lo else sh_a0_n3,
+                            sh_a1_n2 if tip_lo else sh_a1_n3,
+                            sh_b0_n2 if tip_lo else sh_b0_n3,
+                            sh_b1_n2 if tip_lo else sh_b1_n3,
+                        )
+                        # pa3: lower rows, ni=ni0+2/ni0+3
+                        sh_a2_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][2], src_lane_a)
+                        sh_a3_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][3], src_lane_a)
+                        sh_a2_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][2], src_lane_a)
+                        sh_a3_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][3], src_lane_a)
+                        sh_b2_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][2], src_lane_b)
+                        sh_b3_n2 = cute.arch.shuffle_sync(s_regs[g][ni0+2][3], src_lane_b)
+                        sh_b2_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][2], src_lane_b)
+                        sh_b3_n3 = cute.arch.shuffle_sync(s_regs[g][ni0+3][3], src_lane_b)
+                        pa3 = cvt_f32_to_fp8x4(
+                            sh_a2_n2 if tip_lo else sh_a2_n3,
+                            sh_a3_n2 if tip_lo else sh_a3_n3,
+                            sh_b2_n2 if tip_lo else sh_b2_n3,
+                            sh_b3_n2 if tip_lo else sh_b3_n3,
+                        )
+                        pa_reg[g][pv_ki][0] = pa0
+                        pa_reg[g][pv_ki][1] = pa1
+                        pa_reg[g][pv_ki][2] = pa2
+                        pa_reg[g][pv_ki][3] = pa3
+
+                # ---- Wait for V ready ----
+                v_pipeline.consumer_wait(v_consumer_state)
+                v_stage = v_consumer_state.index
+
+                # ---- Path A: ldmatrix.x4.trans.b16 directly from sV with
+                # SW128 swizzle (manual swizzle in address) — eliminates the
+                # software transpose AND reduces ldmatrix bank conflicts.
+                # See /tmp/probe_ldmatrix_layout.py for the validated bridge.
+                sV_ptr_base = sV.iterator
+                stage_off = v_stage * N * D
+                warp_lane = tidx % 32
+                lane_g_block = warp_lane // 8
+                row_in_block = warp_lane & 7
+                kv_for_lane = (
+                    (lane_g_block & 1) * 16
+                    + ((lane_g_block >> 1) & 1) * 8
+                    + row_in_block
+                )
+                pv_gid = warp_lane // 4
+                pv_tip = warp_lane % 4
+                src_la = (pv_gid // 2) * 4 + (pv_tip & 1) * 2
+                src_lb = src_la + 1
+                tip_lo_int = cutlass.Int32(1) - ((pv_tip >> 1) & 1)
+                prmt_sel = cutlass.Int32(0x6420) + (pv_gid & 1) * cutlass.Int32(0x1111)
+                ldmat_n_d_chunks = n_d_tiles // 2
+                src_la_b = src_la + 16
+                src_lb_b = src_lb + 16
+                # Swizzle(B, M=4, S=3) XOR mask. Constexpr selection (D is
+                # known at compile time): SW128(B=3)/SW64(B=2)/SW32(B=1).
+                SWIZZLE_BMASK = cutlass.Int32(
+                    7 if D >= 128 else 3 if D >= 64 else 1
+                )
+                for pv_ki in cutlass.range_constexpr(n_pv_k_iters):
+                    pv_kv_base = pv_ki * 32
+                    for dc in cutlass.range_constexpr(ldmat_n_d_chunks):
+                        d_chunk_base_fp8 = dc * 16
+                        # Logical byte offset within sV stage
+                        kv_d_off = (pv_kv_base + kv_for_lane) * D + d_chunk_base_fp8
+                        # Apply Swizzle(B,4,3) XOR: ((addr>>7) & ((1<<B)-1)) << 4
+                        swizzled_kv_d = kv_d_off ^ (((kv_d_off >> 7) & SWIZZLE_BMASK) << 4)
+                        elem_off = stage_off + swizzled_kv_d
+                        my_ptr = sV_ptr_base + elem_off
+                        addr_u32 = cvta_to_shared_u32(my_ptr)
+                        ldm_r0, ldm_r1, ldm_r2, ldm_r3 = ldmatrix_x4_trans_b16(addr_u32)
+
+                        # Bridge: shuffle raw regs, select per q, prmt per g_parity
+                        b0_a = prmt_b32(
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r0, src_la),
+                                cute.arch.shuffle_sync(ldm_r2, src_la),
+                                tip_lo_int),
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r0, src_lb),
+                                cute.arch.shuffle_sync(ldm_r2, src_lb),
+                                tip_lo_int),
+                            prmt_sel)
+                        b1_a = prmt_b32(
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r1, src_la),
+                                cute.arch.shuffle_sync(ldm_r3, src_la),
+                                tip_lo_int),
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r1, src_lb),
+                                cute.arch.shuffle_sync(ldm_r3, src_lb),
+                                tip_lo_int),
+                            prmt_sel)
+                        b0_b = prmt_b32(
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r0, src_la_b),
+                                cute.arch.shuffle_sync(ldm_r2, src_la_b),
+                                tip_lo_int),
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r0, src_lb_b),
+                                cute.arch.shuffle_sync(ldm_r2, src_lb_b),
+                                tip_lo_int),
+                            prmt_sel)
+                        b1_b = prmt_b32(
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r1, src_la_b),
+                                cute.arch.shuffle_sync(ldm_r3, src_la_b),
+                                tip_lo_int),
+                            selp_b32(
+                                cute.arch.shuffle_sync(ldm_r1, src_lb_b),
+                                cute.arch.shuffle_sync(ldm_r3, src_lb_b),
+                                tip_lo_int),
+                            prmt_sel)
+                        for g in cutlass.range_constexpr(n_warp_groups):
+                            pa0 = pa_reg[g][pv_ki][0]
+                            pa1 = pa_reg[g][pv_ki][1]
+                            pa2 = pa_reg[g][pv_ki][2]
+                            pa3 = pa_reg[g][pv_ki][3]
+                            o_regs[g][dc*2][0], o_regs[g][dc*2][1], o_regs[g][dc*2][2], o_regs[g][dc*2][3] = \
+                                mma_f8f6f4_m16n8k32_e4m3(
+                                    pa0, pa1, pa2, pa3, b0_a, b1_a,
+                                    o_regs[g][dc*2][0], o_regs[g][dc*2][1],
+                                    o_regs[g][dc*2][2], o_regs[g][dc*2][3])
+                            o_regs[g][dc*2+1][0], o_regs[g][dc*2+1][1], o_regs[g][dc*2+1][2], o_regs[g][dc*2+1][3] = \
+                                mma_f8f6f4_m16n8k32_e4m3(
+                                    pa0, pa1, pa2, pa3, b0_b, b1_b,
+                                    o_regs[g][dc*2+1][0], o_regs[g][dc*2+1][1],
+                                    o_regs[g][dc*2+1][2], o_regs[g][dc*2+1][3])
+
+                # Release V stage after all ldmatrix loads complete
+                v_pipeline.consumer_release(v_consumer_state)
+                v_consumer_state.advance()
+
+            # ---- Final normalize and store O (per row group) ----
+            seq_lim = mO.shape[1]
+            for g in cutlass.range_constexpr(n_warp_groups):
+                rsu = row_sum_u[g] + cute.arch.shuffle_sync_bfly(
+                    row_sum_u[g], offset=2, mask=-1, mask_and_clamp=31)
+                rsu = rsu + cute.arch.shuffle_sync_bfly(
+                    rsu, offset=1, mask=-1, mask_and_clamp=31)
+                rsl = row_sum_l[g] + cute.arch.shuffle_sync_bfly(
+                    row_sum_l[g], offset=2, mask=-1, mask_and_clamp=31)
+                rsl = rsl + cute.arch.shuffle_sync_bfly(
+                    rsl, offset=1, mask=-1, mask_and_clamp=31)
+
+                inv_u = cutlass.Float32(1.0) / rsu if rsu != cutlass.Float32(0.0) else cutlass.Float32(1.0)
+                inv_l = cutlass.Float32(1.0) / rsl if rsl != cutlass.Float32(0.0) else cutlass.Float32(1.0)
+
+                rg = m_warp_base + g * 16
+                for dt in cutlass.range_constexpr(n_d_tiles):
+                    db = dt * 8
+                    row_u = m_base + rg + gid
+                    row_l = m_base + rg + gid + 8
+                    if row_u < seq_lim:
+                        mO[batch_idx, row_u, head_idx, db + tip*2]     = o_regs[g][dt][0] * inv_u
+                        mO[batch_idx, row_u, head_idx, db + tip*2 + 1] = o_regs[g][dt][1] * inv_u
+                    if row_l < seq_lim:
+                        mO[batch_idx, row_l, head_idx, db + tip*2]     = o_regs[g][dt][2] * inv_l
+                        mO[batch_idx, row_l, head_idx, db + tip*2 + 1] = o_regs[g][dt][3] * inv_l
+
+        elif warp_idx == self._num_mma_warps:
+            # === DMA warp (producer) ===
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            # Load Q (once)
+            q_pipeline.producer_acquire(q_producer_state)
+            cute.copy(
+                tma_atom_q, tQgQ_block,
+                tQsQ[(None, q_producer_state.index)],
+                tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state),
+            )
+            q_pipeline.producer_commit(q_producer_state)
+
+            # Load K, V tiles (high → low for causal/iter order)
+            for n_tile in range(0, n_block_max, 1, unroll=1):
+                nb = n_block_max - n_tile - 1
+
+                k_pipeline.producer_acquire(k_producer_state)
+                cute.copy(
+                    tma_atom_k,
+                    tKgK_block[(None, nb)],
+                    tKsK[(None, k_producer_state.index)],
+                    tma_bar_ptr=k_pipeline.producer_get_barrier(k_producer_state),
+                )
+                k_pipeline.producer_commit(k_producer_state)
+                k_producer_state.advance()
+
+                v_pipeline.producer_acquire(v_producer_state)
+                cute.copy(
+                    tma_atom_v,
+                    tVgV_block[(None, nb)],
+                    tVsV[(None, v_producer_state.index)],
+                    tma_bar_ptr=v_pipeline.producer_get_barrier(v_producer_state),
+                )
+                v_pipeline.producer_commit(v_producer_state)
+                v_producer_state.advance()
+
+            k_pipeline.producer_tail(k_producer_state)
+            v_pipeline.producer_tail(v_producer_state)
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Test / benchmark harness
+# /////////////////////////////////////////////////////////////////////////////
+
+def make_cute_fp8(t):
+    fp8 = cutlass.Float8E4M3FN
+    u8 = t.view(torch.uint8)
+    ct = from_dlpack(u8, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=u8.dim_order(), divisibility=(128 // fp8.width))
+    ct.element_type = fp8
+    return ct
+
+
+def make_cute_f32(t):
+    return from_dlpack(t, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=t.dim_order(), divisibility=4)
+
+
+def run_test(B, Sq, Sk, H, D, is_causal=False, desc="",
+             m_block_size=128, n_block_size=64, kv_stages=2):
+    """Correctness test against an FP32 reference.
+
+    Returns True on PASS (max_diff < 0.1).
+    """
+    scale = 1.0 / (D ** 0.5)
+    torch.manual_seed(42)
+    q = (torch.randn(B, Sq, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    k = (torch.randn(B, Sk, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    v = (torch.randn(B, Sk, H, D, device='cuda') * 0.1).to(torch.float8_e4m3fn)
+
+    # Reference: must permute (B, S, H, D) -> (B, H, S, D) before flattening to
+    # (B*H, S, D); a plain view would interleave seq and head, scrambling
+    # per-head data for H >= 2 and silently failing the comparison.
+    qf = q.float().permute(0, 2, 1, 3).contiguous().view(B * H, Sq, D)
+    kf = k.float().permute(0, 2, 1, 3).contiguous().view(B * H, Sk, D)
+    vf = v.float().permute(0, 2, 1, 3).contiguous().view(B * H, Sk, D)
+    s = torch.bmm(qf, kf.transpose(1, 2)) * scale
+    if is_causal:
+        mask = torch.triu(torch.ones(Sq, Sk, device='cuda'), diagonal=1).bool()
+        s.masked_fill_(mask.unsqueeze(0), float('-inf'))
+    p = torch.softmax(s, dim=-1)
+    ref = torch.bmm(p, vf).view(B, H, Sq, D).permute(0, 2, 1, 3).contiguous()
+
+    o_f32 = torch.zeros(B, Sq, H, D, dtype=torch.float32, device='cuda')
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    kern = FP8FlashAttentionSm120Tma(
+        D, m_block_size=m_block_size, n_block_size=n_block_size,
+        kv_stages=kv_stages, is_causal=is_causal,
+    )
+    compiled = cute.compile(
+        kern, make_cute_fp8(q), make_cute_fp8(k), make_cute_fp8(v),
+        make_cute_f32(o_f32), scale, stream,
+    )
+    compiled(make_cute_fp8(q), make_cute_fp8(k), make_cute_fp8(v),
+             make_cute_f32(o_f32), scale, stream)
+    torch.cuda.synchronize()
+
+    diff = (o_f32 - ref).abs()
+    max_d = diff.max().item()
+    mean_d = diff.mean().item()
+    # Also check per-row coverage — if any row is entirely zero, the kernel
+    # likely has an indexing bug (some warps not computing their rows).
+    row_norms = o_f32.norm(dim=-1).flatten()
+    n_zero_rows = (row_norms < 1e-6).sum().item()
+    ok = (max_d < 0.05) and (n_zero_rows == 0)
+    tag = "tma" + (" causal" if is_causal else "")
+    print(f"{'PASS' if ok else 'FAIL'} | {desc:30s} | B={B} Sq={Sq:4d} Sk={Sk:4d} "
+          f"H={H} D={D:3d} {tag:12s} | max={max_d:.6f} mean={mean_d:.6f}"
+          f" zero_rows={n_zero_rows}")
+    return ok
+
+
+def run_benchmark(
+    batch_size, seqlen_q, seqlen_k, num_head, head_dim,
+    softmax_scale=None, is_causal=False,
+    m_block_size=128, n_block_size=64, kv_stages=2,
+    warmup_iterations=10, iterations=50,
+    skip_ref_check=False,
+):
+    """Benchmark FP8 TMA flash attention. Returns avg time in microseconds."""
+    import cutlass.cute.testing as testing
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / (head_dim ** 0.5)
+
+    print(f"Running FP8 FA (tma): B={batch_size} Sq={seqlen_q} "
+          f"Sk={seqlen_k} H={num_head} D={head_dim} causal={is_causal}")
+
+    torch.manual_seed(42)
+    q_torch = (torch.randn(batch_size, seqlen_q, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    k_torch = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    v_torch = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+    o_torch = torch.zeros(batch_size, seqlen_q, num_head, head_dim,
+                          dtype=torch.float32, device='cuda')
+
+    q = make_cute_fp8(q_torch)
+    k = make_cute_fp8(k_torch)
+    v = make_cute_fp8(v_torch)
+    o = make_cute_f32(o_torch)
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    kern = FP8FlashAttentionSm120Tma(
+        head_dim, m_block_size=m_block_size, n_block_size=n_block_size,
+        kv_stages=kv_stages, is_causal=is_causal,
+    )
+    compiled = cute.compile(kern, q, k, v, o, softmax_scale, stream)
+
+    if not skip_ref_check:
+        compiled(q, k, v, o, softmax_scale, stream)
+        torch.cuda.synchronize()
+        qf = q_torch.float().permute(0, 2, 1, 3).contiguous().view(
+            batch_size * num_head, seqlen_q, head_dim)
+        kf = k_torch.float().permute(0, 2, 1, 3).contiguous().view(
+            batch_size * num_head, seqlen_k, head_dim)
+        vf = v_torch.float().permute(0, 2, 1, 3).contiguous().view(
+            batch_size * num_head, seqlen_k, head_dim)
+        s = torch.bmm(qf, kf.transpose(1, 2)) * softmax_scale
+        if is_causal:
+            mask = torch.triu(torch.ones(seqlen_q, seqlen_k, device='cuda'),
+                              diagonal=1).bool()
+            s.masked_fill_(mask.unsqueeze(0), float('-inf'))
+        p = torch.softmax(s, dim=-1)
+        ref = torch.bmm(p, vf).view(
+            batch_size, num_head, seqlen_q, head_dim,
+        ).permute(0, 2, 1, 3).contiguous()
+        diff = (o_torch - ref).abs().max().item()
+        assert diff < 0.1, f"Reference check failed: max_diff={diff}"
+        print(f"  Reference check passed (max_diff={diff:.6f})")
+        o_torch.zero_()
+
+    def generate_tensors():
+        q_w = (torch.randn(batch_size, seqlen_q, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+        k_w = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+        v_w = (torch.randn(batch_size, seqlen_k, num_head, head_dim,
+                           device='cuda') * 0.1).to(torch.float8_e4m3fn)
+        o_w = torch.zeros(batch_size, seqlen_q, num_head, head_dim,
+                          dtype=torch.float32, device='cuda')
+        jit_args = testing.JitArguments(
+            make_cute_fp8(q_w), make_cute_fp8(k_w), make_cute_fp8(v_w),
+            make_cute_f32(o_w), softmax_scale, stream,
+        )
+        jit_args.add_to_scope([q_w, k_w, v_w, o_w])
+        return jit_args
+
+    avg_time_us = testing.benchmark(
+        compiled,
+        workspace_generator=generate_tensors,
+        workspace_count=1,
+        stream=stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+    )
+
+    return avg_time_us
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="FP8 Flash Attention TMA for SM120 (Blackwell GeForce)")
+    parser.add_argument("--quick", action="store_true", help="Run minimal tests")
+    parser.add_argument("--benchmark", action="store_true",
+                        help="Run benchmarks instead of correctness tests")
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--seqlen", type=int, default=512)
+    parser.add_argument("--num_head", type=int, default=16)
+    parser.add_argument("--head_dim", type=int, default=128)
+    parser.add_argument("--is_causal", action="store_true")
+    parser.add_argument("--m_block_size", type=int, default=128)
+    parser.add_argument("--n_block_size", type=int, default=64)
+    parser.add_argument("--kv_stages", type=int, default=2)
+    parser.add_argument("--warmup_iterations", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    parser.add_argument("--skip_ref_check", action="store_true")
+    args = parser.parse_args()
+
+    if args.benchmark:
+        avg_us = run_benchmark(
+            args.batch_size, args.seqlen, args.seqlen, args.num_head,
+            args.head_dim, is_causal=args.is_causal,
+            m_block_size=args.m_block_size, n_block_size=args.n_block_size,
+            kv_stages=args.kv_stages,
+            warmup_iterations=args.warmup_iterations,
+            iterations=args.iterations,
+            skip_ref_check=args.skip_ref_check,
+        )
+        flops = 4 * args.batch_size * args.num_head * args.seqlen * args.seqlen * args.head_dim
+        if args.is_causal:
+            flops //= 2
+        tflops = flops / (avg_us * 1e-6) / 1e12
+        print(f"avg time: {avg_us:.2f} us, {tflops:.2f} TFLOPS")
+    else:
+        # Correctness test sweep
+        if args.quick:
+            shapes = [(1, 256, 256, 4, 64), (1, 512, 512, 4, 128)]
+        else:
+            shapes = [
+                (1, 256,  256,  1, 64), (1, 256,  256,  4, 128),
+                (1, 512,  512,  4, 64), (1, 512,  512,  4, 128),
+                (1, 1024, 1024, 4, 64), (1, 1024, 1024, 4, 128),
+                (1, 2048, 2048, 4, 64), (1, 2048, 2048, 4, 128),
+                # Non-divisible shapes (test OOB masking)
+                (1, 300,  300,  4, 128),
+                (4, 100,  100,  16, 64),
+                (1, 600,  600,  4, 64),
+                # Causal sweep
+                (1, 512,  512,  4, 128),
+                (1, 1024, 1024, 4, 128),
+            ]
+        all_pass = True
+        for B, Sq, Sk, H, D in shapes:
+            for causal in [False, True]:
+                ok = run_test(B, Sq, Sk, H, D, is_causal=causal,
+                              m_block_size=args.m_block_size,
+                              n_block_size=args.n_block_size,
+                              kv_stages=args.kv_stages)
+                all_pass = all_pass and ok
+        print(f"\n{'ALL PASS' if all_pass else 'SOME FAILED'}")

--- a/examples/python/CuTeDSL/blackwell_geforce/fp8_gemm.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/fp8_gemm.py
@@ -1,0 +1,377 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+FP8 GEMM example for NVIDIA Blackwell GeForce SM120 architecture using CuTe DSL.
+
+Computes C = A @ B^T where A and B are FP8 (e4m3) and C is FP32, using SM120's
+``mma.sync.aligned.kind::f8f6f4.m16n8k32`` tensor core instruction via inline PTX.
+
+SM120 FP8 MMA Register Layout
+==============================
+
+The ``kind::f8f6f4`` instruction has a **different** register layout from the standard
+``m16n8k32`` integer MMA. The key differences are:
+
+1. **A register ordering is K-paired, not row-paired:**
+   Standard m16n8k32: {upper_k0, upper_k16, lower_k0, lower_k16}
+   kind::f8f6f4:      {upper_k0, lower_k0, upper_k16, lower_k16}
+
+2. **B register split is along K, not N:**
+   Standard m16n8k32: b0 -> N=0..3, b1 -> N=4..7 (N-split)
+   kind::f8f6f4:      b0 -> K=0..15, b1 -> K=16..31 (K-split)
+
+3. **B loading indices are swapped:**
+   Standard: b0 = sB_f32[tip, gid]  (tip indexes N, gid indexes K-groups)
+   kind::f8f6f4: b0 = sB_f32[gid, tip]  (gid indexes N, tip indexes K-groups)
+
+Complete Register Mapping (gid = tid // 4, tip = tid % 4)
+----------------------------------------------------------
+
+A registers (row-major A[16, 32], sA_f32 = recast to Float32 giving shape [16, 8]):
+  a0 = sA_f32[gid,   tip]     -> A[gid,   tip*4 : tip*4+3]     (rows 0-7,  K=0..15)
+  a1 = sA_f32[gid+8, tip]     -> A[gid+8, tip*4 : tip*4+3]     (rows 8-15, K=0..15)
+  a2 = sA_f32[gid,   tip+4]   -> A[gid,   tip*4+16 : tip*4+19] (rows 0-7,  K=16..31)
+  a3 = sA_f32[gid+8, tip+4]   -> A[gid+8, tip*4+16 : tip*4+19] (rows 8-15, K=16..31)
+
+B registers (row-major B[8, 32], sB_f32 = recast to Float32 giving shape [8, 8]):
+  b0 = sB_f32[gid, tip]       -> B[gid, tip*4 : tip*4+3]       (all N, K=0..15)
+  b1 = sB_f32[gid, tip+4]     -> B[gid, tip*4+16 : tip*4+19]   (all N, K=16..31)
+
+C/D layout (standard PTX ISA):
+  d0 -> C[gid,   tip*2]
+  d1 -> C[gid,   tip*2+1]
+  d2 -> C[gid+8, tip*2]
+  d3 -> C[gid+8, tip*2+1]
+
+Why not use CuTe's MmaAtom?
+============================
+
+CuTe's ``MmaAtomSM80Type`` segfaults when configured with FP8 types on SM120 because
+the MLIR backend lacks a lowering path for the ``kind::f8f6f4`` PTX variant (see Issue
+#3044). This example works around this via inline PTX assembly using ``llvm.inline_asm``.
+
+Why not use ldmatrix?
+=====================
+
+SM120's ``ldmatrix`` only supports 16-bit element types. For FP8, we use direct 32-bit
+scalar loads (recast SMEM to Float32, then bitcast to Int32) with the natural row-major
+SMEM layout. This avoids the cross-thread swizzling that ldmatrix performs and requires
+different SMEM indexing than the CuTe ThrVal layouts used for ldmatrix-based kernels.
+
+To run this example:
+
+.. code-block:: bash
+
+    python examples/python/CuTeDSL/blackwell_geforce/fp8_gemm.py
+    python examples/python/CuTeDSL/blackwell_geforce/fp8_gemm.py --M 128 --N 64 --K 256
+
+Constraints:
+  * M must be a multiple of 16, N a multiple of 8, K a multiple of 32.
+  * Only FP8 e4m3 (Float8E4M3FN) inputs are supported.
+  * Output is FP32.
+  * Requires SM120 or later (Blackwell GeForce / DGX Spark).
+"""
+
+import argparse
+
+import torch
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int32, Float32
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Inline PTX MMA wrapper
+# /////////////////////////////////////////////////////////////////////////////
+
+@dsl_user_op
+def mma_f8f6f4_m16n8k32_e4m3(
+    a0, a1, a2, a3, b0, b1, c0, c1, c2, c3,
+    *, loc=None, ip=None,
+):
+    """Emit mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32.
+
+    Args:
+        a0..a3: Int32 — A matrix fragment registers (4 x uint32, 16 FP8 values)
+        b0, b1: Int32 — B matrix fragment registers (2 x uint32, 8 FP8 values)
+        c0..c3: Float32 — C accumulator registers (4 x f32)
+
+    Returns:
+        Tuple of 4 Float32 — D result registers
+    """
+    a0_ir = Int32(a0).ir_value(loc=loc, ip=ip)
+    a1_ir = Int32(a1).ir_value(loc=loc, ip=ip)
+    a2_ir = Int32(a2).ir_value(loc=loc, ip=ip)
+    a3_ir = Int32(a3).ir_value(loc=loc, ip=ip)
+    b0_ir = Int32(b0).ir_value(loc=loc, ip=ip)
+    b1_ir = Int32(b1).ir_value(loc=loc, ip=ip)
+    c0_ir = Float32(c0).ir_value(loc=loc, ip=ip)
+    c1_ir = Float32(c1).ir_value(loc=loc, ip=ip)
+    c2_ir = Float32(c2).ir_value(loc=loc, ip=ip)
+    c3_ir = Float32(c3).ir_value(loc=loc, ip=ip)
+    ret = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(f32,f32,f32,f32)>"),
+        [a0_ir, a1_ir, a2_ir, a3_ir, b0_ir, b1_ir,
+         c0_ir, c1_ir, c2_ir, c3_ir],
+        "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        "{$0,$1,$2,$3},{$4,$5,$6,$7},{$8,$9},{$10,$11,$12,$13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=True, asm_dialect=0, loc=loc, ip=ip,
+    )
+    return (Float32(llvm.extractvalue(T.f32(), ret, [0], loc=loc, ip=ip)),
+            Float32(llvm.extractvalue(T.f32(), ret, [1], loc=loc, ip=ip)),
+            Float32(llvm.extractvalue(T.f32(), ret, [2], loc=loc, ip=ip)),
+            Float32(llvm.extractvalue(T.f32(), ret, [3], loc=loc, ip=ip)))
+
+
+@dsl_user_op
+def bitcast_f32_to_i32(val, *, loc=None, ip=None):
+    """Bitcast a Float32 value to Int32 (reinterpret 4 FP8 bytes as uint32)."""
+    f32_ir = Float32(val).ir_value(loc=loc, ip=ip)
+    i32_ir = llvm.bitcast(T.i32(), f32_ir, loc=loc, ip=ip)
+    return Int32(i32_ir)
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# FP8 Tiled GEMM kernel
+# /////////////////////////////////////////////////////////////////////////////
+
+class FP8GemmSm120:
+    """FP8 GEMM for SM120: C[M,N] = A[M,K] @ B[N,K]^T.
+
+    Each CTA computes one (16, 8) output tile, looping over K in chunks of 32.
+    Grid: (M//16, N//8, 1), Block: (32, 1, 1) — one warp per tile.
+    """
+
+    def __init__(self, K: int):
+        self._K = K
+
+    @cute.jit
+    def __call__(self, mA: cute.Tensor, mB: cute.Tensor, mC: cute.Tensor,
+                 stream: cuda.CUstream):
+        fp8 = cutlass.Float8E4M3FN
+
+        # SMEM layouts for one MMA tile: A[16, 32] and B[8, 32] in FP8
+        sA_layout = cute.make_layout((16, 32), stride=(32, 1))
+        sB_layout = cute.make_layout((8, 32), stride=(32, 1))
+
+        @cute.struct
+        class SharedStorage:
+            sA: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sA_layout)], 128
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[fp8, cute.cosize(sB_layout)], 128
+            ]
+
+        # Global -> Shared copy: 64-bit (8 FP8 elements) per copy
+        g2s_bits = 64
+        g2s_elems = g2s_bits // fp8.width
+        g2s_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), fp8, num_bits_per_copy=g2s_bits,
+        )
+        t_dim = 32 // g2s_elems
+        num_m = 32 // t_dim
+        tv_layout = cute.make_layout((num_m, t_dim), stride=(t_dim, 1))
+        v_layout = cute.make_layout((1, g2s_elems))
+        g2s_tiled = cute.make_tiled_copy_tv(g2s_atom, tv_layout, v_layout)
+
+        grid_dim = (
+            cute.ceil_div(mC.shape[1], 16),
+            cute.ceil_div(mC.shape[3], 8),
+            1,
+        )
+
+        self.kernel(mA, mB, mC, sA_layout, sB_layout, g2s_tiled, SharedStorage,
+        ).launch(grid=grid_dim, block=[32, 1, 1], stream=stream,
+                 smem=SharedStorage.size_in_bytes())
+
+    @cute.kernel
+    def kernel(self, mA: cute.Tensor, mB: cute.Tensor, mC: cute.Tensor,
+               sA_layout: cute.Layout, sB_layout: cute.Layout,
+               g2s_tiled: cute.TiledCopy, SharedStorage: cutlass.Constexpr):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_block, n_block, _ = cute.arch.block_idx()
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sA = storage.sA.get_tensor(sA_layout)
+        sB = storage.sB.get_tensor(sB_layout)
+
+        # Thread decomposition for MMA fragment indexing
+        gid = tidx // 4   # 0..7: indexes rows for A/B, columns for C
+        tip = tidx % 4    # 0..3: indexes K-groups (4 consecutive FP8 values)
+
+        # Initialize FP32 accumulators
+        acc0 = cutlass.Float32(0.0)
+        acc1 = cutlass.Float32(0.0)
+        acc2 = cutlass.Float32(0.0)
+        acc3 = cutlass.Float32(0.0)
+
+        n_k_tiles = self._K // 32
+
+        for k_tile in range(n_k_tiles):
+            # Load A[m_block*16 : (m_block+1)*16, k_tile*32 : (k_tile+1)*32]
+            gA = cute.local_tile(mA[0, None, 0, None], (16, 32), (m_block, k_tile))
+            # Load B[n_block*8 : (n_block+1)*8, k_tile*32 : (k_tile+1)*32]
+            gB = cute.local_tile(mB[0, None, 0, None], (8, 32), (n_block, k_tile))
+
+            thr_g2s = g2s_tiled.get_slice(tidx)
+            cute.copy(g2s_tiled, thr_g2s.partition_S(gA), thr_g2s.partition_D(sA))
+            cute.copy(g2s_tiled, thr_g2s.partition_S(gB), thr_g2s.partition_D(sB))
+            cute.arch.sync_threads()
+
+            # Recast SMEM to Float32 view for 4-byte (4 FP8) loads
+            sA_f32 = cute.recast_tensor(sA, cutlass.Float32)  # shape: (16, 8)
+            sB_f32 = cute.recast_tensor(sB, cutlass.Float32)  # shape: (8, 8)
+
+            # Load A registers: kind::f8f6f4 ordering
+            # a0 -> rows 0-7,  K first half;  a1 -> rows 8-15, K first half
+            # a2 -> rows 0-7,  K second half; a3 -> rows 8-15, K second half
+            a0 = bitcast_f32_to_i32(sA_f32[gid,     tip])
+            a1 = bitcast_f32_to_i32(sA_f32[gid + 8, tip])
+            a2 = bitcast_f32_to_i32(sA_f32[gid,     tip + 4])
+            a3 = bitcast_f32_to_i32(sA_f32[gid + 8, tip + 4])
+
+            # Load B registers: K-split ordering (gid indexes N, tip indexes K)
+            b0 = bitcast_f32_to_i32(sB_f32[gid, tip])
+            b1 = bitcast_f32_to_i32(sB_f32[gid, tip + 4])
+
+            # Accumulate: D = A * B^T + C
+            acc0, acc1, acc2, acc3 = mma_f8f6f4_m16n8k32_e4m3(
+                a0, a1, a2, a3, b0, b1, acc0, acc1, acc2, acc3,
+            )
+
+            cute.arch.sync_threads()
+
+        # Store results using PTX ISA C/D layout
+        mC[0, m_block * 16 + gid,     0, n_block * 8 + tip * 2]     = acc0
+        mC[0, m_block * 16 + gid,     0, n_block * 8 + tip * 2 + 1] = acc1
+        mC[0, m_block * 16 + gid + 8, 0, n_block * 8 + tip * 2]     = acc2
+        mC[0, m_block * 16 + gid + 8, 0, n_block * 8 + tip * 2 + 1] = acc3
+
+
+# /////////////////////////////////////////////////////////////////////////////
+# Helper functions
+# /////////////////////////////////////////////////////////////////////////////
+
+def make_cute_fp8_tensor(t):
+    """Wrap a torch FP8 tensor as a CuTe tensor."""
+    fp8 = cutlass.Float8E4M3FN
+    t_u8 = t.view(torch.uint8)
+    ct = from_dlpack(t_u8, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=t_u8.dim_order(),
+        divisibility=(128 // fp8.width))
+    ct.element_type = fp8
+    return ct
+
+
+def make_cute_f32_tensor(t):
+    """Wrap a torch FP32 tensor as a CuTe tensor."""
+    return from_dlpack(t, assumed_align=16).mark_layout_dynamic(
+        leading_dim=3).mark_compact_shape_dynamic(
+        mode=3, stride_order=t.dim_order(), divisibility=4)
+
+
+def run(M: int, N: int, K: int):
+    """Run FP8 GEMM and verify against reference."""
+    assert M % 16 == 0, f"M ({M}) must be a multiple of 16"
+    assert N % 8 == 0, f"N ({N}) must be a multiple of 8"
+    assert K % 32 == 0, f"K ({K}) must be a multiple of 32"
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Create random FP8 data
+    torch.manual_seed(42)
+    a_data = torch.randn(1, M, 1, K, dtype=torch.float32, device='cuda') * 0.3
+    b_data = torch.randn(1, N, 1, K, dtype=torch.float32, device='cuda') * 0.3
+    a_fp8 = a_data.to(torch.float8_e4m3fn)
+    b_fp8 = b_data.to(torch.float8_e4m3fn)
+
+    # Reference: compute in FP32 using FP8-quantized values
+    ref = a_fp8.squeeze().float() @ b_fp8.squeeze().float().T  # (M, N)
+
+    # CuTe tensors
+    a_c = make_cute_fp8_tensor(a_fp8)
+    b_c = make_cute_fp8_tensor(b_fp8)
+    c_f32 = torch.zeros(1, M, 1, N, dtype=torch.float32, device='cuda')
+    c_c = make_cute_f32_tensor(c_f32)
+
+    # Compile and run
+    kern = FP8GemmSm120(K)
+    compiled = cute.compile(kern, a_c, b_c, c_c, stream)
+    compiled(a_c, b_c, c_c, stream)
+    torch.cuda.synchronize()
+
+    # Verify
+    result = c_f32.squeeze()
+    max_diff = (result - ref.squeeze()).abs().max().item()
+    return max_diff
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="FP8 GEMM for Blackwell GeForce SM120"
+    )
+    parser.add_argument("--M", type=int, default=None,
+                        help="M dimension (default: run test suite)")
+    parser.add_argument("--N", type=int, default=None)
+    parser.add_argument("--K", type=int, default=None)
+    args = parser.parse_args()
+
+    if args.M is not None and args.N is not None and args.K is not None:
+        max_diff = run(args.M, args.N, args.K)
+        status = "PASS" if max_diff < 0.1 else "FAIL"
+        print(f"{status} | M={args.M} N={args.N} K={args.K} | max_diff={max_diff:.6f}")
+    else:
+        # Run test suite
+        configs = [
+            (16, 8, 32, "Single MMA tile"),
+            (16, 8, 64, "K=64 (2 K-iterations)"),
+            (16, 8, 128, "K=128 (4 K-iterations)"),
+            (32, 16, 64, "2x2 MMA tiles"),
+            (64, 32, 128, "4x4 MMA tiles"),
+            (128, 64, 256, "8x8 MMA tiles"),
+            (128, 128, 128, "8x16 MMA tiles"),
+        ]
+        all_pass = True
+        for M, N, K, desc in configs:
+            max_diff = run(M, N, K)
+            status = "PASS" if max_diff < 0.1 else "FAIL"
+            if status == "FAIL":
+                all_pass = False
+            print(f"{status} | {desc:25s} | M={M:3d} N={N:3d} K={K:3d} | "
+                  f"max_diff={max_diff:.6f}")
+        print(f"\n{'PASS' if all_pass else 'FAIL'}")


### PR DESCRIPTION
## Summary

Adds CuTe DSL Flash Attention v2 forward pass kernels for SM120 (RTX 5090, GB10 / DGX Spark), addressing the lack of high-performance FA kernels for this architecture.

**Three implementations included:**

### BF16 Kernels (`flash_attention_v2.py`)

1. **CpAsync variant** (`FlashAttentionForwardSm120`): All threads perform both loads and compute using `cp.async` — the Ampere-era approach, tuned for SM120's 101 KB shared memory.

2. **TMA variant** (`FlashAttentionForwardSm120Tma`): Uses TMA (`cp.async.bulk`) with warp specialization — 1 dedicated DMA warp handles TMA loads while N MMA warps compute, enabling load/compute overlap via multi-stage KV pipelining with `PipelineTmaAsync` mbarrier synchronization.

Both use SM80-compatible tensor core instructions (`mma.sync.aligned.m16n8k16`) since SM120 lacks tcgen05 MMA. Supports FP16/BF16, causal/non-causal, configurable tile sizes, asymmetric Q/K lengths, online softmax fusion, and register pipelining.

### FP8 Kernel (`fp8_flash_attention.py`)

3. **FP8 optimized variant** (`FP8FlashAttentionSm120Opt`): Uses SM120's native FP8 MMA instruction (`mma.sync.aligned.kind::f8f6f4.m16n8k32`) via inline PTX, with CpAsync double-buffered K/V pipeline, vectorized 4×4 byte transpose via `prmt.b32`, and bank-conflict-free SMEM layout (+16 byte row padding).

FP8 kernel features:
- 4-warp design with register-level O accumulation (no SMEM round-trip for output)
- Inline PTX MMA as workaround for CUTLASS `MmaAtomSM80Type` segfault with FP8 types (#3044)
- CpAsync pipelining: V load overlaps QK GEMM, next K prefetch overlaps transpose + PV GEMM
- Vectorized V transpose using 8-instruction `prmt.b32` 4×4 byte shuffle (no `ldmatrix.b8` on SM120)
- Bank-conflict-free SMEM: +16 bytes/row padding eliminates 8-way bank conflicts for stride-D access

### TMA variant details

- 4D TMA descriptors `(seq, dim, head, batch)` for native multi-batch support
- TMA-compatible `Swizzle(B, 4, 3)` pattern (M=4 required by TMA hardware; the CpAsync version uses `Swizzle(B, 3, 3)` which is not valid for TMA)
- Separate K and V pipelines for independent scheduling
- Configurable `kv_stages` for double-buffering (default 2, falls back to 1 for large head_dim)

## Benchmark Results

### FP8 vs BF16 Performance on DGX Spark (SM121a)

*Updated 2026-06-12: the table below originally predated the `FP8FlashAttentionSm120Tma` variant and an FP8 reference-check fix (`fdd8cf12`) — see [the April analysis](https://github.com/NVIDIA/cutlass/pull/3030#issuecomment-4328524695) for full details. Current summary at head (cutlass-dsl 4.5.2, CUDA 13.0, GB10):*

- All 16 benchmark configs pass reference checks, including causal (the earlier causal failures were a test-reference bug — `view` on `(B,S,H,D)` without permute — not a kernel bug)
- FP8 TMA vs FP8 Opt: 1.09–1.14x sum-time, up to ~1.5x at B=4 D=128
- FP8 TMA vs BF16 TMA: 0.81–0.88x sum-time — BF16 remains faster overall at these shapes; the structural cost is the `f8f6f4` B-operand register-layout bridge (~16 shuffles per `ldmatrix` in the PV path). The FP8 path's value is the validated inline-PTX `f8f6f4` route pending #3044, plus the memory-side win.

### BF16 TMA vs CpAsync Performance on DGX Spark (SM121a)

TMA kernel: `FlashAttentionForwardSm120Tma` (warp-specialized, 3 MMA + 1 DMA warp, `PipelineTmaAsync`)
CpAsync kernel: `FlashAttentionForwardSm120` (all threads load+compute, `cp.async`)
Both: M=128, N=64, 16 heads, 20 warmup iters, 100 timed iters

| Batch | SeqLen | HDim | Causal | CpAsync (μs) | TMA (μs) | CpAsync TFLOPS | TMA TFLOPS | Speedup |
|:-----:|:------:|:----:|:------:|-------------:|---------:|---------------:|-----------:|:-------:|
| 1 | 512 | 64 | no | 20.5 | 24.6 | 52.48 | 43.67 | 0.83x |
| 1 | 512 | 64 | yes | 22.7 | 32.8 | 23.60 | 16.39 | 0.69x |
| 1 | 512 | 128 | no | 41.0 | 41.0 | 52.40 | 52.38 | 1.00x |
| 1 | 512 | 128 | yes | 32.8 | 34.8 | 32.77 | 30.85 | 0.94x |
| 1 | 1024 | 64 | no | 82.2 | 65.5 | 52.26 | 65.55 | **1.25x** |
| 1 | 1024 | 64 | yes | 45.1 | 51.3 | 47.66 | 41.85 | 0.88x |
| 1 | 1024 | 128 | no | 112.4 | 110.8 | 76.45 | 77.55 | 1.01x |
| 1 | 1024 | 128 | yes | 85.4 | 86.1 | 50.32 | 49.90 | 0.99x |
| 1 | 2048 | 64 | no | 217.8 | 281.5 | 78.86 | 61.03 | 0.77x |
| 1 | 2048 | 64 | yes | 155.2 | 157.5 | 55.33 | 54.52 | 0.99x |
| 1 | 2048 | 128 | no | 519.7 | 461.3 | 66.11 | 74.49 | **1.13x** |
| 1 | 2048 | 128 | yes | 317.6 | 285.9 | 54.09 | 60.10 | **1.11x** |
| 4 | 512 | 64 | no | 55.3 | 88.9 | 77.72 | 48.30 | 0.62x |
| 4 | 512 | 128 | no | 175.7 | 179.3 | 48.88 | 47.91 | 0.98x |
| 4 | 1024 | 64 | no | 226.9 | 318.2 | 75.72 | 53.98 | 0.71x |
| 4 | 1024 | 128 | no | 598.8 | 533.4 | 57.38 | 64.41 | **1.12x** |
| 4 | 2048 | 64 | no | 1272.0 | 1136.9 | 54.02 | 60.45 | **1.12x** |
| 4 | 2048 | 128 | no | 1842.1 | 1865.4 | 74.61 | 73.68 | 0.99x |
| 1 | 4096 | 128 | no | 1863.6 | 1901.2 | 73.75 | 72.29 | 0.98x |
| 1 | 4096 | 128 | yes | 909.2 | 981.3 | 75.58 | 70.03 | 0.93x |
| 1 | 8192 | 128 | no | 7425.3 | 8109.9 | 74.04 | 67.79 | 0.92x |
| 1 | 8192 | 128 | yes | 3866.6 | 3648.6 | 71.09 | 75.34 | **1.06x** |
| 4 | 4096 | 128 | no | 6966.4 | 6840.3 | 78.91 | 80.37 | 1.02x |

Geometric mean speedup: **0.95x** · Min: 0.62x · Max: 1.25x

> **Note:** These initial results contained JIT compilation artifacts (some configs inflated/deflated by first-compilation overhead) and a causal masking bug — see updated results below.

**Key findings:**
- **D=128, medium-to-large sequences**: TMA wins 6-13% (S≥2048 causal, B=4 S≥1024) — warp specialization amortizes DMA warp overhead
- **D=64**: TMA consistently loses (0.62x-0.88x) — tiles too small to amortize the dedicated DMA warp
- **Short sequences (S=512)**: Roughly neutral for D=128, overhead-dominated for D=64
- **kv_stages=1** (required by SMEM budget for D=128): Limits TMA pipelining benefit — no double-buffering of KV tiles
- TMA's primary advantage is architectural: it demonstrates `cp.async.bulk` + warp specialization on SM120, a pattern that scales better with larger tile sizes and multi-stage pipelining

### BF16 TMA vs CpAsync — Updated (post causal masking fix)

The initial results above had two issues:

1. **JIT compilation artifacts**: The CuTe DSL JIT-compiles kernels on first invocation, which inflated/deflated some configs (e.g. the 1.25x outlier at B=1 S=1024 D=64 was a JIT artifact). The updated benchmark pre-warms all kernel variants before timing.

2. **Causal masking bug** (fixed in `106e24b`): The TMA variant applied expensive per-element causal masking to *all* KV tiles instead of only the `ceil_div(m_block, n_block)` tiles near the diagonal. The CpAsync variant correctly used a two-loop structure (masked loop + fast loop). This caused up to 40% regression on causal configs (e.g. B=1 S=512 D=64 causal: 0.69x → 1.00x after fix).

Updated results with JIT pre-warming + causal fix:

| Batch | SeqLen | HDim | Causal | CpAsync (μs) | TMA (μs) | CpAsync TFLOPS | TMA TFLOPS | Speedup |
|:-----:|:------:|:----:|:------:|-------------:|---------:|---------------:|-----------:|:-------:|
| 1 | 512 | 64 | no | 20.5 | 24.6 | 52.46 | 43.69 | 0.83x |
| 1 | 512 | 64 | yes | 20.5 | 20.5 | 26.22 | 26.18 | 1.00x |
| 1 | 512 | 128 | no | 40.9 | 41.0 | 52.44 | 52.40 | 1.00x |
| 1 | 512 | 128 | yes | 32.5 | 34.8 | 33.08 | 30.84 | 0.93x |
| 1 | 1024 | 64 | no | 53.3 | 65.4 | 80.52 | 65.63 | 0.82x |
| 1 | 1024 | 64 | yes | 43.5 | 51.2 | 49.41 | 41.92 | 0.85x |
| 1 | 1024 | 128 | no | 123.9 | 122.7 | 69.35 | 70.03 | 1.01x |
| 1 | 1024 | 128 | yes | 81.6 | 85.6 | 52.64 | 50.18 | 0.95x |
| 1 | 2048 | 64 | no | 201.2 | 240.1 | 85.38 | 71.54 | 0.84x |
| 1 | 2048 | 64 | yes | 128.2 | 156.0 | 67.00 | 55.07 | 0.82x |
| 1 | 2048 | 128 | no | 484.3 | 474.7 | 70.95 | 72.38 | 1.02x |
| 1 | 2048 | 128 | yes | 269.7 | 281.1 | 63.71 | 61.11 | 0.96x |
| 4 | 512 | 64 | no | 53.9 | 69.6 | 79.70 | 61.71 | 0.77x |
| 4 | 512 | 128 | no | 160.9 | 206.6 | 53.39 | 41.58 | 0.78x |
| 4 | 1024 | 64 | no | 259.4 | 272.6 | 66.22 | 63.01 | 0.95x |
| 4 | 1024 | 128 | no | 556.5 | 504.5 | 61.74 | 68.11 | **1.10x** |
| 4 | 2048 | 64 | no | 818.2 | 1040.6 | 83.99 | 66.04 | 0.79x |
| 4 | 2048 | 128 | no | 1784.1 | 1727.8 | 77.03 | 79.55 | 1.03x |
| 1 | 4096 | 128 | no | 1629.5 | 1579.0 | 84.35 | 87.04 | 1.03x |
| 1 | 4096 | 128 | yes | 923.3 | 928.0 | 74.43 | 74.05 | 0.99x |
| 1 | 8192 | 128 | no | 6420.1 | 7276.4 | 85.63 | 75.55 | 0.88x |
| 1 | 8192 | 128 | yes | 3668.0 | 3825.6 | 74.94 | 71.85 | 0.96x |
| 4 | 4096 | 128 | no | 6848.6 | 6269.1 | 80.27 | 87.69 | **1.09x** |

Geometric mean speedup: **0.93x** · Min: 0.77x · Max: 1.10x

**What changed vs initial results:**
- **Causal regression eliminated**: B=1 S=512 D=64 causal went from 0.69x → **1.00x**, B=1 S=512 D=128 causal from 0.94x → **0.93x** (stable)
- **JIT artifacts removed**: B=1 S=1024 D=64 non-causal went from 1.25x → 0.82x (the "win" was JIT noise); similarly B=4 S=2048 D=64 from 1.12x → 0.79x
- **Range tightened**: Min improved from 0.62x → 0.77x; Max normalized from 1.25x → 1.10x

**Updated key findings:**
- **D=128 compute-heavy configs**: TMA provides real 3-10% wins (B=4 S≥1024, B=1 S=4096) where warp specialization amortizes the dedicated DMA warp cost
- **D=64**: TMA consistently loses 5-23% — the N=64 KV tile is too small to benefit from hardware-managed bulk loads vs thread-cooperative CpAsync
- **Causal configs**: After the fix, causal is roughly neutral to slightly slower (0.93x-1.00x) — the runtime branch adds minor overhead vs CpAsync's compile-time two-loop structure
- **Overall**: CpAsync remains the faster default for most configs on SM120. TMA's value is primarily as a reference implementation demonstrating `cp.async.bulk` + warp specialization patterns in the CuTe DSL

## Test Results

Validated on **NVIDIA GB10 (SM121a / DGX Spark)** hardware at [Second Nature Computing](https://joinsecondnature.com) against PyTorch `scaled_dot_product_attention`:

### BF16 CpAsync variant

| dtype | head_dim | seqlen_q | seqlen_k | heads | causal | tile (m x n) | result |
|-------|----------|----------|----------|-------|--------|------------|--------|
| FP16 | 64 | 128 | 128 | 4 | no | 64x64 | PASS |
| BF16 | 128 | 256 | 256 | 8 | no | 64x64 | PASS |
| FP16 | 128 | 512 | 512 | 16 | yes | 128x128 | PASS |
| BF16 | 128 | 1024 | 1024 | 16 | yes | 128x64 | PASS |
| BF16 | 64 | 512 | 1024 | 4 | no | 64x64 | PASS |

### BF16 TMA variant (`--use_tma`)

| dtype | batch | seqlen | heads | head_dim | kv_stages | causal | result |
|-------|-------|--------|-------|----------|-----------|--------|--------|
| BF16 | 1 | 128 | 1 | 64 | 1 | no | PASS |
| BF16 | 1 | 512 | 4 | 128 | 1 | no | PASS |
| BF16 | 1 | 512 | 4 | 64 | 1 | yes | PASS |
| BF16 | 1 | 1024 | 1 | 128 | 1 | yes | PASS |
| BF16 | 2 | 512 | 4 | 128 | 1 | no | PASS |
| BF16 | 2 | 256 | 8 | 64 | 2 | no | PASS |
| BF16 | 4 | 128 | 4 | 128 | 1 | no | PASS |
| BF16 | 3 | 512 | 4 | 64 | 1 | no | PASS |
| BF16 | 2 | 512 | 4 | 128 | 1 | yes | PASS |
| BF16 | 3 | 256 | 8 | 64 | 1 | yes | PASS |
| BF16 | 2 | 1024 | 1 | 128 | 1 | yes | PASS |

### FP8 kernel

| variant | batch | seqlen_q | seqlen_k | heads | head_dim | causal | result |
|---------|-------|----------|----------|-------|----------|--------|--------|
| POC | 1 | 16 | 32 | 1 | 128 | no | PASS |
| POC | 1 | 16 | 64 | 1 | 128 | no | PASS |
| POC | 1 | 16 | 128 | 1 | 128 | no | PASS |
| POC | 1 | 32 | 64 | 1 | 128 | no | PASS |
| POC | 1 | 64 | 128 | 1 | 128 | no | PASS |
| POC | 1 | 16 | 32 | 1 | 64 | no | PASS |
| POC | 1 | 16 | 32 | 1 | 256 | no | PASS |
| POC | 2 | 32 | 64 | 1 | 128 | no | PASS |
| POC | 1 | 32 | 64 | 4 | 128 | no | PASS |
| POC | 1 | 32 | 32 | 1 | 128 | yes | PASS |
| POC | 1 | 64 | 64 | 1 | 128 | yes | PASS |
| Opt | 1 | 64 | 64 | 1 | 128 | no | PASS |
| Opt | 1 | 64 | 128 | 1 | 128 | no | PASS |
| Opt | 1 | 128 | 256 | 1 | 128 | no | PASS |
| Opt | 1 | 64 | 64 | 1 | 64 | no | PASS |
| Opt | 2 | 128 | 128 | 1 | 128 | no | PASS |
| Opt | 1 | 128 | 128 | 4 | 128 | no | PASS |
| Opt | 1 | 64 | 64 | 1 | 128 | yes | PASS |
| Opt | 1 | 128 | 128 | 1 | 128 | yes | PASS |
| Opt | 1 | 256 | 256 | 1 | 128 | yes | PASS |

Tolerance: `atol=1e-02, rtol=1e-04`

## Motivation

There are currently few high-performance flash attention kernels available for SM120. The existing Blackwell FMHA (`blackwell/fmha.py`) targets SM100 and uses tcgen05 MMA + TMEM, which SM120 does not support. This implementation fills that gap by:

1. Providing a working BF16 CpAsync baseline (same algorithmic approach as Ampere FA2)
2. Adding TMA with warp specialization as a meaningful architectural improvement — hardware-managed bulk data movement frees compute warps from load duties
3. Demonstrating FP8 flash attention using SM120's native `f8f6f4` MMA instructions for up to 2× arithmetic throughput over BF16

## Usage

```bash
# BF16 CpAsync variant (default)
python flash_attention_v2.py --batch_size 4 --seqlen_q 8192 --seqlen_k 8192 --num_head 16 --head_dim 128

# BF16 TMA variant with warp specialization
python flash_attention_v2.py --use_tma --batch_size 4 --seqlen_q 8192 --seqlen_k 8192 --num_head 16 --head_dim 128 --kv_stages 1

# FP8 Flash Attention
python fp8_flash_attention.py

# FP8 vs BF16 benchmark
python benchmark_fp8_vs_bf16.py --iters 50
```

Closes #2956

---
*Contributed by [Second Nature Computing](https://joinsecondnature.com) — tested on DGX Spark hardware*



