### PR TITLE
[CuTe DSL] Add sm_120a and sm_121a to BlockScaledMmaOp admissible_archs

### DIFF
--- a/python/CuTeDSL/cutlass/cute/nvgpu/tcgen05/mma.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/tcgen05/mma.py
@@ -312,6 +312,8 @@ class BlockScaledMmaOp(Tcgen05MmaOp):
     admissible_archs = [
         Arch.sm_100a,
         Arch.sm_103a,
+        Arch.sm_120a,
+        Arch.sm_121a,
     ]
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
BlockScaledMmaOp was restricting FP4 MMA operations to sm_100a and sm_103a only, blocking RTX 50-series (sm_120) and DGX Spark GB10 (sm_121) users.

CUTLASS 4.2+ added C++ kernel support for these architectures, but the Python DSL admissible_archs list was not updated to match.

Tested on RTX 5080 (SM120, CUDA 12.8): MmaMXF4NVF4Op initializes successfully with CUTE_DSL_ARCH=sm_120a.

Fixes #2800