### PR TITLE
clamp max_workers to at least 1 for single-cpu systems

### DIFF
--- a/python/CuTeDSL/cutlass/cutlass_dsl/cutlass.py
+++ b/python/CuTeDSL/cutlass/cutlass_dsl/cutlass.py
@@ -410,7 +410,7 @@ class CutlassBaseDSL(BaseDSL):
         per_file_chunks = {}
         # 16 threads max to avoid context switching overhead
         # To avoid oversubscription, we use half of cpu_count()
-        max_workers = min(16, (os.cpu_count() or 8) // 2)
+        max_workers = max(1, min(16, (os.cpu_count() or 8) // 2))
         with ThreadPoolExecutor(max_workers=max_workers) as ex:
             futures = [ex.submit(_hash_chunk, *job) for job in _iter_jobs()]
             for fut in as_completed(futures):

--- a/python/CuTeDSL/cutlass/cutlass_dsl/test_max_workers.py
+++ b/python/CuTeDSL/cutlass/cutlass_dsl/test_max_workers.py
@@ -1,0 +1,31 @@
+"""Test that max_workers is always >= 1, even on single-cpu systems."""
+
+import os
+from unittest import mock
+
+
+def compute_max_workers():
+    """Mirror the logic in cutlass.py for computing max_workers."""
+    return max(1, min(16, (os.cpu_count() or 8) // 2))
+
+
+def test_single_cpu():
+    with mock.patch("os.cpu_count", return_value=1):
+        assert compute_max_workers() >= 1
+
+
+def test_cpu_count_none():
+    with mock.patch("os.cpu_count", return_value=None):
+        assert compute_max_workers() >= 1
+
+
+def test_normal_cpu_count():
+    with mock.patch("os.cpu_count", return_value=8):
+        assert compute_max_workers() == 4
+
+
+if __name__ == "__main__":
+    test_single_cpu()
+    test_cpu_count_none()
+    test_normal_cpu_count()
+    print("all tests passed")


### PR DESCRIPTION
## summary
- clamp max_workers to at least 1 so ThreadPoolExecutor doesn't crash on single-cpu systems

## test plan
- verified fix prevents ValueError on systems where os.cpu_count() returns 1

fixes #3139