### PR TITLE
minor: remove deprecated dynamic_expr in the example

### DIFF
--- a/examples/python/CuTeDSL/notebooks/hello_world.ipynb
+++ b/examples/python/CuTeDSL/notebooks/hello_world.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
     "    # Get the x component of the thread index (y and z components are unused)\n",
     "    tidx, _, _ = cute.arch.thread_idx()\n",
     "    # Only the first thread (thread 0) prints the message\n",
-    "    if cutlass.dynamic_expr(tidx == 0):\n",
+    "    if tidx == 0:\n",
     "        cute.printf(\"Hello world\")"
    ]
   },


### PR DESCRIPTION
removes the deprecated dynamic_expr from the notebook