### PR TITLE
[CuTeDSL] Fix dense_gemm_ptr_array example for workspace API change

### DIFF
--- a/examples/python/CuTeDSL/experimental/blackwell/dense_gemm_ptr_array.py
+++ b/examples/python/CuTeDSL/experimental/blackwell/dense_gemm_ptr_array.py
@@ -37,6 +37,8 @@ from cutlass.base_dsl.typing import Numeric
 from cutlass import cute as cute
 from cutlass import utils
 from cutlass import torch as cutlass_torch
+from cutlass.cute.experimental.host_runtime import QueryDeviceWorkspaceFunc
+from cutlass.cute.runtime import from_dlpack
 import cutlass.utils.blackwell_helpers as sm100_utils
 
 import cutlass.cute.testing as testing
@@ -674,7 +676,15 @@ def run(
     compiled_dense_gemm = cute_ext.compile(
         ptr_array_dense_gemm, a_tensor, b_tensor, d_tensor
     )
-    compiled_dense_gemm(a_tensor, b_tensor, d_tensor)
+
+    query = compiled_dense_gemm.get_aux_func(
+        QueryDeviceWorkspaceFunc, kernel=ptr_array_dense_gemm.kernel
+    )
+    req = query(a_tensor, b_tensor, d_tensor)
+    workspace = torch.empty(req.size_in_bytes, dtype=torch.uint8, device="cuda")
+    workspace_cute = from_dlpack(workspace)
+
+    compiled_dense_gemm(a_tensor, b_tensor, d_tensor, workspace_cute)
 
     if not skip_ref_check:
         for batch_idx in range(l):
@@ -704,7 +714,10 @@ def run(
         ) = create_tensors_for_ptr_array(
             l, m, n, k, a_major, b_major, d_major, ab_dtype, d_dtype
         )
-        args = testing.JitArguments(a_tensor, b_tensor, d_tensor)
+        ws = torch.empty(req.size_in_bytes, dtype=torch.uint8, device="cuda")
+        ws_cute = from_dlpack(ws)
+
+        args = testing.JitArguments(a_tensor, b_tensor, d_tensor, ws_cute)
         args.add_to_scope([A_cutes, B_cutes, D_cutes])
         return args
 


### PR DESCRIPTION
  Update the dense_gemm_ptr_array example under examples/python/CuTeDSL/experimental/blackwell/ to allocate and pass a
  device workspace, matching the new cute_ext.compile() contract.

  Recent versions of cutlass-dsl return compiled kernels that expect a trailing device-workspace pointer argument. The
  example was still calling compiled_dense_gemm(a_tensor, b_tensor, d_tensor) with the old 3-arg signature, producing:

  DSLRuntimeError: Wrong number of extra workspace arguments
      expected: 1
      got: 0

  Changes

  - Import QueryDeviceWorkspaceFunc and from_dlpack.
  - Query workspace size via compiled_dense_gemm.get_aux_func(QueryDeviceWorkspaceFunc, kernel=...), allocate a
  torch.empty(req.size_in_bytes, dtype=torch.uint8, device="cuda"), wrap with from_dlpack, and pass as the 4th
  positional argument to both the one-shot call and the benchmark JitArguments.

  No behavioral change beyond supplying the now-required workspace buffer.