### PR TITLE
[CuTeDSL] Support type checking w/ Constexpr and layout/tensor __repr__

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/typing.py
+++ b/python/CuTeDSL/cutlass/base_dsl/typing.py
@@ -26,6 +26,8 @@ from typing import (
     overload,
     runtime_checkable,
     get_origin,
+    Annotated,
+    TYPE_CHECKING,
 )
 from types import FunctionType
 from dataclasses import dataclass
@@ -1800,11 +1802,13 @@ class TensorMeta(DslType):
 # Generic type
 TY = TypeVar("TY")
 
+if TYPE_CHECKING:
+    Constexpr = Annotated[TY, "Constexpr"]
+else:
+    class Constexpr(Generic[TY]):
+        """Value is passed and computed by python interpreter"""
 
-class Constexpr(Generic[TY]):
-    """Value is passed and computed by python interpreter"""
-
-    pass
+        pass
 
 
 class align:

--- a/python/CuTeDSL/cutlass/cute/typing.py
+++ b/python/CuTeDSL/cutlass/cute/typing.py
@@ -110,6 +110,9 @@ class Layout(ir.Value):
 
     def __str__(self) -> str: ...
 
+    def __repr__(self) -> str:
+        return str(self)
+
     def get_hier_coord(self, idx) -> Coord:
         """Return the (hierarchical) ND logical coordinate corresponding to the linear index"""
         ...
@@ -299,6 +302,9 @@ class Tensor(ABC):
 
     @abstractmethod
     def __str__(self) -> str: ...
+
+    def __repr__(self) -> str:
+        return str(self)
 
     @abstractmethod
     def __getitem__(self, idx) -> Union["Tensor", ir.Value, IntTuple]: ...


### PR DESCRIPTION
- Let python type checking treat `cutlass.Constexpr[T]` transparently as type `T`.
- Support python debug-style formatting (e.g., `f"{layout=}"`) for Layout and Tensor classes, similar to what `SymInt` already supported.