### PR TITLE
[bugfix] use acquire to prevent reordering.

### DIFF
--- a/examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py
@@ -1383,7 +1383,7 @@ class PersistentDenseGemmKernel:
                         if lane_id == 0:
                             res = 0
                             while res < self.num_ranks:
-                                res = cute.arch.load(flag.llvm_ptr, cutlass.Int32, sem="relaxed", scope="gpu")
+                                res = cute.arch.load(flag.llvm_ptr, cutlass.Int32, sem="acquire", scope="gpu")
                     cute.arch.barrier(
                         barrier_id=self.reduce_scatter_sync_bar_id,
                         number_of_threads=32 * len(self.reduce_scatter_warp_id),


### PR DESCRIPTION
we need acquire semantics to prevent reordering as https://github.com/NVIDIA/cutlass/issues/3117 said. 