### PR TITLE
docs: Fix invalid composition example in cute.composition docstring

### DIFF
--- a/python/CuTeDSL/cutlass/cute/core.py
+++ b/python/CuTeDSL/cutlass/cute/core.py
@@ -3544,7 +3544,7 @@ def composition(lhs, rhs: Union[Layout, Shape, Tile], *, loc=None, ip=None):
         @cute.jit
         def foo():
             # Create a layout that maps (i,j) to i*4 + j
-            L1 = cute.make_layout((2, 3), stride=(4, 1))
+            L1 = cute.make_layout((3, 4), stride=(4, 1))
             # Create a layout that maps (i,j) to i*3 + j
             L2 = cute.make_layout((3, 4), stride=(3, 1))
             # Compose L1 and L2


### PR DESCRIPTION
## Summary

The code example in the `cutlass.cute.composition` docstring uses layouts with incompatible sizes, causing a compiler error when executed:

```
error: unable to compute the following composition:
  '!cute.layout<"(2,3):(4,1)">' o '!cute.layout<"(3,4):(3,1)">'
```

The issue is that L2's cosize (10) exceeds L1's domain size (6). Changed L1's shape from `(2, 3)` to `(3, 4)`, expanding its domain to 12, which is large enough to cover L2's full range.

## Validation

The fix is verified mathematically:

- **Before:** L1 = `(2,3):(4,1)` has domain = 2 x 3 = **6**. L2 = `(3,4):(3,1)` has cosize = max(2\*3 + 3\*1) + 1 = **10**. Since 10 > 6, the composition is invalid.
- **After:** L1 = `(3,4):(4,1)` has domain = 3 x 4 = **12**. L2 cosize is still 10. Since 10 <= 12, the composition is valid.

The comment "maps (i,j) to i\*4 + j" remains accurate for the new shape `(3, 4)` with stride `(4, 1)`.

Fixes #2657

Signed-off-by: Blake Ledden <bledden@users.noreply.github.com>