### PR TITLE
[CuTeDSL] Disable threading in MLIR contexts (to avoid excessive number of threads)

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/dsl.py
+++ b/python/CuTeDSL/cutlass/base_dsl/dsl.py
@@ -1341,7 +1341,12 @@ class BaseDSL(metaclass=DSLSingletonMeta):
         location=None,
     ):
         """Generate MLIR module and compile iself.T_provider."""
-        with ir.Context(), self.get_ir_location(location):
+        with ir.Context() as ctx, self.get_ir_location(location):
+            # If threading is enabled, each MLIR context will keep alive a thread pool.
+            # When we cache MLIR compilation results, we also cache its context thus accumulating #(compilations) * thread_pool_size threads.
+            # Disable threading to avoid such excessive number of threads.
+            ctx.enable_multithreading(False)
+
             try:
                 # Convert input arguments to MLIR arguments
                 exe_args, func_types, adapted_args = self.generate_mlir_function_types(


### PR DESCRIPTION
MLIR context will keep alive a thread pool if threading is enabled. That means the total number of threads created by cutedsl compiler scales with the number of MLIR compilations (with an observed factor of 6~10; in other words, cute.compile N times, there will be 10*N new idle threads).

Similar issues has also been reported in jax
https://github.com/jax-ml/jax/issues/16272

and fixed by disabling MLIR threading
https://github.com/jax-ml/jax/pull/16284

For example in FA4 [cutedsl testing](https://github.com/Dao-AILab/flash-attention/blob/main/tests/cute/test_flash_attn.py), I have seen thousands of threads with name `llvm-worker-xxx` (and the python would crash with "cannot create new threads" eventually), since the test has 46K configurations to sweep.
With this PR, I no longer see `llvm-worker-x` threads.

Checking `ps -p $(pgrep xxx) -L -o pid,lwp,times,comm | sort -n -k3 -r` suggests that those `llvm-worker-x` threadpool has zero "cumulative  CPU time", thus this diff should have no impact on compiling performance.