### PR TITLE
Fix incorrect warp arrangement in PitchLinearWarpStripedThreadMap

### DIFF
--- a/examples/113_sm80_pitch_gemm/CMakeLists.txt
+++ b/examples/113_sm80_pitch_gemm/CMakeLists.txt
@@ -1,0 +1,34 @@
+
+# Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cutlass_example_add_executable(
+  113_sm80_double_gemm
+  pitch_linear_warp_striped_thread_map_demo.cu
+)
+  

--- a/examples/113_sm80_pitch_gemm/pitch_linear_warp_striped_thread_map_demo.cu
+++ b/examples/113_sm80_pitch_gemm/pitch_linear_warp_striped_thread_map_demo.cu
@@ -1,0 +1,235 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ **************************************************************************************************/
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <set>
+#include <vector>
+
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/gemm/threadblock/default_mma_core_sm80.h"
+
+#include "helper.h"
+
+using ElementA = double;
+using ElementB = double;
+using ElementC = double;
+using ElementAccumulator = double;
+
+using LayoutA = cutlass::layout::ColumnMajor;
+using LayoutB = cutlass::layout::RowMajor;
+using LayoutC = cutlass::layout::RowMajor;
+
+using OperatorClass = cutlass::arch::OpClassTensorOp;
+using ArchTag = cutlass::arch::Sm80;
+
+using ShapeMMAThreadBlock = cutlass::gemm::GemmShape<128, 128, 8>;
+using ShapeMMAWarp = cutlass::gemm::GemmShape<32, 32, 8>;
+using ShapeMMAOp = cutlass::gemm::GemmShape<8, 8, 4>;
+using SwizzleThreadBlock = cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>;
+using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+    ElementC, 1, ElementAccumulator, ElementAccumulator>;
+constexpr int NumStages = 3;
+
+using CutlassGemm = cutlass::gemm::device::Gemm<
+    ElementA,
+    LayoutA,
+    ElementB,
+    LayoutB,
+    ElementC,
+    LayoutC,
+    ElementAccumulator,
+    OperatorClass,
+    ArchTag,
+    ShapeMMAThreadBlock,
+    ShapeMMAWarp,
+    ShapeMMAOp,
+    EpilogueOp,
+    SwizzleThreadBlock,
+    NumStages>;
+
+using MmaCore = cutlass::gemm::threadblock::DefaultMmaCore<
+    ShapeMMAThreadBlock,
+    ShapeMMAWarp,
+    ShapeMMAOp,
+    ElementA,
+    LayoutA,
+    ElementB,
+    LayoutB,
+    ElementAccumulator,
+    LayoutC,
+    OperatorClass,
+    NumStages,
+    cutlass::arch::OpMultiplyAdd>;
+
+template <typename ThreadMap>
+void print_thread_map_offsets(char const* name) {
+  std::cout << "\n" << name << "\n";
+  std::cout << "Threads                = " << ThreadMap::kThreads << "\n";
+  std::cout << "Shape                  = (" << ThreadMap::Shape::kContiguous << ", "
+            << ThreadMap::Shape::kStrided << ")\n";
+  std::cout << "ShapeInAccesses        = (" << ThreadMap::Detail::ShapeInAccesses::kContiguous << ", "
+            << ThreadMap::Detail::ShapeInAccesses::kStrided << ")\n";
+  std::cout << "WarpThreadArrangement  = (" << ThreadMap::Detail::WarpThreadArrangement::kContiguous
+            << ", " << ThreadMap::Detail::WarpThreadArrangement::kStrided << ")\n";
+  std::cout << "WarpAccessIterations   = ("
+            << ThreadMap::Detail::WarpAccessIterations::kContiguous << ", "
+            << ThreadMap::Detail::WarpAccessIterations::kStrided << ")\n";
+  std::cout << "WarpArrangement        = (" << ThreadMap::Detail::kWarpsContiguous
+            << ", " << ThreadMap::Detail::kWarpsStrided << ")\n";
+  std::cout << "Iterations             = (" << ThreadMap::Iterations::kContiguous
+            << ", " << ThreadMap::Iterations::kStrided << ")\n";
+  std::cout << "Delta                  = (" << ThreadMap::Delta::kContiguous
+            << ", " << ThreadMap::Delta::kStrided << ")\n";
+
+  std::set<int> active_warps;
+  for (int thread_id = 0; thread_id < ThreadMap::kThreads; ++thread_id) {
+    int warp_id = thread_id / 32;
+    auto coord = ThreadMap::initial_offset(thread_id);
+    bool in_bounds = coord.contiguous() < ThreadMap::Shape::kContiguous &&
+                     coord.strided() < ThreadMap::Shape::kStrided;
+    if (in_bounds) {
+      active_warps.insert(warp_id);
+    }
+    std::cout << "thread " << std::setw(3) << thread_id
+              << "  warp " << std::setw(2) << warp_id
+              << "  coord=(" << std::setw(3) << coord.contiguous() << ", "
+              << std::setw(2) << coord.strided() << ")"
+              << "  " << (in_bounds ? "in-bounds" : "out-of-bounds") << "\n";
+  }
+
+  std::cout << "active warps:";
+  for (int warp_id : active_warps) {
+    std::cout << " " << warp_id;
+  }
+  std::cout << "\nactive warp count = " << active_warps.size() << "\n";
+}
+
+int host_index_a(int row, int col, int lda) { return row + col * lda; }
+int host_index_b(int row, int col, int ldb) { return row * ldb + col; }
+int host_index_c(int row, int col, int ldc) { return row * ldc + col; }
+
+int main() {
+  int M = 128;
+  int N = 128;
+  int K = 8;
+  int lda = M;
+  int ldb = N;
+  int ldc = N;
+
+  double alpha = 1.0;
+  double beta = 0.0;
+
+  print_thread_map_offsets<typename MmaCore::IteratorThreadMapA>("IteratorThreadMapA");
+  print_thread_map_offsets<typename MmaCore::IteratorThreadMapB>("IteratorThreadMapB");
+
+  std::vector<ElementA> host_a(M * K);
+  std::vector<ElementB> host_b(K * N);
+  std::vector<ElementC> host_c(M * N);
+  std::vector<ElementC> host_d(M * N);
+  std::vector<double> reference(M * N, 0.0);
+
+  for (int col = 0; col < K; ++col) {
+    for (int row = 0; row < M; ++row) {
+      double value = double((row + col) % 7 - 3);
+      host_a[host_index_a(row, col, lda)] = ElementA(value);
+    }
+  }
+
+  for (int row = 0; row < K; ++row) {
+    for (int col = 0; col < N; ++col) {
+      double value = double((2 * row + col) % 11 - 5);
+      host_b[host_index_b(row, col, ldb)] = ElementB(value);
+    }
+  }
+
+  for (int row = 0; row < M; ++row) {
+    for (int col = 0; col < N; ++col) {
+      host_c[host_index_c(row, col, ldc)] = ElementC(0.0);
+    }
+  }
+
+  ElementA* device_a = nullptr;
+  ElementB* device_b = nullptr;
+  ElementC* device_c = nullptr;
+  ElementC* device_d = nullptr;
+
+  CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&device_a), sizeof(ElementA) * host_a.size()));
+  CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&device_b), sizeof(ElementB) * host_b.size()));
+  CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&device_c), sizeof(ElementC) * host_c.size()));
+  CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&device_d), sizeof(ElementC) * host_d.size()));
+
+  CUDA_CHECK(cudaMemcpy(device_a, host_a.data(), sizeof(ElementA) * host_a.size(),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(device_b, host_b.data(), sizeof(ElementB) * host_b.size(),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(device_c, host_c.data(), sizeof(ElementC) * host_c.size(),
+                        cudaMemcpyHostToDevice));
+
+  CutlassGemm gemm_op;
+  typename CutlassGemm::Arguments args(
+      {M, N, K},
+      {device_a, lda},
+      {device_b, ldb},
+      {device_c, ldc},
+      {device_d, ldc},
+      {alpha, beta});
+
+  cutlass::Status can_implement = gemm_op.can_implement(args);
+  if (can_implement != cutlass::Status::kSuccess) {
+    std::cerr << "can_implement failed: " << cutlassGetStatusString(can_implement) << "\n";
+    return -1;
+  }
+
+  cutlass::Status status = gemm_op(args);
+  if (status != cutlass::Status::kSuccess) {
+    std::cerr << "CUTLASS GEMM launch failed: " << cutlassGetStatusString(status) << "\n";
+    return -1;
+  }
+
+  CUDA_CHECK(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaMemcpy(host_d.data(), device_d, sizeof(ElementC) * host_d.size(),
+                        cudaMemcpyDeviceToHost));
+
+  for (int row = 0; row < M; ++row) {
+    for (int col = 0; col < N; ++col) {
+      double accum = 0.0;
+      for (int k = 0; k < K; ++k) {
+        double a = host_a[host_index_a(row, k, lda)];
+        double b = host_b[host_index_b(k, col, ldb)];
+        accum += a * b;
+      }
+      reference[host_index_c(row, col, ldc)] = accum;
+    }
+  }
+
+  double max_abs_diff = 0.0;
+  for (int row = 0; row < M; ++row) {
+    for (int col = 0; col < N; ++col) {
+      double got = host_d[host_index_c(row, col, ldc)];
+      double ref = reference[host_index_c(row, col, ldc)];
+      max_abs_diff = std::max(max_abs_diff, std::fabs(got - ref));
+    }
+  }
+  bool passed = (max_abs_diff == 0.0);
+
+  std::cout << "Verification: " << (passed ? "passed" : "failed")
+            << ", max_abs_diff = " << max_abs_diff << "\n";
+  std::cout << "D[0:4, 0:8]\n";
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 8; ++col) {
+      std::cout << std::setw(10) << host_d[host_index_c(row, col, ldc)] << " ";
+    }
+    std::cout << "\n";
+  }
+
+  CUDA_CHECK(cudaFree(device_a));
+  CUDA_CHECK(cudaFree(device_b));
+  CUDA_CHECK(cudaFree(device_c));
+  CUDA_CHECK(cudaFree(device_d));
+
+  return 0;
+}

--- a/include/cutlass/transform/pitch_linear_thread_map.h
+++ b/include/cutlass/transform/pitch_linear_thread_map.h
@@ -699,7 +699,7 @@ struct PitchLinearWarpStripedThreadMap {
 
     static int const kWarpsContiguous =
       (kWarpCount > WarpAccessIterations::kStrided ?
-        WarpAccessIterations::kContiguous / kWarpsStrided : 1);
+        (kWarpCount / kWarpsStrided) : 1);
 
     /// Arrangement of warps within a threadblock-scoped tile
     using WarpArrangement = layout::PitchLinearShape<


### PR DESCRIPTION
This PR fixes the computation of `kWarpsContiguous` in `cutlass::transform::PitchLinearWarpStripedThreadMap`.

The current implementation computes:

```c++
static int const kWarpsContiguous =
  (kWarpCount > WarpAccessIterations::kStrided ?
    WarpAccessIterations::kContiguous / kWarpsStrided : 1);
```

This can produce an incorrect warp arrangement when WarpAccessIterations::kStrided < kWarpCount. This change updates the computation to:
```c++
static int const kWarpsContiguous =
  (kWarpCount > WarpAccessIterations::kStrided ?
    (kWarpCount / kWarpsStrided) : 1);
```

so that WarpArrangement reflects the actual number of participating warps after partitioning the strided dimension.

# Problem
PitchLinearWarpStripedThreadMap first partitions the strided dimension and then partitions the contiguous dimension.

When `WarpAccessIterations::kStrided < kWarpCount`, the original formula for kWarpsContiguous derives the contiguous warp count from `WarpAccessIterations::kContiguous / kWarpsStrided`.

In practice this can produce an inconsistent warp arrangement relative to the actual participating warp count, which then leads to incorrect initial_offset() mapping and redundant / out-of-bounds warp placement in the generated thread map.

# Fix
Compute kWarpsContiguous from the remaining participating warps:
```
kWarpsContiguous = kWarpCount / kWarpsStrided
```

This means:
```
// Number of warp rows assigned along the strided dimension.
// In other words, this determines how many layers of warps are distributed
// along the strided direction.
static int const kWarpsStrided =
  (WarpAccessIterations::kStrided >= kWarpCount
    ? kWarpCount : (kWarpCount / WarpAccessIterations::kStrided));

// Number of warp columns assigned along the contiguous dimension
// after the strided warp partition has been determined.
// In other words, once the number of warp rows in the strided direction
// is fixed, this determines how many warp columns are used in the
// contiguous direction.
static int const kWarpsContiguous =
  (kWarpCount > WarpAccessIterations::kStrided ?
    (kWarpCount / kWarpsStrided) : 1);

```



This preserves the intended relationship:

WarpArrangement = (kWarpsContiguous, kWarpsStrided) WarpArrangement::kCount == kWarpCount and makes the warp arrangement consistent with the actual threadblock warp layout.

# Reproducer
I observed this with a SM80 double-precision Tensor Core GEMM path using PitchLinearWarpStripedThreadMap, where:

WarpCount = 16
Shape = (128, 8)
ShapeInAccesses = (128, 8)
WarpThreadArrangement = (16, 2)
WarpAccessIterations = (8, 4)
With the original code, the derived warp arrangement and resulting initial_offset() mapping were inconsistent.

With this change, the thread map becomes consistent and the offsets match the expected warp layout.