### PR TITLE
fix: Use is_family_of() for SM90 arch guard in warpgroup MmaOp

### DIFF
--- a/python/CuTeDSL/cutlass/cute/nvgpu/warpgroup/mma.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/warpgroup/mma.py
@@ -131,10 +131,10 @@ class MmaOp(WarpGroupMmaOp):
     def __post_init__(self) -> None:
         # Verify arch
         arch = BaseDSL._get_dsl().get_arch_enum()
-        if not arch == Arch.sm_90a:
+        if not arch.is_family_of(Arch.sm_90a):
             raise OpError(
                 self,
-                f"expects arch to be {Arch.sm_90a}, but got {arch}",
+                f"expects arch to be in the SM90 family, but got {arch}",
                 suggestion="Ensure env CUTE_DSL_ARCH matches your GPU architecture",
             )
         # Verify that the user provided enum values


### PR DESCRIPTION
## Summary

- Replace hardcoded `arch == Arch.sm_90a` with `arch.is_family_of(Arch.sm_90a)` in `warpgroup/mma.py`'s `MmaOp.__post_init__`

## Problem

`MmaOp` in `warpgroup/mma.py` uses `if not arch == Arch.sm_90a` to guard its arch check. While functionally correct today (sm_90a is the only Hopper "a"-suffix arch), this is inconsistent with the `is_family_of()` pattern used elsewhere in CuTe DSL (see #3082 for the SM12x equivalent fix).

## Fix

```python
# Before
if not arch == Arch.sm_90a:

# After
if not arch.is_family_of(Arch.sm_90a):
```

## Validation

```
$ python3 -c "from cutlass.base_dsl.arch import Arch; print(Arch.sm_90a.is_family_of(Arch.sm_90a))"
True

$ python3 -c "from cutlass.base_dsl.arch import Arch; print(Arch.sm_120a.is_family_of(Arch.sm_90a))"
False

$ python3 -c "from cutlass.base_dsl.arch import Arch; print(Arch.sm_100a.is_family_of(Arch.sm_90a))"
False
```

sm_90a accepted, non-Hopper arches correctly rejected.

## Related

- #3082 — Same fix for SM12x arch guard in `warp/mma.py`

Contributed by Second Nature Computing (https://joinsecondnature.com)