### PR TITLE
fix: Add missing kElementsPerAccess division in RegularTileIterator store

### DIFF
--- a/include/cutlass/transform/threadblock/regular_tile_iterator_pitch_linear.h
+++ b/include/cutlass/transform/threadblock/regular_tile_iterator_pitch_linear.h
@@ -204,7 +204,8 @@ public:
   void store(Fragment const &frag, TensorCoord const & tile_offset) {
     store_with_pointer_offset(
       frag,
-      tile_offset.contiguous() * Shape::kContiguous + tile_offset.strided() * Shape::kStrided * stride_
+      tile_offset.contiguous() * Shape::kContiguous / ThreadMap::kElementsPerAccess +
+        tile_offset.strided() * Shape::kStrided * stride_
     );
   }
 


### PR DESCRIPTION
## Summary

I noticed that `store(frag, tile_offset)` in `RegularTileIterator<layout::PitchLinear>` computes the pointer offset differently from the matching `load(frag, tile_offset)`. The load path divides the contiguous component by `kElementsPerAccess`, but the store path skips this division:

**Load (line 165):**
```cpp
tile_offset.contiguous() * Shape::kContiguous / ThreadMap::kElementsPerAccess +
    tile_offset.strided() * Shape::kStrided * stride_
```

**Store (line 207, before fix):**
```cpp
tile_offset.contiguous() * Shape::kContiguous +
    tile_offset.strided() * Shape::kStrided * stride_
```

Both `load_with_pointer_offset` and `store_with_pointer_offset` apply the same byte conversion (`pointer_offset * sizeof_bits<Element>::value / 8`), so the tile-to-pointer offset calculation should be identical. When `kElementsPerAccess > 1`, the missing division causes load and store to target different memory addresses for the same logical tile offset.

## Verification

With `kElementsPerAccess = 4`, `Shape::kContiguous = 64`, `Element = float` (4 bytes):
- **Load offset**: `(64 / 4) * 4 = 64 bytes`
- **Store offset (before)**: `64 * 4 = 256 bytes` — wrong
- **Store offset (after)**: `(64 / 4) * 4 = 64 bytes` — matches load

The bug is latent in most SIMT kernels where `kElementsPerAccess = 1` since the division is a no-op in that case.

Fixes #3017

Signed-off-by: Blake Ledden <bledden@users.noreply.github.com>