### PR TITLE
correct BLayout stride in SM80 m16n8k32 int4 MMA traits

### DIFF
--- a/include/cute/atom/mma_traits_sm80.hpp
+++ b/include/cute/atom/mma_traits_sm80.hpp
@@ -458,7 +458,7 @@ struct MMA_Traits<SM80_16x8x32_S32S4S4S32_TN> {
                          Stride<Stride<_128, _1>, Stride<_16, _8>>>;
   // (T32,V8) -> (M8,N32)
   using BLayout = Layout<Shape <Shape < _4, _8>, Shape <_8>>,
-                         Stride<Stride<_32, _1>, Stride<_8>>>;
+                         Stride<Stride<_64, _1>, Stride<_8>>>;
   using CLayout = SM80_16x8_Row;
 };
 


### PR DESCRIPTION
## Description
This PR fixes a critical memory mapping bug in the `BLayout` definition for `SM80_16x8x32` MMA traits involving 4-bit integer types (S4/U4).

By correcting the stride logic in the base template, this single code change automatically resolves the layout truncation for all 8 derived instruction variants via C++ template inheritance.

**Root Cause & Mathematical Correction:**
For the `m16n8k32` MMA instruction, Matrix B (K=32, N=8) contains 256 elements. A warp of 32 threads maps to these elements, requiring a bijective index generation.
The original implementation in the base trait defined the `BLayout` outer stride as `_32`:
`Stride<Stride<_32, _1>, Stride<_8>>`

The inner mapping `(t1, v)` covers 64 elements (indices 0 to 63). Advancing the outer coordinate `t0` by a stride of only 32 elements caused:
1. Memory overlap in the [32, 63] index range.
2. Truncation of the mapping domain to a maximum index of 159, completely missing the [160, 255] range (the bottom 12 rows of Matrix B).

**The Fix:**
Changed the outer stride for `t0` from `_32` to `_64` to match the capacity of the inner coordinates. 
`Stride<Stride<_64, _1>, Stride<_8>>`
The mathematical mapping becomes `Idx = t0 * 64 + t1 * 1 + v * 8`, perfectly covering the exact [0, 255] domain.

**Template Inheritance Impact:**
Due to the structure of `MMA_Traits`, modifying the base `S32S4S4S32_TN` trait propagates the correct `BLayout` to all child structs. This single line modification fixes the following 8 variants:
* `SM80_16x8x32_S32S4S4S32_TN`
* `SM80_16x8x32_S32S4S4S32_TN_SATURATE`
* `SM80_16x8x32_S32S4U4S32_TN`
* `SM80_16x8x32_S32S4U4S32_TN_SATURATE`
* `SM80_16x8x32_S32U4S4S32_TN`
* `SM80_16x8x32_S32U4S4S32_TN_SATURATE`
* `SM80_16x8x32_S32U4U4S32_TN`
* `SM80_16x8x32_S32U4U4S32_TN_SATURATE`

## Visual Proof
Here is the `print_latex` visualization of the TN layout before and after the fix. 
- **Before:**
<img width="4963" height="5908" alt="SM80_16x8x32_S32S4S4S32_TN" src="https://github.com/user-attachments/assets/1a785685-0abc-476c-b2e9-1f5ff21f8011" />

- **After:**
<img width="4963" height="5908" alt="SM80_16x8x32_S32S4S4S32_TN" src="https://github.com/user-attachments/assets/7b2e013d-519d-483d-aac8-328399eb5e24" />



## Affected Files
- `include/cute/atom/mma_traits_sm80.hpp` (2 variants updated)
