### PR TITLE
Fix elementwise_apply.py

### DIFF
--- a/examples/python/CuTeDSL/ampere/elementwise_apply.py
+++ b/examples/python/CuTeDSL/ampere/elementwise_apply.py
@@ -147,8 +147,13 @@ def elementwise_apply_kernel(
 
     # Load data before use. The compiler will optimize the copy and load
     # operations to convert some memory ld/st into register uses.
-    result = op(*[thrInput.load() for thrInput in thrInputs])
-    thrC.store(result)
+    regThrInputs = [cute.make_fragment_like(thrInput) for thrInput in thrInputs]
+    for i in cutlass.range_constexpr(len(regThrInputs)):
+        cute.basic_copy_if(frgPred, thrInputs[i], regThrInputs[i])
+    result = op(*[regThrInput.load() for regThrInput in regThrInputs])
+    regThrC = cute.make_fragment_like(thrC)
+    regThrC.store(result)
+    cute.basic_copy_if(frgPred, regThrC, thrC)
 
 
 @cute.jit
@@ -254,6 +259,7 @@ def elementwise_apply(
 
     idC = cute.make_identity_tensor(result.shape)
     cC = cute.zipped_divide(idC, tiler=tiler_mn)
+    cC = cute.composition(cC, (None, remap_block))
     print(f"[DSL INFO]   coord tensor = {cC}")
 
     # Launch the kernel asynchronously
@@ -332,7 +338,7 @@ def run_and_verify(
         inputs[1] = torch.where(inputs[1] == 0, torch.tensor(epsilon), inputs[1])
 
     inputs_ = [from_dlpack(t, assumed_align=16) for t in inputs]
-    c_ = from_dlpack(c, assumed_align=16).mark_layout_dynamic()
+    c_ = from_dlpack(c, assumed_align=16)
 
     print("Compiling kernel with cute.compile ...")
     start_time = time.time()


### PR DESCRIPTION
When I studied this example, I encountered several problems.
Both input and output should have the same static layout, but the output layout is marked as dynamic:
https://github.com/NVIDIA/cutlass/blob/baea077e425056e2d1d22d2bf5ed928908878790/examples/python/CuTeDSL/ampere/elementwise_apply.py#L334-L335
`cC` should be permute to `((TileM, TileN), (RestN, RestM))`. This operation was not shown in the example, which may cause some problems when the Shape is not aligned:
https://github.com/NVIDIA/cutlass/blob/baea077e425056e2d1d22d2bf5ed928908878790/examples/python/CuTeDSL/ampere/elementwise_apply.py#L255-L256
Prediction tensor is not actually used, which may cause IMA:
https://github.com/NVIDIA/cutlass/blob/baea077e425056e2d1d22d2bf5ed928908878790/examples/python/CuTeDSL/ampere/elementwise_apply.py#L132-L151