### PR TITLE
[Fix] distributed gemm all reduce and reduce scatter examples

### DIFF
--- a/examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py
@@ -2247,6 +2247,8 @@ def run(
         barrier_flag, barrier_flag_mc, barrier_flag_torch_gpu, barrier_flag_torch_gpu_mc = create_mc_tensor(
             barrier_flag_torch_cpu, cutlass.Int32, 0, is_dynamic_layout=True
         )
+        torch.cuda.synchronize()
+        dist.barrier()
 
         ja = testing.JitArguments(
             a_tensor, 

--- a/examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py
@@ -2408,6 +2408,8 @@ def run(
             is_dynamic_layout=True,
         )
         barrier_flag_torch, barrier_flag_torch_mc, barrier_flag, barrier_flag_mc = create_barrier_flags()
+        torch.cuda.synchronize()
+        dist.barrier()
         add_free_func_and_tensor(nvshmem.core.free_tensor, c_torch_gpu_mc)
         add_free_func_and_tensor(nvshmem.core.free_tensor, c_torch_gpu)
         for i in range(len(c_peer_torch_tensors)):


### PR DESCRIPTION
## Problem
`distributed_gemm_reduce_scatter_blackwell.py` hangs due to `testing.benchmark`, but runs correctly when invoked directly without `testing.benchmark`.  Hang manifests as: only some not all ranks reach final `spin_lock_atom_cas_relaxed_wait`.

Separately, `distributed_gemm_all_reduce_blackwell.py` also hangs and works without call to `testing.benchmark`. Weirdly, also works when `--skip_ref_check` flag is passed.

Reproduced with: `cu12.9`, `cu13.0`, `nvidia-cutlass-dsl 4.4.0-dev` and `4.4.2`.

## Cause
Suspect after `nvshmem.core.get_multicast_tensor()` for new tensors, newly allocated multicast mappings are not guaranteed to be visible to all ranks immediately. When a rank's kernel executes `multimem_red_add1` on the new `barrier_flag_mc` multicast address before all ranks have their multicast mappings fully propagated, the atomic add silently fails to reach some rank. This leaves those ranks' per-tile barrier flags below `num_ranks`, causing their warps to spin forever.

Direct invocation works because cute.compile implicitly creates delay allowing multicast mappings to propagate. `testing.benchmark` fails because it calls `generate_tensors` then launches kernel immediately even though multicast mappings are not ready.

## Fix
Add explicit synchronization inside `generate_tensors()`.