### PR TITLE
CuTeDSL] Fix Boolean.__dsl_and__ to emit arith.andi directly for i1 operands

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/typing.py
+++ b/python/CuTeDSL/cutlass/base_dsl/typing.py
@@ -1021,6 +1021,14 @@ class Numeric(metaclass=NumericMeta, is_abstract=True):
             0 and 3 -> 0
             3 and 0 and ... -> 0
         """
+        # Fast path: Boolean & Boolean → single arith.andi i1 instruction.
+        # The general path promotes i1 operands to i32 via arith.extui, performs
+        # arith.select, then converts back to i1 via arith.cmpi ne — generating
+        # 6 unnecessary MLIR operations.  For Boolean inputs the semantics of
+        # `and` are identical to bitwise AND, so delegate directly to __and__.
+        if isinstance(self, Boolean) and isinstance(other, Boolean):
+            return self.__and__(other, loc=loc, ip=ip)
+
         is_true = self.__dsl_bool__(loc=loc, ip=ip)
 
         def and_op(lhs, rhs):


### PR DESCRIPTION
## Summary
https://github.com/NVIDIA/cutlass/issues/3086
In the CuTe DSL, Python’s and operator between two Boolean (i1) values (for example, in a while loop condition) is rewritten by the AST preprocessor as __dsl_and__. Prior to this fix, __dsl_and__ unconditionally promoted both operands from i1 to i32 using arith.extui, performed an arith.select, and then converted the result back to i1 via arith.cmpi ne. This resulted in six unnecessary MLIR operations for what should have been a single arith.andi.

In contrast, the bitwise & operator (__and__) already emitted the correct single-operation IR. Since both operators are semantically equivalent for Boolean inputs, this fix updates __dsl_and__ to generate the same clean IR as &.
  Root Cause

  Boolean.__dsl_and__ calls _binary_op_type_promote with promote_bool=True, which unconditionally
   widens Boolean → Int32 before performing the operation. For two Boolean (i1) inputs, the i32
  round-trip is semantically identical to bitwise AND but generates unnecessary IR.

## Fix
  Add a fast path at the top of __dsl_and__ that delegates to __and__ when both operands are
  Boolean: python/CuTeDSL/cutlass/base_dsl/typing.py
```
  def __dsl_and__(self, other, *, loc=None, ip=None):
      # Fast path: Boolean & Boolean → single arith.andi i1, no i32 round-trip
      if isinstance(self, Boolean) and isinstance(other, Boolean):
          return self.__and__(other, loc=loc, ip=ip)
      ...  # existing code unchanged
```

  Before (6 ops):
  %0 = arith.extui  %a : i1 to i32
  %1 = arith.cmpi ne, %0, %c0_i32 : i32
  %2 = arith.extui  %a : i1 to i32
  %3 = arith.extui  %b : i1 to i32
  %4 = arith.select %1, %3, %2 : i32
  %5 = arith.cmpi ne, %4, %c0_i32 : i32

  After (1 op):
  %0 = arith.andi %a, %b : i1

### Files Changed
<img width="678" height="187" alt="image" src="https://github.com/user-attachments/assets/efb40b50-db71-4afb-a312-6abf37ff8277" />

  
## Testing
`  pytest examples/python/CuTeDSL/hopper/test_dsl_and_fix.py -v`
  # 3 passed

  Tests cover:
  1. and_() and & emit identical IR — single arith.andi, zero extui/select
  2. Both return Boolean with MLIR type i1 (valid for scf.ConditionOp)
  3. Full scf.while loop condition generates identical IR for both operators