### PR TITLE
Replace std::min with cute::min in sm120 blockwise scaling device functions

### DIFF
--- a/include/cutlass/gemm/collective/sm120_mma_array_tma_blockwise_scaling.hpp
+++ b/include/cutlass/gemm/collective/sm120_mma_array_tma_blockwise_scaling.hpp
@@ -540,8 +540,8 @@ struct CollectiveMma<
       Tensor tApA_SFA = make_tensor<bool>(shape(tAsA_SFA(_,_,0)));
       Tensor tBpB_SFB = make_tensor<bool>(shape(tBsB_SFB(_,_,0)));
 
-      auto scale_m_lim = std::min(scales_m, (m_coord + 1) * ScaleMsPerTile);
-      auto scale_n_lim = std::min(scales_n, (n_coord + 1) * ScaleNsPerTile);
+      auto scale_m_lim = cute::min(scales_m, (m_coord + 1) * ScaleMsPerTile);
+      auto scale_n_lim = cute::min(scales_n, (n_coord + 1) * ScaleNsPerTile);
 
       CUTLASS_PRAGMA_UNROLL
       for (int i = 0; i < size(tApA_SFA); ++i)

--- a/include/cutlass/gemm/collective/sm120_mma_tma_blockwise_scaling.hpp
+++ b/include/cutlass/gemm/collective/sm120_mma_tma_blockwise_scaling.hpp
@@ -472,8 +472,8 @@ struct CollectiveMma<
     Tensor tApA_SFA = make_tensor<bool>(shape(tAsA_SFA(_,_,0)));
     Tensor tBpB_SFB = make_tensor<bool>(shape(tBsB_SFB(_,_,0)));
 
-    auto scale_m_lim = std::min(scales_m, (m_coord + 1) * ScaleMsPerTile);
-    auto scale_n_lim = std::min(scales_n, (n_coord + 1) * ScaleNsPerTile);
+    auto scale_m_lim = cute::min(scales_m, (m_coord + 1) * ScaleMsPerTile);
+    auto scale_n_lim = cute::min(scales_n, (n_coord + 1) * ScaleNsPerTile);
 
     CUTLASS_PRAGMA_UNROLL
     for (int i = 0; i < size(tApA_SFA); ++i)


### PR DESCRIPTION
 Fixes #3051.

 ## Fix

  Replaced `std::min` with `cute::min`, which is tagged `CUTE_HOST_DEVICE constexpr`
  and is safe to call from device code. It accepts plain arithmetic types (both
  arguments here are runtime integers), and is already the standard choice for this
  pattern across the rest of the CUTLASS collective headers.

  The same bug was also present in the `load()` function of the sister file
  `sm120_mma_array_tma_blockwise_scaling.hpp`, so that has been fixed here as well.