### PR TITLE
fix: Exclude SM12x (desktop Blackwell) from CUDA_PTX_FP4FP6_CVT_ENABLED

### DIFF
--- a/include/cutlass/float_subbyte.h
+++ b/include/cutlass/float_subbyte.h
@@ -44,15 +44,19 @@
 #define CUDA_FP4_ENABLED 1
 #endif
 
+// Note: SM12x (desktop Blackwell: RTX 5090/5080, DGX Spark GB10) is intentionally
+// excluded below. SM12x GPUs have mma.e2m1 tensor cores but lack the
+// cvt.rn.satfinite.e2m1x2.f32 PTX instruction required for native FP4/FP6
+// conversion — this instruction is SM100-family only. Including SM12x here causes
+// CUTLASS to emit invalid PTX, producing NaN during NVFP4 inference. SM12x falls
+// through to the existing software E2M1 conversion path instead.
 #if (defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) || defined(CUTLASS_ARCH_MMA_SM101A_ENABLED) ||\
-     defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) || defined(CUTLASS_ARCH_MMA_SM110A_ENABLED) ||\
-     defined(CUTLASS_ARCH_MMA_SM120A_ENABLED) || defined(CUTLASS_ARCH_MMA_SM121A_ENABLED))
+     defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) || defined(CUTLASS_ARCH_MMA_SM110A_ENABLED))
 #  define CUDA_PTX_FP4FP6_CVT_ENABLED 1
 #endif
 
 #if (defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) || defined(CUTLASS_ARCH_MMA_SM101F_ENABLED) ||\
-     defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) || defined(CUTLASS_ARCH_MMA_SM110F_ENABLED) ||\
-     defined(CUTLASS_ARCH_MMA_SM120F_ENABLED) || defined(CUTLASS_ARCH_MMA_SM121F_ENABLED))
+     defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) || defined(CUTLASS_ARCH_MMA_SM110F_ENABLED))
 #  define CUDA_PTX_FP4FP6_CVT_ENABLED 1
 #endif
 


### PR DESCRIPTION
## Summary

SM12x GPUs (RTX 5090/5080/PRO 6000 = SM120, DGX Spark GB10 = SM121) have `mma.e2m1` tensor cores but lack the `cvt.rn.satfinite.e2m1x2.f32` PTX instruction for native FP4/FP6 conversion. This instruction is SM100-family only.

When `SM120A/F` or `SM121A/F` is included in the `CUDA_PTX_FP4FP6_CVT_ENABLED` guard in `float_subbyte.h`, CUTLASS emits the missing PTX instruction, which produces **NaN during all NVFP4 inference** on SM12x hardware.

### Fix

Remove all SM12x variants (`SM120A`, `SM120F`, `SM121A`, `SM121F`) from the `CUDA_PTX_FP4FP6_CVT_ENABLED` preprocessor guard. SM12x falls through to the existing software E2M1 conversion path, which works correctly.

### Testing

Tested on DGX Spark (SM121, 128 GB unified LPDDR5X) running:
- **Nemotron-3-Super-120B-A12B-NVFP4** — 24 tok/s via vLLM + FlashInfer CUTLASS MoE
- **Qwen3.5-122B-A10B-NVFP4** — 26 tok/s via vLLM + FlashInfer CUTLASS MoE

Without this fix, both models produce NaN output on SM12x.

### Related work

This CUTLASS fix is the root cause. Downstream projects have independent software E2M1 workarounds that complement it:

- **vLLM** [#35947](https://github.com/vllm-project/vllm/pull/35947) by @blake-snc — software E2M1 fallback in vLLM's `nvfp4_utils.cuh` (same root cause, different code path)
- **FlashInfer** — software E2M1 in vendored TRT-LLM `quantization_utils.cuh` (no PR yet)

cc @blake-snc — your vLLM PR #35947 addresses the same hardware limitation in vLLM's copy of the quantization code. Happy to withdraw this if you'd prefer to upstream the CUTLASS-side fix yourself, otherwise I'll work this through the review process.

### Impact

This is a **correctness blocker** for all NVFP4 inference on desktop Blackwell GPUs (RTX 50-series and DGX Spark). Without this fix, no NVFP4 model produces valid output on SM12x.