### PR TITLE
Fix incorrect example paths in CuTeDSL docstrings

### DIFF
--- a/examples/python/CuTeDSL/ampere/call_bypass_dlpack.py
+++ b/examples/python/CuTeDSL/ampere/call_bypass_dlpack.py
@@ -46,7 +46,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/call_bypass_dlpack.py
+    python examples/python/CuTeDSL/ampere/call_bypass_dlpack.py
 
 
 It's worth to mention that by-passing dlpack protocol can resolve the issue that dlpack doesn't handle shape-1

--- a/examples/python/CuTeDSL/ampere/call_from_jit.py
+++ b/examples/python/CuTeDSL/ampere/call_from_jit.py
@@ -44,7 +44,7 @@ Usage:
 
 .. code-block:: bash
 
-    python examples/ampere/call_from_jit.py
+    python examples/python/CuTeDSL/ampere/call_from_jit.py
 
 Default configuration:
 - Batch dimension (L): 16

--- a/examples/python/CuTeDSL/ampere/cooperative_launch.py
+++ b/examples/python/CuTeDSL/ampere/cooperative_launch.py
@@ -55,7 +55,7 @@ and an expected failure when exceeding the grid size limit.
 Usage:
 
 Run directly:
-    $ python cooperative_launch.py
+    $ python examples/python/CuTeDSL/ampere/cooperative_launch.py
 
 This will:
     1. Demonstrate expected failure with too many thread blocks

--- a/examples/python/CuTeDSL/ampere/dynamic_smem_size.py
+++ b/examples/python/CuTeDSL/ampere/dynamic_smem_size.py
@@ -37,7 +37,7 @@ This example demonstrates how to let the DSL automatically set shared memory
   provided that developers are using `SmemAllocator` for all allocations.
 
 Usage:
-    python dynamic_smem_size.py         # Show auto inference
+    python examples/python/CuTeDSL/ampere/dynamic_smem_size.py         # Show auto inference
 """
 
 

--- a/examples/python/CuTeDSL/ampere/elementwise_add.py
+++ b/examples/python/CuTeDSL/ampere/elementwise_add.py
@@ -116,16 +116,16 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/elementwise_add.py --M 3 --N 12
-    python examples/ampere/elementwise_add.py --M 1024 --N 512
-    python examples/ampere/elementwise_add.py --M 1024 --N 1024 --benchmark --warmup_iterations 2 --iterations 1000
+    python examples/python/CuTeDSL/ampere/elementwise_add.py --M 3 --N 12
+    python examples/python/CuTeDSL/ampere/elementwise_add.py --M 1024 --N 512
+    python examples/python/CuTeDSL/ampere/elementwise_add.py --M 1024 --N 1024 --benchmark --warmup_iterations 2 --iterations 1000
 
 To collect performance with NCU profiler:
 
 .. code-block:: bash
 
     # Don't iterate too many times when profiling with ncu
-    ncu python examples/ampere/elementwise_add.py --M 2048 --N 2048 --benchmark --iterations 10 --skip_ref_check
+    ncu python examples/python/CuTeDSL/ampere/elementwise_add.py --M 2048 --N 2048 --benchmark --iterations 10 --skip_ref_check
 """
 
 

--- a/examples/python/CuTeDSL/ampere/elementwise_add_autotune.py
+++ b/examples/python/CuTeDSL/ampere/elementwise_add_autotune.py
@@ -42,9 +42,9 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/elementwise_add_autotune.py --M 3 --N 12
-    python examples/ampere/elementwise_add_autotune.py --M 1024 --N 512
-    python examples/ampere/elementwise_add_autotune.py --M 1024 --N 1024 --benchmark --warmup_iterations 2 --iterations 1000
+    python examples/python/CuTeDSL/ampere/elementwise_add_autotune.py --M 3 --N 12
+    python examples/python/CuTeDSL/ampere/elementwise_add_autotune.py --M 1024 --N 512
+    python examples/python/CuTeDSL/ampere/elementwise_add_autotune.py --M 1024 --N 1024 --benchmark --warmup_iterations 2 --iterations 1000
 
 """
 

--- a/examples/python/CuTeDSL/ampere/elementwise_apply.py
+++ b/examples/python/CuTeDSL/ampere/elementwise_apply.py
@@ -58,16 +58,16 @@ To run this example:
 .. code-block:: bash
 
     # Run with addition operation
-    python examples/ampere/elementwise_apply.py --M 1024 --N 512 --op add
+    python examples/python/CuTeDSL/ampere/elementwise_apply.py --M 1024 --N 512 --op add
 
     # Run with multiplication operation
-    python examples/ampere/elementwise_apply.py --M 1024 --N 512 --op mul
+    python examples/python/CuTeDSL/ampere/elementwise_apply.py --M 1024 --N 512 --op mul
 
     # Run with subtraction operation
-    python examples/ampere/elementwise_apply.py --M 1024 --N 512 --op sub
+    python examples/python/CuTeDSL/ampere/elementwise_apply.py --M 1024 --N 512 --op sub
 
     # Benchmark performance
-    python examples/ampere/elementwise_apply.py --M 2048 --N 2048 --op add --benchmark --warmup_iterations 2 --iterations 10
+    python examples/python/CuTeDSL/ampere/elementwise_apply.py --M 2048 --N 2048 --op add --benchmark --warmup_iterations 2 --iterations 10
 
 The example demonstrates how to express complex CUDA kernels with customizable operations
 while maintaining high performance through efficient memory access patterns.

--- a/examples/python/CuTeDSL/ampere/flash_attention_v2.py
+++ b/examples/python/CuTeDSL/ampere/flash_attention_v2.py
@@ -65,7 +65,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/flash_attention_v2.py                                            \
+    python examples/python/CuTeDSL/ampere/flash_attention_v2.py                                            \
       --dtype Float16 --head_dim 128 --m_block_size 128 --n_block_size 128                  \
       --num_threads 128 --batch_size 1 --seqlen_q 1280 --seqlen_k 1536                      \
       --num_head 16 --softmax_scale 1.0 --is_causal
@@ -79,7 +79,7 @@ To collect the performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/ampere/flash_attention_v2.py                                        \
+    ncu python examples/python/CuTeDSL/ampere/flash_attention_v2.py                                        \
         --dtype Float16 --head_dim 128 --m_block_size 128 --n_block_size 128                \
         --num_threads 128 --batch_size 1 --seqlen_q 1280 --seqlen_k 1536                    \
         --num_head 16 --softmax_scale 1.0 --is_causal --skip_ref_check

--- a/examples/python/CuTeDSL/ampere/hstu_attention.py
+++ b/examples/python/CuTeDSL/ampere/hstu_attention.py
@@ -49,7 +49,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/hstu_attention.py --batch_size 4 --seqlen_q 8192 --seqlen_kv 8192 --num_head 4 --head_dim 128 --m_block_size 128 --n_block_size 64 --is_causal --perf_test
+    python examples/python/CuTeDSL/ampere/hstu_attention.py --batch_size 4 --seqlen_q 8192 --seqlen_kv 8192 --num_head 4 --head_dim 128 --m_block_size 128 --n_block_size 64 --is_causal --perf_test
 
 The above example tests the performance of HSTU attention with batch size 4, sequence length 8192, 4 attention heads, and head dimension 128. The m_block_size is 128, and n_block_size is 64. The causal masking is enabled.
 

--- a/examples/python/CuTeDSL/ampere/inline_ptx.py
+++ b/examples/python/CuTeDSL/ampere/inline_ptx.py
@@ -57,7 +57,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/inline_ptx.py
+    python examples/python/CuTeDSL/ampere/inline_ptx.py
 
 The example will run the vote kernel with inline ptx and nvvm dialect separately.
 The results from inline ptx and nvvm dialect will be verified correspondingly.

--- a/examples/python/CuTeDSL/ampere/sgemm.py
+++ b/examples/python/CuTeDSL/ampere/sgemm.py
@@ -65,7 +65,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/sgemm.py                       \
+    python examples/python/CuTeDSL/ampere/sgemm.py                       \
       --mnk 8192,8192,8192                                \
       --a_major m --b_major n --c_major n
 
@@ -73,7 +73,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/ampere/sgemm.py                   \
+    ncu python examples/python/CuTeDSL/ampere/sgemm.py                   \
       --mnk 8192,8192,8192                                \
       --a_major m --b_major n --c_major n                 \
       --skip_ref_check --iterations 2

--- a/examples/python/CuTeDSL/ampere/smem_allocator.py
+++ b/examples/python/CuTeDSL/ampere/smem_allocator.py
@@ -51,7 +51,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/smem_allocator.py
+    python examples/python/CuTeDSL/ampere/smem_allocator.py
 
 The example will allocate shared memory, perform tensor operations, and verify the results.
 """

--- a/examples/python/CuTeDSL/ampere/tensorop_gemm.py
+++ b/examples/python/CuTeDSL/ampere/tensorop_gemm.py
@@ -62,7 +62,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/ampere/tensorop_gemm.py                                  \
+    python examples/python/CuTeDSL/ampere/tensorop_gemm.py                                  \
       --mnkl 8192,8192,8192,1 --atom_layout_mnk 2,2,1                        \
       --ab_dtype Float16                                                     \
       --c_dtype Float16 --acc_dtype Float32                                  \
@@ -77,7 +77,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/ampere/tensorop_gemm.py                              \
+    ncu python examples/python/CuTeDSL/ampere/tensorop_gemm.py                              \
       --mnkl 8192,8192,8192,1 --atom_layout_mnk 2,2,1                        \
       --ab_dtype Float16                                                     \
       --c_dtype Float16 --acc_dtype Float32                                  \

--- a/examples/python/CuTeDSL/blackwell/blockwise_gemm/blockwise_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/blockwise_gemm/blockwise_gemm.py
@@ -78,7 +78,7 @@ The accumulator in TMEM must then be loaded to registers before writing back to 
 
 .. code-block:: bash
 
-    python examples/blackwell/blockwise_gemm/blockwise_gemm.py                  \
+    python examples/python/CuTeDSL/blackwell/blockwise_gemm/blockwise_gemm.py                  \
       --ab_dtype Float8E4M3FN --c_dtype BFloat16 --acc_dtype Float32            \
       --scale_dtype Float32                                                     \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,2                             \
@@ -88,7 +88,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/blockwise_gemm/blockwise_gemm.py              \
+    ncu python examples/python/CuTeDSL/blackwell/blockwise_gemm/blockwise_gemm.py              \
       --ab_dtype Float8E4M3FN --c_dtype BFloat16 --acc_dtype Float32            \
       --scale_dtype Float32                                                     \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,2                             \

--- a/examples/python/CuTeDSL/blackwell/blockwise_gemm/contiguous_grouped_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/blockwise_gemm/contiguous_grouped_gemm.py
@@ -94,7 +94,7 @@ The accumulator in TMEM must then be loaded to registers before writing back to 
 
 .. code-block:: bash
 
-    python examples/blackwell/blockwise_gemm/contiguous_grouped_gemm.py         \
+    python examples/python/CuTeDSL/blackwell/blockwise_gemm/contiguous_grouped_gemm.py         \
       --ab_dtype Float8E4M3FN --c_dtype BFloat16 --acc_dtype Float32            \
       --scale_dtype Float32                                                     \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,2                             \
@@ -104,7 +104,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/blockwise_gemm/contiguous_grouped_gemm.py     \
+    ncu python examples/python/CuTeDSL/blackwell/blockwise_gemm/contiguous_grouped_gemm.py     \
       --ab_dtype Float8E4M3FN --c_dtype BFloat16 --acc_dtype Float32            \
       --scale_dtype Float32                                                     \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,2                             \

--- a/examples/python/CuTeDSL/blackwell/blockwise_gemm/masked_grouped_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/blockwise_gemm/masked_grouped_gemm.py
@@ -93,7 +93,7 @@ The accumulator in TMEM must then be loaded to registers before writing back to 
 
 .. code-block:: bash
 
-    python examples/blackwell/blockwise_gemm/masked_grouped_gemm.py         \
+    python examples/python/CuTeDSL/blackwell/blockwise_gemm/masked_grouped_gemm.py         \
       --ab_dtype Float8E4M3FN --c_dtype BFloat16 --acc_dtype Float32            \
       --scale_dtype Float32                                                     \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,2                             \
@@ -103,7 +103,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/blockwise_gemm/masked_grouped_gemm.py     \
+    ncu python examples/python/CuTeDSL/blackwell/blockwise_gemm/masked_grouped_gemm.py     \
       --ab_dtype Float8E4M3FN --c_dtype BFloat16 --acc_dtype Float32            \
       --scale_dtype Float32                                                     \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,2                             \

--- a/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py
+++ b/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py
@@ -86,7 +86,7 @@ Input arguments to this example is shown below:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_blockscaled_gemm_persistent.py             \
+    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py             \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
@@ -96,7 +96,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_blockscaled_gemm_persistent.py         \
+    ncu python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py         \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \

--- a/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_amax.py
+++ b/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_amax.py
@@ -85,7 +85,7 @@ Input arguments to this example is shown below:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_blockscaled_gemm_persistent.py            \
+    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py            \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
@@ -95,7 +95,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_blockscaled_gemm_persistent.py        \
+    ncu python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py        \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \

--- a/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_amax.py
+++ b/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_amax.py
@@ -85,7 +85,7 @@ Input arguments to this example is shown below:
 
 .. code-block:: bash
 
-    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py            \
+    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_amax.py       \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
@@ -95,7 +95,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent.py        \
+    ncu python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_amax.py   \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \

--- a/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_prefetch.py
+++ b/examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_prefetch.py
@@ -98,7 +98,7 @@ Input arguments to this example is shown below:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_blockscaled_gemm_persistent_prefetch.py    \
+    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_prefetch.py    \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
@@ -108,7 +108,7 @@ To run with explicit prefetch distance:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_blockscaled_gemm_persistent_prefetch.py    \
+    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_prefetch.py    \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
@@ -119,7 +119,7 @@ To run with prefetch disabled:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_blockscaled_gemm_persistent_prefetch.py    \
+    python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_prefetch.py    \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16        \
       --c_dtype Float16                                                        \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
@@ -130,7 +130,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_blockscaled_gemm_persistent_prefetch.py \
+    ncu python examples/python/CuTeDSL/blackwell/dense_blockscaled_gemm_persistent_prefetch.py \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16         \
       --c_dtype Float16                                                         \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \

--- a/examples/python/CuTeDSL/blackwell/dense_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/dense_gemm.py
@@ -74,7 +74,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm.py                                     \
+    python examples/python/CuTeDSL/blackwell/dense_gemm.py                                     \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -89,7 +89,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm.py                                \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm.py                                \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \

--- a/examples/python/CuTeDSL/blackwell/dense_gemm_alpha_beta_persistent.py
+++ b/examples/python/CuTeDSL/blackwell/dense_gemm_alpha_beta_persistent.py
@@ -79,7 +79,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_alpha_beta_persistent.py                                    \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_alpha_beta_persistent.py                                    \
       --ab_dtype Float16 --c_dtype Float16 --d_dtype Float16 --acc_dtype Float32 --epi_dtype Float32 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                                                  \
       --mnkl 8192,8192,8192,1                                                                        \
@@ -89,7 +89,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_alpha_beta_persistent.py                                \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm_alpha_beta_persistent.py                                \
       --ab_dtype Float16 --c_dtype Float16 --d_dtype Float16 --acc_dtype Float32 --epi_dtype Float32 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                                                  \
       --mnkl 8192,8192,8192,1                                                                        \

--- a/examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py
+++ b/examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py
@@ -75,7 +75,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent.py                          \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py                          \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -85,7 +85,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_persistent.py                     \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py                     \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \

--- a/examples/python/CuTeDSL/blackwell/dense_gemm_persistent_dynamic.py
+++ b/examples/python/CuTeDSL/blackwell/dense_gemm_persistent_dynamic.py
@@ -83,7 +83,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent_dynamic.py                          \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_persistent_dynamic.py                          \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -93,7 +93,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_persistent_dynamic.py                     \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm_persistent_dynamic.py                     \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \

--- a/examples/python/CuTeDSL/blackwell/dense_gemm_persistent_prefetch.py
+++ b/examples/python/CuTeDSL/blackwell/dense_gemm_persistent_prefetch.py
@@ -87,7 +87,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent_prefetch.py                 \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_persistent_prefetch.py                 \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -97,7 +97,7 @@ To run with explicit prefetch distance:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent_prefetch.py                 \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_persistent_prefetch.py                 \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -108,7 +108,7 @@ To run with prefetch disabled:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent_prefetch.py                 \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_persistent_prefetch.py                 \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -119,7 +119,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_persistent_prefetch.py             \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm_persistent_prefetch.py             \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \

--- a/examples/python/CuTeDSL/blackwell/dense_gemm_software_pipeline.py
+++ b/examples/python/CuTeDSL/blackwell/dense_gemm_software_pipeline.py
@@ -72,7 +72,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_software_pipeline.py                   \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_software_pipeline.py                   \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -87,7 +87,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_software_pipeline.py              \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm_software_pipeline.py              \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \

--- a/examples/python/CuTeDSL/blackwell/fmha.py
+++ b/examples/python/CuTeDSL/blackwell/fmha.py
@@ -70,7 +70,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/fmha.py                                     \
+    python examples/python/CuTeDSL/blackwell/fmha.py                                     \
       --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
       --mma_tiler_mn 128,128                                              \
       --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
@@ -84,7 +84,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/fmha.py                                 \
+    ncu python examples/python/CuTeDSL/blackwell/fmha.py                                 \
       --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
       --mma_tiler_mn 128,128                                              \
       --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \

--- a/examples/python/CuTeDSL/blackwell/fmha_bwd.py
+++ b/examples/python/CuTeDSL/blackwell/fmha_bwd.py
@@ -74,7 +74,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/fmha_bwd.py \\
+    python examples/python/CuTeDSL/blackwell/fmha_bwd.py \\
         --s_q_max 1024 --s_k_max 1024 \\
         --h_q 8 --h_k 8 --d 128 --b 1 \\
         --element_dtype float16 --acc_dtype float32 \\

--- a/examples/python/CuTeDSL/blackwell/grouped_blockscaled_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/grouped_blockscaled_gemm.py
@@ -62,7 +62,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/grouped_blockscaled_gemm.py                                     \
+    python examples/python/CuTeDSL/blackwell/grouped_blockscaled_gemm.py                                     \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16                       \
       --c_dtype Float16                                                                       \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,1                                           \
@@ -77,7 +77,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/grouped_blockscaled_gemm.py                                 \
+    ncu python examples/python/CuTeDSL/blackwell/grouped_blockscaled_gemm.py                                 \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16                       \
       --c_dtype Float16                                                                       \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,1                                           \

--- a/examples/python/CuTeDSL/blackwell/grouped_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/grouped_gemm.py
@@ -59,7 +59,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/grouped_gemm.py                                                 \
+    python examples/python/CuTeDSL/blackwell/grouped_gemm.py                                                 \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                \
       --mma_tiler_mn 128,64 --cluster_shape_mn 1,1                                            \
       --problem_sizes_mnkl "(8192,1280,32,1),(16,384,1536,1),(640,1280,16,1),(640,160,16,1)"  \
@@ -73,7 +73,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/grouped_gemm.py                                             \
+    ncu python examples/python/CuTeDSL/blackwell/grouped_gemm.py                                             \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                \
       --mma_tiler_mn 128,64 --cluster_shape_mn 1,1                                            \
       --problem_sizes_mnkl "(8192,1280,32,1),(16,384,1536,1),(640,1280,16,1),(640,160,16,1)"  \

--- a/examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py
@@ -102,7 +102,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/grouped_mixed_input_gemm.py      \
+    python examples/python/CuTeDSL/blackwell/grouped_mixed_input_gemm.py      \
       --a_dtype Int8 --b_dtype BFloat16                        \
       --scale_granularity_m 0 --scale_granularity_k 0          \
       --c_dtype BFloat16 --acc_dtype Float32                   \
@@ -118,7 +118,7 @@ Here is an example of running convert-scale mode:
 
 .. code-block:: bash
 
-    python examples/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py    \
+    python examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py    \
       --a_dtype Int4 --b_dtype BFloat16                                       \
       --scale_granularity_m 1 --scale_granularity_k 256                       \
       --c_dtype BFloat16 --acc_dtype Float32                                  \
@@ -138,7 +138,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py    \
+    ncu python examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py    \
       --a_dtype Int8 --b_dtype BFloat16                                           \
       --scale_granularity_m 0 --scale_granularity_k 0                             \
       --c_dtype BFloat16 --acc_dtype Float32                                      \

--- a/examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py
@@ -102,7 +102,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/python/CuTeDSL/blackwell/grouped_mixed_input_gemm.py      \
+    python examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm.py      \
       --a_dtype Int8 --b_dtype BFloat16                        \
       --scale_granularity_m 0 --scale_granularity_k 0          \
       --c_dtype BFloat16 --acc_dtype Float32                   \

--- a/examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm_acc_scale.py
+++ b/examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm_acc_scale.py
@@ -78,7 +78,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/mixed_input_gemm/grouped_mixed_input_gemm_acc_scale.py      \
+    python examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm_acc_scale.py      \
       --a_dtype Int4 --b_dtype BFloat16                                  \
       --scale_granularity_m 1 --scale_granularity_k 256                  \
       --c_dtype BFloat16 --acc_dtype Float32                             \
@@ -89,7 +89,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/mixed_input_gemm/grouped_mixed_input_gemm_acc_scale.py  \
+    ncu python examples/python/CuTeDSL/blackwell/mixed_input_gemm/grouped_mixed_input_gemm_acc_scale.py  \
       --a_dtype Int4 --b_dtype BFloat16                                  \
       --scale_granularity_m 1 --scale_granularity_k 256                  \
       --c_dtype BFloat16 --acc_dtype Float32                             \

--- a/examples/python/CuTeDSL/blackwell/mixed_input_gemm/mixed_input_gemm.py
+++ b/examples/python/CuTeDSL/blackwell/mixed_input_gemm/mixed_input_gemm.py
@@ -85,7 +85,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/mixed_input_gemm/mixed_input_gemm.py    \
+    python examples/python/CuTeDSL/blackwell/mixed_input_gemm/mixed_input_gemm.py    \
       --a_dtype Int8 --b_dtype BFloat16                               \
       --scale_granularity_m 0 --scale_granularity_k 0                 \
       --c_dtype BFloat16 --acc_dtype Float32                          \
@@ -101,7 +101,7 @@ Here is an example of running convert-scale mode:
 
 .. code-block:: bash
 
-    python examples/blackwell/mixed_input_gemm/mixed_input_gemm.py    \
+    python examples/python/CuTeDSL/blackwell/mixed_input_gemm/mixed_input_gemm.py    \
       --a_dtype Int4 --b_dtype BFloat16                               \
       --scale_granularity_m 1 --scale_granularity_k 256               \
       --c_dtype BFloat16 --acc_dtype Float32                          \
@@ -122,7 +122,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/mixed_input_gemm/mixed_input_gemm.py    \
+    ncu python examples/python/CuTeDSL/blackwell/mixed_input_gemm/mixed_input_gemm.py    \
       --a_dtype Int8 --b_dtype BFloat16                                   \
       --scale_granularity_m 0 --scale_granularity_k 0                     \
       --c_dtype BFloat16 --acc_dtype Float32                              \

--- a/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp16.py
+++ b/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp16.py
@@ -82,7 +82,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/mla_fp16.py                                \
+    python examples/python/CuTeDSL/blackwell/mla_fp16.py                                \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float16 --out_dtype Float16                             \
@@ -106,7 +106,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/mla_fp16.py                            \
+    ncu python examples/python/CuTeDSL/blackwell/mla_fp16.py                            \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float16 --out_dtype Float16                             \

--- a/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp16.py
+++ b/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp16.py
@@ -82,7 +82,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/python/CuTeDSL/blackwell/mla_fp16.py                                \
+    python examples/python/CuTeDSL/blackwell/mla/mla_decode_fp16.py                      \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float16 --out_dtype Float16                             \
@@ -106,7 +106,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/python/CuTeDSL/blackwell/mla_fp16.py                            \
+    ncu python examples/python/CuTeDSL/blackwell/mla/mla_decode_fp16.py                  \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float16 --out_dtype Float16                             \

--- a/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp8.py
+++ b/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp8.py
@@ -82,7 +82,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/mla_fp8.py                                 \
+    python examples/python/CuTeDSL/blackwell/mla_fp8.py                                 \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float8E4M3FN --out_dtype Float8E4M3FN                   \
@@ -106,7 +106,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/mla_fp8.py                             \
+    ncu python examples/python/CuTeDSL/blackwell/mla_fp8.py                             \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float8E4M3FN --out_dtype Float8E4M3FN                   \

--- a/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp8.py
+++ b/examples/python/CuTeDSL/blackwell/mla/mla_decode_fp8.py
@@ -82,7 +82,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/python/CuTeDSL/blackwell/mla_fp8.py                                 \
+    python examples/python/CuTeDSL/blackwell/mla/mla_decode_fp8.py                       \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float8E4M3FN --out_dtype Float8E4M3FN                   \
@@ -106,7 +106,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/python/CuTeDSL/blackwell/mla_fp8.py                             \
+    ncu python examples/python/CuTeDSL/blackwell/mla/mla_decode_fp8.py                   \
       --batch_size 4 --latent_dim 512 --rope_dim 64                      \
       --num_heads 128 --seq_len_q 1 --seq_len_k 1024                     \
       --in_dtype Float8E4M3FN --out_dtype Float8E4M3FN                   \

--- a/examples/python/CuTeDSL/blackwell/programmatic_dependent_launch.py
+++ b/examples/python/CuTeDSL/blackwell/programmatic_dependent_launch.py
@@ -102,15 +102,15 @@ We could run this example with and without PDL:
 
 .. code-block:: bash
 
-    python examples/blackwell/programmatic_dependent_launch.py --benchmark
-    python examples/blackwell/programmatic_dependent_launch.py --benchmark --use_pdl
+    python examples/python/CuTeDSL/blackwell/programmatic_dependent_launch.py --benchmark
+    python examples/python/CuTeDSL/blackwell/programmatic_dependent_launch.py --benchmark --use_pdl
 
 From the benchmark results, you can see some speedups for the PDL version in most cases, benefiting from
 the overlapping execution of consecutive kernels. Moreover, you can use nsys to observe the overlapping execution.
 
 .. code-block:: bash
 
-    nsys profile python examples/blackwell/programmatic_dependent_launch.py --benchmark --use_pdl
+    nsys profile python examples/python/CuTeDSL/blackwell/programmatic_dependent_launch.py --benchmark --use_pdl
 
 Note, PDL feature is supported on Hopper and later GPUs.
 

--- a/examples/python/CuTeDSL/blackwell/sm103_dense_blockscaled_gemm_persistent.py
+++ b/examples/python/CuTeDSL/blackwell/sm103_dense_blockscaled_gemm_persistent.py
@@ -87,7 +87,7 @@ Input arguments to this example is shown below:
 
 .. code-block:: bash
 
-    python examples/blackwell/sm103_dense_blockscaled_gemm_persistent.py     \
+    python examples/python/CuTeDSL/blackwell/sm103_dense_blockscaled_gemm_persistent.py     \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16      \
       --c_dtype Float16                                                       \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,4                          \
@@ -97,7 +97,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/sm103_dense_blockscaled_gemm_persistent.py \
+    ncu python examples/python/CuTeDSL/blackwell/sm103_dense_blockscaled_gemm_persistent.py \
       --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16      \
       --c_dtype Float16                                                       \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,4                          \

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_0.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_0.py
@@ -33,7 +33,7 @@ with optimizations for challenges that may arise with other problem sizes.
 To run this example:
 .. code-block:: bash
 
-    python examples/blackwell/tutorial_gemm/fp16_gemm_0.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_0.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_1.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_1.py
@@ -56,7 +56,7 @@ These two factors should be considered for latency/memory throughput bound cases
 To run this example:
 .. code-block:: bash
 
-    python examples/blackwell/tutorial_gemm/fp16_gemm_1.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_1.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_2.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_2.py
@@ -61,7 +61,7 @@ so less ALU instructions are issued in MMA warp, and mma instructions can be iss
 
 To run this example:
 .. code-block:: bash
-    python examples/blackwell/tutorial_gemm/fp16_gemm_2.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_2.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_3.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_3.py
@@ -41,7 +41,7 @@ in which case the performance gains become even more significant.
 
 To run this example:
 .. code-block:: bash
-    python examples/blackwell/tutorial_gemm/fp16_gemm_3.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_3.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_3_1.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_3_1.py
@@ -32,7 +32,7 @@ The dynamic scheduler is more flexible than the static scheduler, as it can hand
 
 To run this example:
 .. code-block:: bash
-    python examples/blackwell/tutorial_gemm/fp16_gemm_3_1.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_3_1.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_4.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_4.py
@@ -55,7 +55,7 @@ CuTe DSL Blackwell SM100 kernels. Users can specify preferred and fallback clust
 
 To run this example:
 .. code-block:: bash
-    python examples/blackwell/tutorial_gemm/fp16_gemm_4.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_4.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_5.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_5.py
@@ -44,7 +44,7 @@ Key differences from fp16_gemm_3_1.py:
 
 To run this example:
 .. code-block:: bash
-    python examples/blackwell/tutorial_gemm/fp16_gemm_5.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_5.py  \
       --mnk 8192,8192,8192
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_6.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_6.py
@@ -57,7 +57,7 @@ For --mnk 256,8192,128, the speedup pdl v.s. no pdl can be up to 1.16x.
 
 To run this example:
 .. code-block:: bash
-    python examples/blackwell/tutorial_gemm/fp16_gemm_6.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/fp16_gemm_6.py  \
       --mnk 256,8192,128
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/nvfp4_gemm_0.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/nvfp4_gemm_0.py
@@ -71,7 +71,7 @@ challenges that may arise with other problem sizes.
 To run this example:
 .. code-block:: bash
 
-    python examples/blackwell/tutorial_gemm/nvfp4_gemm_0.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/nvfp4_gemm_0.py  \
       --mnkl 8192,8192,8192,1 --do_benchmark
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/blackwell/tutorial_gemm/nvfp4_gemm_1.py
+++ b/examples/python/CuTeDSL/blackwell/tutorial_gemm/nvfp4_gemm_1.py
@@ -101,7 +101,7 @@ Both could be tried when the workload is latency-bound or limited by memory thro
 To run this example:
 .. code-block:: bash
 
-    python examples/blackwell/tutorial_gemm/nvfp4_gemm_1.py  \
+    python examples/python/CuTeDSL/blackwell/tutorial_gemm/nvfp4_gemm_1.py  \
       --mnkl 8192,8192,8192,1 --do_benchmark
 
 Constraints for this example:

--- a/examples/python/CuTeDSL/cute/export/export_to_c.py
+++ b/examples/python/CuTeDSL/cute/export/export_to_c.py
@@ -45,7 +45,7 @@ To run this example:
 .. code-block:: bash
 
     # export the compiled function to a object file and a C header file
-    python cutlass_ir/compiler/python/examples/cute/export/export_to_c.py
+    python examples/python/CuTeDSL/cute/export/export_to_c.py
 """
 
 

--- a/examples/python/CuTeDSL/cute/export/load_in_python.py
+++ b/examples/python/CuTeDSL/cute/export/load_in_python.py
@@ -42,9 +42,9 @@ To run this example:
 .. code-block:: bash
 
     # prerequesites: export the compiled functions to object files and compile them into a shared library
-    python examples/cute/export/export_to_c.py
+    python examples/python/CuTeDSL/cute/export/export_to_c.py
     # load the module from a object file or a shared library
-    python examples/cute/export/load_in_python.py
+    python examples/python/CuTeDSL/cute/export/load_in_python.py
 """
 
 

--- a/examples/python/CuTeDSL/cute/export/run_with_dynamic_loading.cpp
+++ b/examples/python/CuTeDSL/cute/export/run_with_dynamic_loading.cpp
@@ -18,8 +18,8 @@
  * .. code-block:: bash
  *
  *    # prerequesites: export the compiled functions to object files and compile
- * them into a shared library python examples/cute/export/export_to_c.py # run
- * the example bash ./examples/cute/export/run_with_dynamic_loading.sh
+ * them into a shared library python examples/python/CuTeDSL/cute/export/export_to_c.py # run
+ * the example bash ./examples/python/CuTeDSL/cute/export/run_with_dynamic_loading.sh
  */
 
 #include "CuteDSLRuntime.h"

--- a/examples/python/CuTeDSL/cute/export/run_with_static_linking.cpp
+++ b/examples/python/CuTeDSL/cute/export/run_with_static_linking.cpp
@@ -18,8 +18,8 @@
  * .. code-block:: bash
  *
  *    # prerequesites: export the compiled functions to object files and compile
- * them into a shared library python examples/cute/export/export_to_c.py # run
- * the example bash ./examples/cute/export/run_with_static_linking.sh
+ * them into a shared library python examples/python/CuTeDSL/cute/export/export_to_c.py # run
+ * the example bash ./examples/python/CuTeDSL/cute/export/run_with_static_linking.sh
  */
 
 #include "add_one_example.h"

--- a/examples/python/CuTeDSL/cute/torch_fake_tensor.py
+++ b/examples/python/CuTeDSL/cute/torch_fake_tensor.py
@@ -54,7 +54,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/cute/torch_fake_tensor.py
+    python examples/python/CuTeDSL/cute/torch_fake_tensor.py
 """
 
 

--- a/examples/python/CuTeDSL/cute/tvm_ffi/aot_export.py
+++ b/examples/python/CuTeDSL/cute/tvm_ffi/aot_export.py
@@ -37,13 +37,13 @@ To run this example:
 
 .. code-block:: bash
 
-    python cutlass_ir/compiler/python/examples/cute/tvm_ffi/aot_export.py
+    python examples/python/CuTeDSL/cute/tvm_ffi/aot_export.py
     # run example to use in torch
-    python cutlass_ir/compiler/python/examples/cute/tvm_ffi/aot_use_in_torch.py
+    python examples/python/CuTeDSL/cute/tvm_ffi/aot_use_in_torch.py
     # run example to use in jax
-    python cutlass_ir/compiler/python/examples/cute/tvm_ffi/aot_use_in_jax.py
+    python examples/python/CuTeDSL/cute/tvm_ffi/aot_use_in_jax.py
     # run example to use in c++ bundle
-    bash cutlass_ir/compiler/python/examples/cute/tvm_ffi/aot_use_in_cpp_bundle.sh
+    bash examples/python/CuTeDSL/cute/tvm_ffi/aot_use_in_cpp_bundle.sh
 """
 
 from pathlib import Path

--- a/examples/python/CuTeDSL/cute/tvm_ffi/aot_use_in_cpp_bundle.cpp
+++ b/examples/python/CuTeDSL/cute/tvm_ffi/aot_use_in_cpp_bundle.cpp
@@ -15,7 +15,7 @@
 // This example shows how to interface with an AOT compiled function in a C++
 // bundle. to build and run the example, run the following command in project
 // root bash
-// cutlass_ir/compiler/python/examples/cute/tvm_ffi/aot_use_in_cpp_bundle.sh
+// examples/python/CuTeDSL/cute/tvm_ffi/aot_use_in_cpp_bundle.sh
 
 #include <cuda_runtime.h>
 #include <tvm/ffi/container/tensor.h>

--- a/examples/python/CuTeDSL/cute/tvm_ffi/error_reporting.py
+++ b/examples/python/CuTeDSL/cute/tvm_ffi/error_reporting.py
@@ -36,7 +36,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python cutlass_ir/compiler/python/examples/cute/tvm_ffi/error_reporting.py
+    python examples/python/CuTeDSL/cute/tvm_ffi/error_reporting.py
 """
 
 import torch

--- a/examples/python/CuTeDSL/cute/tvm_ffi/jit_and_use_in_jax.py
+++ b/examples/python/CuTeDSL/cute/tvm_ffi/jit_and_use_in_jax.py
@@ -39,7 +39,7 @@ To run this example:
     pip install jax-tvm-ffi
     pip install jax[cuda13]
 
-    python cutlass_ir/compiler/python/examples/cute/tvm_ffi/jit_and_use_in_jax.py
+    python examples/python/CuTeDSL/cute/tvm_ffi/jit_and_use_in_jax.py
 """
 
 import jax

--- a/examples/python/CuTeDSL/cute/tvm_ffi/jit_and_use_in_torch.py
+++ b/examples/python/CuTeDSL/cute/tvm_ffi/jit_and_use_in_torch.py
@@ -36,7 +36,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python cutlass_ir/compiler/python/examples/cute/tvm_ffi/jit_and_use_in_torch.py
+    python examples/python/CuTeDSL/cute/tvm_ffi/jit_and_use_in_torch.py
 """
 
 import cutlass.cute as cute

--- a/examples/python/CuTeDSL/distributed/all_reduce_one_shot_lamport.py
+++ b/examples/python/CuTeDSL/distributed/all_reduce_one_shot_lamport.py
@@ -87,8 +87,8 @@ The .SYS memory scope and .VOLATILE memory order are used to ensure that the dat
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8  examples/distributed/all_reduce_one_shot_lamport.py --M 8192 --N 8192
-    torchrun --nproc-per-node 8  examples/distributed/all_reduce_one_shot_lamport.py \
+    torchrun --nproc-per-node 8  examples/python/CuTeDSL/distributed/all_reduce_one_shot_lamport.py --M 8192 --N 8192
+    torchrun --nproc-per-node 8  examples/python/CuTeDSL/distributed/all_reduce_one_shot_lamport.py \
         --M 8192 --N 8192 --benchmark --warmup_iterations 2 --iterations 10
 """
 

--- a/examples/python/CuTeDSL/distributed/all_reduce_simple.py
+++ b/examples/python/CuTeDSL/distributed/all_reduce_simple.py
@@ -88,8 +88,8 @@ To run this example:
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8  examples/distributed/all_reduce_simple.py --M 1024 --N 512
-    torchrun --nproc-per-node 8  examples/distributed/all_reduce_simple.py \
+    torchrun --nproc-per-node 8  examples/python/CuTeDSL/distributed/all_reduce_simple.py --M 1024 --N 512
+    torchrun --nproc-per-node 8  examples/python/CuTeDSL/distributed/all_reduce_simple.py \
         --M 1024 --N 1024 --benchmark --warmup_iterations 2 --iterations 100
 """
 

--- a/examples/python/CuTeDSL/distributed/all_reduce_tma.py
+++ b/examples/python/CuTeDSL/distributed/all_reduce_tma.py
@@ -62,8 +62,8 @@ To run this example:
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8 examples/distributed/all_reduce_tma.py --shape 1024,1024
-    torchrun --nproc-per-node 8 examples/distributed/all_reduce_tma.py --shape 4,6,8,10,12
+    torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/all_reduce_tma.py --shape 1024,1024
+    torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/all_reduce_tma.py --shape 4,6,8,10,12
 """
 
 import cutlass

--- a/examples/python/CuTeDSL/distributed/all_reduce_two_shot_multimem.py
+++ b/examples/python/CuTeDSL/distributed/all_reduce_two_shot_multimem.py
@@ -86,8 +86,8 @@ To run this example:
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8  examples/distributed/all_reduce_two_shot_multimem.py --M 1024 --N 512
-    torchrun --nproc-per-node 8  examples/distributed/all_reduce_two_shot_multimem.py \
+    torchrun --nproc-per-node 8  examples/python/CuTeDSL/distributed/all_reduce_two_shot_multimem.py --M 1024 --N 512
+    torchrun --nproc-per-node 8  examples/python/CuTeDSL/distributed/all_reduce_two_shot_multimem.py \
         --M 1024 --N 1024 --benchmark --warmup_iterations 2 --iterations 100
 """
 

--- a/examples/python/CuTeDSL/distributed/distributed_all_gather_gemm_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_all_gather_gemm_blackwell.py
@@ -105,7 +105,7 @@ Input arguments to this example is same as dense_gemm_persistent.py.
 
 .. code-block:: bash
 
-    torchrun --nproc_per_node=8 examples/distributed/distributed_all_gather_gemm_blackwell.py                          \
+    torchrun --nproc_per_node=8 examples/python/CuTeDSL/distributed/distributed_all_gather_gemm_blackwell.py                          \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -115,7 +115,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu torchrun --nproc_per_node=8 examples/distributed/distributed_all_gather_gemm_blackwell.py                     \
+    ncu torchrun --nproc_per_node=8 examples/python/CuTeDSL/distributed/distributed_all_gather_gemm_blackwell.py                     \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \

--- a/examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py
@@ -112,7 +112,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8 examples/distributed/distributed_dense_gemm_persistent_all_reduce.py  \
+    torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_dense_gemm_persistent_all_reduce.py  \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                        \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                   \
       --mnkl 1024,1000,1024,1 --warmup_iterations 3 --iterations 10                                   \
@@ -123,7 +123,7 @@ To collect performance with NSYS profiler:
 .. code-block:: bash
 
     nsys profile  --gpu-metrics-devices=cuda-visible                                                    \
-      torchrun --nproc-per-node 8 examples/distributed/distributed_dense_gemm_persistent_all_reduce.py  \
+      torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_dense_gemm_persistent_all_reduce.py  \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                          \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                     \
       --mnkl 8192,8192,8192,1                                                                           \

--- a/examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py
@@ -112,10 +112,10 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_dense_gemm_persistent_all_reduce.py  \
-      --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                        \
-      --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                   \
-      --mnkl 1024,1000,1024,1 --warmup_iterations 3 --iterations 10                                   \
+    torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py  \
+      --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                              \
+      --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                         \
+      --mnkl 1024,1000,1024,1 --warmup_iterations 3 --iterations 10                                         \
       --use_tma_store --use_2cta_instrs --all_reduce LDMCxSTMC
 
 To collect performance with NSYS profiler:
@@ -123,7 +123,7 @@ To collect performance with NSYS profiler:
 .. code-block:: bash
 
     nsys profile  --gpu-metrics-devices=cuda-visible                                                    \
-      torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_dense_gemm_persistent_all_reduce.py  \
+      torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_gemm_all_reduce_blackwell.py  \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                          \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                     \
       --mnkl 8192,8192,8192,1                                                                           \

--- a/examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py
+++ b/examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py
@@ -113,7 +113,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    torchrun --nproc-per-node 8 examples/distributed/distributed_gemm_reduce_scatter_blackwell.py  \
+    torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py  \
       --ab_dtype Float8E4M3FN --c_dtype Float16 --acc_dtype Float32                                                 \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                            \
       --mnkl 16384,4080,4096,1 --warmup_iterations 3 --iterations 10                                                                               \
@@ -124,7 +124,7 @@ To collect performance with NSYS profiler:
 .. code-block:: bash
 
     nsys profile  --gpu-metrics-devices=cuda-visible                                                             \
-      torchrun --nproc-per-node 8 examples/distributed/distributed_gemm_reduce_scatter_blackwell.py  \
+      torchrun --nproc-per-node 8 examples/python/CuTeDSL/distributed/distributed_gemm_reduce_scatter_blackwell.py  \
       --ab_dtype Float8E5M2 --c_dtype Float16 --acc_dtype Float32                                                   \
       --mma_tiler_mn 256,256 --cluster_shape_mn 2,1                                                              \
       --mnkl 16384,4096,4096,1                                                                                    \

--- a/examples/python/CuTeDSL/experimental/blackwell/dense_gemm_cute_pipeline.py
+++ b/examples/python/CuTeDSL/experimental/blackwell/dense_gemm_cute_pipeline.py
@@ -79,7 +79,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent.py                          \
+    python examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py                          \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -89,7 +89,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_persistent.py                     \
+    ncu python examples/python/CuTeDSL/blackwell/dense_gemm_persistent.py                     \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \

--- a/examples/python/CuTeDSL/hopper/dense_gemm.py
+++ b/examples/python/CuTeDSL/hopper/dense_gemm.py
@@ -67,7 +67,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/hopper/dense_gemm.py                                   \
+    python examples/python/CuTeDSL/hopper/dense_gemm.py                                   \
       --mnkl 8192,8192,8192,1 --tile_shape_mn 128,256                      \
       --cluster_shape_mn 1,1 --a_dtype Float16 --b_dtype Float16           \
       --c_dtype Float16 --acc_dtype Float32                                \
@@ -82,7 +82,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/hopper/dense_gemm.py                               \
+    ncu python examples/python/CuTeDSL/hopper/dense_gemm.py                               \
       --mnkl 8192,8192,8192,1 --tile_shape_mn 128,256                      \
       --cluster_shape_mn 1,1 --a_dtype Float16 --b_dtype Float16           \
       --c_dtype Float16 --acc_dtype Float32                                \

--- a/examples/python/CuTeDSL/hopper/dense_gemm_persistent.py
+++ b/examples/python/CuTeDSL/hopper/dense_gemm_persistent.py
@@ -68,7 +68,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/hopper/dense_gemm_persistent.py                        \
+    python examples/python/CuTeDSL/hopper/dense_gemm_persistent.py                        \
       --mnkl 8192,8192,8192,1 --tile_shape_mn 128,256                      \
       --cluster_shape_mn 1,1 --a_dtype Float16 --b_dtype Float16           \
       --c_dtype Float16 --acc_dtype Float32                                \
@@ -83,7 +83,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/hopper/dense_gemm.py                               \
+    ncu python examples/python/CuTeDSL/hopper/dense_gemm.py                               \
       --mnkl 8192,8192,8192,1 --tile_shape_mn 128,256                      \
       --cluster_shape_mn 1,1 --a_dtype Float16 --b_dtype Float16           \
       --c_dtype Float16 --acc_dtype Float32                                \

--- a/examples/python/CuTeDSL/hopper/fmha.py
+++ b/examples/python/CuTeDSL/hopper/fmha.py
@@ -46,7 +46,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/hopper/fmha.py                                        \
+    python examples/python/CuTeDSL/hopper/fmha.py                                        \
       --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
       --mma_tiler_mn 64,128                                              \
       --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
@@ -60,7 +60,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/hopper/fmha.py                                    \
+    ncu python examples/python/CuTeDSL/hopper/fmha.py                                    \
       --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
       --mma_tiler_mn 64,128                                              \
       --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \

--- a/examples/python/CuTeDSL/hopper/grouped_gemm.py
+++ b/examples/python/CuTeDSL/hopper/grouped_gemm.py
@@ -92,7 +92,7 @@ To run:
 
 .. code-block:: bash
 
-    python hopper/grouped_gemm.py                                             \\
+    python examples/python/CuTeDSL/hopper/grouped_gemm.py                     \\
       --num_groups 4                                                           \\
       --problem_sizes_mnkl "(8192,1280,32,1),(16,384,1536,1),(640,1280,16,1),(640,160,16,1)" \\
       --tile_shape_mn 128,256 --cluster_shape_mn 1,1                          \\

--- a/examples/python/CuTeDSL/jax/cutlass_call_basic.py
+++ b/examples/python/CuTeDSL/jax/cutlass_call_basic.py
@@ -51,7 +51,7 @@ To run this example:
 .. code-block:: bash
 
     # Run with addition operation
-    python examples/jax/cutlass_call_basic.py
+    python examples/python/CuTeDSL/jax/cutlass_call_basic.py
 """
 
 

--- a/examples/python/CuTeDSL/jax/cutlass_call_export.py
+++ b/examples/python/CuTeDSL/jax/cutlass_call_export.py
@@ -55,13 +55,13 @@ To run this example:
 .. code-block:: bash
 
     # Run with defaults
-    python examples/jax/cutlass_call_export.py
+    python examples/python/CuTeDSL/jax/cutlass_call_export.py
 
     # Run with shape (1024, 512)
-    python examples/jax/cutlass_call_export.py --M 1024 --N 512
+    python examples/python/CuTeDSL/jax/cutlass_call_export.py --M 1024 --N 512
 
     # Export with symbolic shapes.
-    python examples/jax/cutlass_call_export.py --export_symbolic
+    python examples/python/CuTeDSL/jax/cutlass_call_export.py --export_symbolic
 """
 
 

--- a/examples/python/CuTeDSL/jax/cutlass_call_sharding.py
+++ b/examples/python/CuTeDSL/jax/cutlass_call_sharding.py
@@ -50,7 +50,7 @@ To run this example:
 .. code-block:: bash
 
     # Run with addition operation
-    python examples/jax/cutlass_call_sharding.py
+    python examples/python/CuTeDSL/jax/cutlass_call_sharding.py
 """
 
 

--- a/examples/python/CuTeDSL/jax/elementwise_apply_example.py
+++ b/examples/python/CuTeDSL/jax/elementwise_apply_example.py
@@ -51,10 +51,10 @@ To run this example:
     python examples/python/CuTeDSL/jax/elementwise_apply_example.py --M 1024 --N 512 --op add
 
     # Run with multiplication operation
-    python examples/python/CuTeDSL/ampere/elementwise_apply_example.py --M 1024 --N 512 --op mul
+    python examples/python/CuTeDSL/jax/elementwise_apply_example.py --M 1024 --N 512 --op mul
 
     # Run with subtraction operation
-    python examples/python/CuTeDSL/ampere/elementwise_apply_example.py --M 1024 --N 512 --op sub
+    python examples/python/CuTeDSL/jax/elementwise_apply_example.py --M 1024 --N 512 --op sub
 """
 
 

--- a/examples/python/CuTeDSL/jax/elementwise_apply_example.py
+++ b/examples/python/CuTeDSL/jax/elementwise_apply_example.py
@@ -39,7 +39,7 @@ import cutlass.cute as cute
 """
 An Elementwise Apply Example using CuTe DSL with cutlass.jax.cutlass_call
 
-This example is similar to examples/ampere/elementwise_apply.py but demonstrates
+This example is similar to examples/python/CuTeDSL/ampere/elementwise_apply.py but demonstrates
 how to run the code in a jax specific way using the cutlass_call primitive. It assumes
 familiarity with basic CuTe DSL concepts as well as the cutlass_call primitive.
 
@@ -48,13 +48,13 @@ To run this example:
 .. code-block:: bash
 
     # Run with addition operation
-    python examples/jax/elementwise_apply_example.py --M 1024 --N 512 --op add
+    python examples/python/CuTeDSL/jax/elementwise_apply_example.py --M 1024 --N 512 --op add
 
     # Run with multiplication operation
-    python examples/ampere/elementwise_apply_example.py --M 1024 --N 512 --op mul
+    python examples/python/CuTeDSL/ampere/elementwise_apply_example.py --M 1024 --N 512 --op mul
 
     # Run with subtraction operation
-    python examples/ampere/elementwise_apply_example.py --M 1024 --N 512 --op sub
+    python examples/python/CuTeDSL/ampere/elementwise_apply_example.py --M 1024 --N 512 --op sub
 """
 
 


### PR DESCRIPTION
This PR fix incorrect file paths in CuTeDSL example docstrings that prevent users from copy-pasting run commands directly. This is a superset of #2741, covering all affected files.

Three categories of issues fixed:

1. **Missing `python/CuTeDSL/` prefix** (69 files) e.g. `examples/ampere/sgemm.py` → `examples/python/CuTeDSL/ampere/sgemm.py`
2. **Stale `cutlass_ir/compiler/python/` prefix** (6 files under `cute/tvm_ffi/`) e.g. `cutlass_ir/compiler/python/examples/cute/tvm_ffi/aot_export.py` → `examples/python/CuTeDSL/cute/tvm_ffi/aot_export.py`
3. **Wrong filenames / missing subdirectories** (9 files) e.g. `blackwell/mla_fp16.py` → `blackwell/mla/mla_decode_fp16.py`