### PR TITLE
fix: Correct stride calculation in AffineRank2RowMajor::packed()

### DIFF
--- a/include/cutlass/layout/matrix.h
+++ b/include/cutlass/layout/matrix.h
@@ -891,7 +891,7 @@ public:
   /// Helper returns a layout to a tightly packed tensor
   CUTLASS_HOST_DEVICE
   static AffineRank2RowMajor packed(MatrixCoord const &extent) {
-    return AffineRank2RowMajor(1, extent.row());
+    return AffineRank2RowMajor(extent.column(), 1);
   }
 
   /// Returns the offset of a coordinate in linear memory. 


### PR DESCRIPTION
## Summary

I noticed that `AffineRank2RowMajor::packed()` returns `AffineRank2RowMajor(1, extent.row())`, which is identical to the column-major version. For a tightly packed row-major layout, columns should be contiguous (stride=1) and rows should be strided by the number of columns — so the correct call is `AffineRank2RowMajor(extent.column(), 1)`.

This is consistent with:
- The single-argument constructor (`stride_[0] = stride; stride_[1] = 1`)
- The `Affine2Layout_Factory<AffineRank2RowMajor>` specialization, which multiplies by `extent[1]` (columns) for the row stride
- The `capacity()` method, which computes `extent.row() * stride_[0]` — currently returning `rows * 1` instead of `rows * cols`

## Verification

For a 4×8 matrix:
- **Before (buggy):** `packed({4, 8})` → row_stride=1, col_stride=4, capacity=4
- **After (fixed):** `packed({4, 8})` → row_stride=8, col_stride=1, capacity=32

Fixes #2991

Signed-off-by: Blake Ledden <bledden@users.noreply.github.com>