### PR TITLE
fix: Handle zero-stride TMA basis in fill_tma_gmem_shape_stride

### DIFF
--- a/include/cute/atom/copy_traits_sm90_tma.hpp
+++ b/include/cute/atom/copy_traits_sm90_tma.hpp
@@ -874,8 +874,14 @@ fill_tma_gmem_shape_stride(Tensor<GEngine,GLayout>   const& gtensor,           /
     if constexpr (tma_i_rank == 1) {
       // Trivial contribution of this gmem mode to this tma mode
       auto ej = unwrap(get<i>(tma_gbasis_stride));
-      gmem_prob_shape[i]  = basis_get(ej, gmem_shape);
-      gmem_prob_stride[i] = basis_get(ej, gmem_stride);
+      if constexpr (cute::is_constant<0, decltype(ej)>::value) {
+        // Zero-stride basis: broadcast dimension — no unique contribution to this TMA mode
+        gmem_prob_shape[i]  = 1;
+        gmem_prob_stride[i] = 0;
+      } else {
+        gmem_prob_shape[i]  = basis_get(ej, gmem_shape);
+        gmem_prob_stride[i] = basis_get(ej, gmem_stride);
+      }
     } else {
       // Apply a recurrence to each gmem mode that contributes to this tma mode
       for_each(get<i>(tma_gbasis_stride), [&](auto ej) {


### PR DESCRIPTION
## Summary

When a block-scaled GEMM layout folds scale factors over a broadcast dimension (stride == 0), `fill_tma_gmem_shape_stride` passes the zero-stride basis to `basis_get()`, which produces undefined `gmem_prob_shape` and `gmem_prob_stride` values in the TMA descriptor. This results in invalid TMA descriptors that cause silent data corruption or runtime errors.

**Fix**: detect zero-stride basis via `is_constant<0>` and emit the correct degenerate descriptor (`shape=1, stride=0`) for broadcast dimensions. This is the standard TMA encoding for a dimension that contributes no unique data.

The bug is latent in all block-scaled GEMM configurations but only manifests when `K/SFVectorSize` creates a broadcast fold — e.g. when the scale factor vector size equals or exceeds the tile K extent.

## Changes

1 file, +8/-2 lines in `include/cute/atom/copy_traits_sm90_tma.hpp`

## Test plan

- [ ] Existing block-scaled GEMM unit tests pass (K≥128 tiles unaffected — codepath is only reached with zero-stride basis)
- [ ] `sm120_bs_gemm_nvf4_nvf4_f32_bf16.cu` with `TileShape = Shape<_128,_128,_64>` no longer produces invalid TMA descriptors

Signed-off-by: Rob Tand <robert.tand@icloud.com>