### PR TITLE
CuTe DSL: work around SM120 rank-2 TMA cute.copy hang

### DIFF
--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py
@@ -29,6 +29,9 @@ __all__ = [
     # helpers.py
     #
     "make_tiled_tma_atom",
+    "make_sm120_tma_load_2d_atom",
+    "get_tma_desc_addr",
+    "sm120_tma_load_2d",
     "tma_partition",
     "create_tma_multicast_mask",
     "prefetch_descriptor",

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
@@ -225,6 +225,12 @@ def make_sm120_tma_load_2d_atom(
     The returned descriptor pointer is intended for ``sm120_tma_load_2d``.
     Generic ``cute.copy`` executable TMA lowering remains a separate backend
     path and is not used by this helper.
+
+    ``smem_layout_`` may be a composed swizzled layout. When it is swizzled,
+    the destination pointer passed to ``sm120_tma_load_2d`` must carry the same
+    swizzle, for example from ``MemRange.get_tensor(layout.outer,
+    swizzle=layout.inner)`` or ``SmemAllocator.allocate_tensor(...,
+    layout.outer, swizzle=layout.inner)``.
     """
     _check_sm120_tma_load_supported()
 

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
@@ -11,8 +11,11 @@
 
 from typing import Optional, Tuple, Type, Union
 
-from cutlass.cutlass_dsl import dsl_user_op
+from cutlass import const_expr
+from cutlass.base_dsl.arch import Arch
+from cutlass.cutlass_dsl import BaseDSL, dsl_user_op
 
+import cutlass._mlir.dialects.cute as _cute_ir
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
 from cutlass._mlir.dialects import llvm
 
@@ -24,10 +27,12 @@ from ...typing import (
     Tiler,
     Pointer,
     Int16,
+    Int32,
+    Int64,
     Numeric,
     NumericMeta,
 )
-from ... import core, atom
+from ... import core, atom, arch as cute_arch
 from .copy import (
     CopyBulkTensorTileG2SOp,
     CopyBulkTensorTileG2SMulticastOp,
@@ -45,6 +50,242 @@ TMAOp = Union[
     CopyBulkTensorTileS2GOp,
     CopyReduceBulkTensorTileS2GOp,
 ]
+
+
+def _check_sm120_tma_load_supported() -> None:
+    BaseDSL._get_dsl().check_arch(lambda arch: arch >= Arch.sm_120)
+
+
+@dsl_user_op
+def get_tma_desc_addr(
+    tma_atom: atom.CopyAtom,
+    *,
+    loc=None,
+    ip=None,
+) -> Pointer:
+    """
+    Return the address of the tiled TMA descriptor associated with a TMA copy atom.
+
+    This is primarily useful for low-level TMA issue paths that need to bypass
+    the generic executable ``cute.copy`` lowering while still using the CuTe DSL
+    TMA descriptor builder.
+    """
+    exec_tma_atom = _cute_nvgpu_ir.atom_make_exec_tma(
+        tma_atom._trait.value,
+        loc=loc,
+        ip=ip,
+    )
+    tma_desc_ptr_ty = _cute_ir.PtrType.get(
+        _cute_nvgpu_ir.TmaDescriptorTiledType.get(),
+        _cute_ir.AddressSpace.generic,
+        128,
+    )
+    return _cute_nvgpu_ir.get_tma_desc_addr(
+        tma_desc_ptr_ty,
+        exec_tma_atom,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _sm120_issue_tma_load_2d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    tile_mode: bool = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """
+    Unsafe raw SM120 CTA-local rank-2 TMA issuer.
+
+    Callers must ensure only one elected thread issues this instruction for a
+    given mbarrier transaction count. Prefer ``sm120_tma_load_2d`` unless the
+    caller has already performed election.
+    """
+    _check_sm120_tma_load_supported()
+
+    dst_smem_i32 = dst_smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    tma_desc_i64 = tma_desc_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    coord0_i32 = Int32(coord0).ir_value(loc=loc, ip=ip)
+    coord1_i32 = Int32(coord1).ir_value(loc=loc, ip=ip)
+    tma_bar_i32 = tma_bar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+
+    tile_qualifier = ".tile" if const_expr(tile_mode) else ""
+    if cache_policy is None:
+        llvm.inline_asm(
+            None,
+            [dst_smem_i32, tma_desc_i64, coord0_i32, coord1_i32, tma_bar_i32],
+            f"cp.async.bulk.tensor.2d.shared::cta.global{tile_qualifier}.mbarrier::complete_tx::bytes [$0], [$1, {{$2, $3}}], [$4];",
+            "r,l,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        cache_policy_i64 = Int64(cache_policy).ir_value(loc=loc, ip=ip)
+        llvm.inline_asm(
+            None,
+            [
+                dst_smem_i32,
+                tma_desc_i64,
+                coord0_i32,
+                coord1_i32,
+                tma_bar_i32,
+                cache_policy_i64,
+            ],
+            f"cp.async.bulk.tensor.2d.shared::cta.global{tile_qualifier}.mbarrier::complete_tx::bytes.L2::cache_hint [$0], [$1, {{$2, $3}}], [$4], $5;",
+            "r,l,r,r,r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+
+
+@dsl_user_op
+def sm120_tma_load_2d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """
+    Issue a rank-2 SM120 CTA-local TMA load from one elected thread.
+
+    The descriptor must use direct TMA basis: coordinate 0 is the contiguous
+    dimension and coordinate 1 is the next slower dimension. For FlashAttention
+    ``(seq, d)`` memory this means constructing the descriptor as ``(d, seq)``
+    and passing coordinates ``{d_coord, seq_coord}``.
+
+    ``already_elected=True`` is only for callers that have already wrapped this
+    call in ``cute.arch.elect_one()`` or an equivalent single-issuer guard.
+    """
+    if const_expr(already_elected):
+        _sm120_issue_tma_load_2d(
+            dst_smem_ptr,
+            tma_desc_ptr,
+            tma_bar_ptr,
+            coord0,
+            coord1,
+            cache_policy=cache_policy,
+            tile_mode=tile_mode,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        with cute_arch.elect_one(loc=loc, ip=ip):
+            _sm120_issue_tma_load_2d(
+                dst_smem_ptr,
+                tma_desc_ptr,
+                tma_bar_ptr,
+                coord0,
+                coord1,
+                cache_policy=cache_policy,
+                tile_mode=tile_mode,
+                loc=loc,
+                ip=ip,
+            )
+
+
+@dsl_user_op
+def make_sm120_tma_load_2d_atom(
+    gmem_tensor: Tensor,
+    smem_layout_: Union[Layout, ComposedLayout],
+    cta_tiler: Tiler,
+    *,
+    internal_type: Optional[Type[Numeric]] = None,
+    loc=None,
+    ip=None,
+) -> Tuple[atom.CopyAtom, Tensor, Pointer]:
+    """
+    Build a narrow SM120 direct-basis rank-2 TMA load atom.
+
+    This helper deliberately does not canonicalize or logicalize tensor modes.
+    The caller must present the tensor in the descriptor basis consumed by TMA:
+    mode 0 is the contiguous physical mode and mode 1 is the next slower mode.
+    For FlashAttention ``(seq, d)`` GMEM, create a separate direct-basis view
+    shaped ``(d, seq)`` with stride ``(1, D)`` before calling this helper.
+
+    The returned descriptor pointer is intended for ``sm120_tma_load_2d``.
+    Generic ``cute.copy`` executable TMA lowering remains a separate backend
+    path and is not used by this helper.
+    """
+    _check_sm120_tma_load_supported()
+
+    if core.rank(gmem_tensor) != 2:
+        raise ValueError(
+            f"SM120 direct TMA load helper expects a rank-2 GMEM tensor, "
+            f"but got rank {core.rank(gmem_tensor)}"
+        )
+
+    if not isinstance(gmem_tensor.element_type, NumericMeta):
+        raise TypeError(
+            "SM120 direct TMA load helper expects a numeric GMEM element type"
+        )
+    if gmem_tensor.element_type.width < 8:
+        raise ValueError(
+            "SM120 direct TMA load helper requires element width >= 8 bits"
+        )
+
+    stride0 = core.get(gmem_tensor.stride, mode=[0], loc=loc, ip=ip)
+    if not core.is_static(stride0) or stride0 != 1:
+        raise ValueError(
+            "SM120 direct TMA load helper expects GMEM mode 0 to be statically "
+            f"contiguous with stride 1, but got stride {stride0}"
+        )
+
+    tile_shape = core.shape(cta_tiler, loc=loc, ip=ip)
+    if core.rank(tile_shape) != 2:
+        raise ValueError(
+            f"SM120 direct TMA load helper expects a rank-2 CTA tiler, "
+            f"but got rank {core.rank(tile_shape)}"
+        )
+
+    tile0 = core.get(tile_shape, mode=[0], loc=loc, ip=ip)
+    if not core.is_static(tile0):
+        raise ValueError(
+            "SM120 direct TMA load helper requires a static mode-0 tile extent"
+        )
+    if tile0 > 256:
+        raise ValueError(
+            f"SM120 direct TMA load helper requires tile extent 0 <= 256, "
+            f"but got {tile0}"
+        )
+
+    element_bytes = gmem_tensor.element_type.width // 8
+    if (tile0 * element_bytes) % 16 != 0:
+        raise ValueError(
+            "SM120 direct TMA load helper requires mode-0 tile bytes to be a "
+            f"multiple of 16, but got {tile0 * element_bytes}"
+        )
+
+    tma_atom, tma_tensor = make_tiled_tma_atom(
+        CopyBulkTensorTileG2SOp(),
+        gmem_tensor,
+        smem_layout_,
+        cta_tiler,
+        num_multicast=1,
+        internal_type=internal_type,
+        loc=loc,
+        ip=ip,
+    )
+    return tma_atom, tma_tensor, get_tma_desc_addr(tma_atom, loc=loc, ip=ip)
 
 
 @dsl_user_op

--- a/test/examples/CuTeDSL/sm_120a/sm120_direct_tma_smoke.py
+++ b/test/examples/CuTeDSL/sm_120a/sm120_direct_tma_smoke.py
@@ -36,13 +36,23 @@ def _direct_basis_tma_kernel(
     seq_tile: cutlass.Constexpr,
     use_cache_hint: cutlass.Constexpr,
     tile_mode: cutlass.Constexpr,
+    use_swizzle: cutlass.Constexpr,
 ):
     smem = cutlass.utils.SmemAllocator()
-    s_tile = smem.allocate_tensor(
-        dtype,
-        cute.make_layout((d_tile, seq_tile), stride=(1, d_tile)),
-        byte_alignment=128,
-    )
+    smem_layout = cute.make_layout((d_tile, seq_tile), stride=(1, d_tile))
+    if cutlass.const_expr(use_swizzle):
+        s_tile = smem.allocate_tensor(
+            dtype,
+            smem_layout,
+            byte_alignment=128,
+            swizzle=cute.make_swizzle(3, 4, 3),
+        )
+    else:
+        s_tile = smem.allocate_tensor(
+            dtype,
+            smem_layout,
+            byte_alignment=128,
+        )
     s_mbar = smem.allocate_tensor(
         cutlass.Int64, cute.make_layout(2), byte_alignment=8
     )
@@ -121,14 +131,22 @@ def _launch_direct_basis_tma(
     seq_tile: cutlass.Constexpr,
     use_cache_hint: cutlass.Constexpr,
     tile_mode: cutlass.Constexpr,
+    use_swizzle: cutlass.Constexpr,
 ):
     gmem_tma = cute.make_tensor(
         src.iterator,
         cute.make_layout((d_total, seq_total), stride=(1, d_total)),
     )
+    smem_layout = cute.make_layout((d_tile, seq_tile), stride=(1, d_tile))
+    if cutlass.const_expr(use_swizzle):
+        smem_layout = cute.make_composed_layout(
+            cute.make_swizzle(3, 4, 3),
+            0,
+            smem_layout,
+        )
     tma_atom, _, _ = cpasync.make_sm120_tma_load_2d_atom(
         gmem_tma,
-        cute.make_layout((d_tile, seq_tile), stride=(1, d_tile)),
+        smem_layout,
         (d_tile, seq_tile),
     )
     smem_bytes = d_tile * seq_tile * dtype.width // 8 + 16
@@ -142,6 +160,7 @@ def _launch_direct_basis_tma(
         seq_tile,
         use_cache_hint,
         tile_mode,
+        use_swizzle,
     ).launch(grid=[1, 1, 1], block=[64, 1, 1], smem=smem_bytes)
 
 
@@ -165,6 +184,7 @@ def _run_direct_basis_case(
     coord1=32,
     use_cache_hint=False,
     tile_mode=False,
+    use_swizzle=False,
 ):
     src = _make_source(seq_total, d_total, torch_dtype)
     dst = torch.zeros(64, device="cuda", dtype=torch.float32)
@@ -183,6 +203,7 @@ def _run_direct_basis_case(
         seq_tile,
         use_cache_hint,
         tile_mode,
+        use_swizzle,
     )
     cute.compile(_launch_direct_basis_tma, *args)(*runtime_args)
     torch.cuda.synchronize()
@@ -208,6 +229,21 @@ def _run_fa_like_kv_direct_basis_smoke(torch_dtype, dtype, d_tile, seq_tile):
         seq_tile=seq_tile,
         coord0=0,
         coord1=32,
+    )
+
+
+def _run_fa_like_kv_swizzled_smoke(torch_dtype, dtype, d_tile, seq_tile):
+    _require_sm120()
+    _run_direct_basis_case(
+        dtype,
+        torch_dtype,
+        d_total=128,
+        seq_total=192,
+        d_tile=d_tile,
+        seq_tile=seq_tile,
+        coord0=16,
+        coord1=32,
+        use_swizzle=True,
     )
 
 
@@ -240,4 +276,9 @@ if __name__ == "__main__":
                 _run_fa_like_kv_direct_basis_smoke(
                     torch_dtype, dtype, d_tile, seq_tile
                 )
+    for torch_dtype, dtype in [
+        (torch.float16, cutlass.Float16),
+        (torch.bfloat16, cutlass.BFloat16),
+    ]:
+        _run_fa_like_kv_swizzled_smoke(torch_dtype, dtype, 64, 64)
     print("SM120 direct TMA smoke passed")

--- a/test/examples/CuTeDSL/sm_120a/sm120_direct_tma_smoke.py
+++ b/test/examples/CuTeDSL/sm_120a/sm120_direct_tma_smoke.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import torch
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline
+import cutlass.utils
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+from cutlass.pipeline.sm90 import PipelineTmaAsync, make_pipeline_state
+
+
+_CACHE_HINT_EVICT_NORMAL = 0x1000000000000000
+
+
+def _require_sm120():
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if torch.cuda.get_device_capability()[0] < 12:
+        raise RuntimeError("SM120 TMA smoke requires compute capability 12.x")
+    os.environ.setdefault("CUTE_DSL_ARCH", "sm_120")
+
+
+@cute.kernel
+def _direct_basis_tma_kernel(
+    tma_atom: cute.CopyAtom,
+    dst: cute.Tensor,
+    coord0: cutlass.Int32,
+    coord1: cutlass.Int32,
+    dtype: cutlass.Constexpr,
+    d_tile: cutlass.Constexpr,
+    seq_tile: cutlass.Constexpr,
+    use_cache_hint: cutlass.Constexpr,
+    tile_mode: cutlass.Constexpr,
+):
+    smem = cutlass.utils.SmemAllocator()
+    s_tile = smem.allocate_tensor(
+        dtype,
+        cute.make_layout((d_tile, seq_tile), stride=(1, d_tile)),
+        byte_alignment=128,
+    )
+    s_mbar = smem.allocate_tensor(
+        cutlass.Int64, cute.make_layout(2), byte_alignment=8
+    )
+
+    tidx, _, _ = cute.arch.thread_idx()
+    warp = tidx // 32
+    lane = tidx % 32
+    desc_ptr = cpasync.get_tma_desc_addr(tma_atom)
+    pipe = PipelineTmaAsync.create(
+        barrier_storage=s_mbar.iterator,
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        consumer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        tx_count=d_tile * seq_tile * dtype.width // 8,
+        defer_sync=False,
+    )
+
+    if warp == 0:
+        with cute.arch.elect_one():
+            cpasync.fence_tma_desc_acquire(desc_ptr)
+
+        producer_state = make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Producer, 1
+        )
+        pipe.producer_acquire(producer_state)
+        if use_cache_hint:
+            cpasync.sm120_tma_load_2d(
+                s_tile.iterator,
+                desc_ptr,
+                pipe.producer_get_barrier(producer_state),
+                coord0,
+                coord1,
+                cache_policy=cutlass.Int64(_CACHE_HINT_EVICT_NORMAL),
+                tile_mode=tile_mode,
+            )
+        else:
+            cpasync.sm120_tma_load_2d(
+                s_tile.iterator,
+                desc_ptr,
+                pipe.producer_get_barrier(producer_state),
+                coord0,
+                coord1,
+                tile_mode=tile_mode,
+            )
+        producer_state.advance()
+        pipe.producer_tail(producer_state)
+
+    if warp == 1:
+        consumer_state = make_pipeline_state(
+            cutlass.pipeline.PipelineUserType.Consumer, 1
+        )
+        pipe.consumer_wait(consumer_state)
+        cute.arch.fence_view_async_shared()
+        pipe.consumer_release(consumer_state)
+
+        # Row in direct TMA basis: d varies at fixed seq.
+        dst[lane] = s_tile[lane, 0].to(cutlass.Float32)
+        # Column in direct TMA basis: seq varies at fixed d.
+        dst[32 + lane] = s_tile[0, lane].to(cutlass.Float32)
+
+
+@cute.jit
+def _launch_direct_basis_tma(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    coord0: cutlass.Int32,
+    coord1: cutlass.Int32,
+    dtype: cutlass.Constexpr,
+    d_total: cutlass.Constexpr,
+    seq_total: cutlass.Constexpr,
+    d_tile: cutlass.Constexpr,
+    seq_tile: cutlass.Constexpr,
+    use_cache_hint: cutlass.Constexpr,
+    tile_mode: cutlass.Constexpr,
+):
+    gmem_tma = cute.make_tensor(
+        src.iterator,
+        cute.make_layout((d_total, seq_total), stride=(1, d_total)),
+    )
+    tma_atom, _, _ = cpasync.make_sm120_tma_load_2d_atom(
+        gmem_tma,
+        cute.make_layout((d_tile, seq_tile), stride=(1, d_tile)),
+        (d_tile, seq_tile),
+    )
+    smem_bytes = d_tile * seq_tile * dtype.width // 8 + 16
+    _direct_basis_tma_kernel(
+        tma_atom,
+        dst,
+        coord0,
+        coord1,
+        dtype,
+        d_tile,
+        seq_tile,
+        use_cache_hint,
+        tile_mode,
+    ).launch(grid=[1, 1, 1], block=[64, 1, 1], smem=smem_bytes)
+
+
+def _make_source(seq_total: int, d_total: int, torch_dtype: torch.dtype):
+    values = torch.empty((seq_total, d_total), device="cuda", dtype=torch.float32)
+    seq = torch.arange(seq_total, device="cuda", dtype=torch.float32)[:, None]
+    d = torch.arange(d_total, device="cuda", dtype=torch.float32)[None, :]
+    values.copy_(seq * 100.0 + d)
+    return values.to(torch_dtype)
+
+
+def _run_direct_basis_case(
+    dtype,
+    torch_dtype,
+    *,
+    d_total=128,
+    seq_total=128,
+    d_tile=64,
+    seq_tile=64,
+    coord0=16,
+    coord1=32,
+    use_cache_hint=False,
+    tile_mode=False,
+):
+    src = _make_source(seq_total, d_total, torch_dtype)
+    dst = torch.zeros(64, device="cuda", dtype=torch.float32)
+    runtime_args = (
+        from_dlpack(src),
+        from_dlpack(dst),
+        cutlass.Int32(coord0),
+        cutlass.Int32(coord1),
+    )
+    args = (
+        *runtime_args,
+        dtype,
+        d_total,
+        seq_total,
+        d_tile,
+        seq_tile,
+        use_cache_hint,
+        tile_mode,
+    )
+    cute.compile(_launch_direct_basis_tma, *args)(*runtime_args)
+    torch.cuda.synchronize()
+
+    src_f32 = src.to(torch.float32)
+    expected_row = src_f32[coord1, coord0 : coord0 + 32]
+    expected_col = src_f32[coord1 : coord1 + 32, coord0]
+    assert torch.equal(dst[:32], expected_row)
+    assert torch.equal(dst[32:], expected_col)
+
+
+def _run_fa_like_kv_direct_basis_smoke(torch_dtype, dtype, d_tile, seq_tile):
+    _require_sm120()
+    # This is the K/V contract FlashAttention needs: GMEM is logically
+    # (seq, d), but TMA sees direct basis (d, seq). Consumers can create a
+    # logical shared-memory view after the load without changing TMA basis.
+    _run_direct_basis_case(
+        dtype,
+        torch_dtype,
+        d_total=128,
+        seq_total=192,
+        d_tile=d_tile,
+        seq_tile=seq_tile,
+        coord0=0,
+        coord1=32,
+    )
+
+
+if __name__ == "__main__":
+    _require_sm120()
+    for dtype, torch_dtype in [
+        (cutlass.Float32, torch.float32),
+        (cutlass.BFloat16, torch.bfloat16),
+    ]:
+        for coord0, coord1 in [(0, 0), (16, 0), (0, 32), (16, 32)]:
+            _run_direct_basis_case(
+                dtype,
+                torch_dtype,
+                coord0=coord0,
+                coord1=coord1,
+            )
+
+    _run_direct_basis_case(
+        cutlass.Float32,
+        torch.float32,
+        use_cache_hint=True,
+        tile_mode=True,
+    )
+    for torch_dtype, dtype in [
+        (torch.float16, cutlass.Float16),
+        (torch.bfloat16, cutlass.BFloat16),
+    ]:
+        for d_tile in [64, 96, 128]:
+            for seq_tile in [64, 128]:
+                _run_fa_like_kv_direct_basis_smoke(
+                    torch_dtype, dtype, d_tile, seq_tile
+                )
+    print("SM120 direct TMA smoke passed")


### PR DESCRIPTION
Author: Alecco (& Codex) for Ologan

## Summary

On SM120/SM120a, CuTe DSL rank-2 G2S descriptor TMA through the normal executable `cute.copy` path can compile and launch, but then hang while waiting on the TMA pipeline mbarrier.

A minimal failing shape is a CTA-local rank-2 TMA load over a direct-basis `(d, seq)` FP32 tensor:

```python
cute.copy(
    tma_atom,
    tma_g,
    tma_s,
    tma_bar_ptr=pipe.producer_get_barrier(producer_state),
)
```

The kernel reaches launch, but torch.cuda.synchronize() does not return. **_A repro is included at the bottom of this PR_**.

This PR does not fix the underlying _cute_nvgpu executable TMA lowering. Instead, it adds a narrow SM120 direct TMA issue path that uses the same CuTe-generated descriptor but bypasses the failing `cute.copy` lowering. It also documents and validates the contract for using that path with swizzled shared-memory destinations.

## Problem

The reduced diagnosis was:

Direct-basis CuTe descriptor + raw SM120 TMA issue + PipelineTmaAsync: pass
Driver API descriptor + raw SM120 TMA issue + PipelineTmaAsync: pass
Direct-basis CuTe descriptor + normal `cute.copy/PipelineTmaAsync`: timeout
Driver API descriptor + normal `cute.copy/PipelineTmaAsync`: timeout
FA-style canonicalize/logicalize descriptor + raw issue: coord1 ignored

This points to two separate issues:

1. normal executable rank-2 TMA `cute.copy` lowering is not currently safe for this SM120 path;
2. the earlier canonicalize-then-logicalize approach for FlashAttention-style `(seq, d)` tensors can construct a descriptor path where the second coordinate is not represented correctly.

The useful working shape is direct TMA basis from the start:

```python
logical GMEM:      (seq, d)
TMA descriptor:    (d, seq)
TMA strides:       (1, D)
TMA coordinates:   {d_coord, seq_coord}
```

For swizzled shared memory, the same direct-basis rule applies. The TMA atom must be built with the intended composed SMEM layout, and the destination pointer passed to the direct issue helper must carry the matching swizzle.

## Workaround Added

This PR adds an explicit SM120/SM120a rank-2 TMA issue helper under:

```python
cutlass.cute.nvgpu.cpasync
```

The intended path is:

```python
gmem_tma = cute.make_tensor(
    gmem.iterator,
    cute.make_layout((D, S), stride=(1, D)),
)

tma_atom, tma_tensor, desc_ptr = cpasync.make_sm120_tma_load_2d_atom(
    gmem_tma,
    smem_layout_tma_basis,
    cta_tiler_tma_basis,
)

cpasync.sm120_tma_load_2d(
    dst_smem_ptr,
    desc_ptr,
    pipe.producer_get_barrier(producer_state),
    d_coord,
    seq_coord,
)
```

This keeps descriptor construction in CuTe DSL, but avoids the failing executable `cute.copy` TMA issue path.

For swizzled SMEM, callers should use a matching layout and pointer contract. Conceptually:

```python
swizzle = cute.make_swizzle(3, 4, 3)

smem_layout_tma_basis = cute.make_composed_layout(
    swizzle,
    0,
    base_smem_layout_tma_basis,
)

sT = smem.allocate_tensor(
    dtype,
    base_smem_layout_tma_basis,
    byte_alignment=128,
    swizzle=swizzle,
)

tma_atom, tma_tensor, desc_ptr = cpasync.make_sm120_tma_load_2d_atom(
    gmem_tma,
    smem_layout_tma_basis,
    cta_tiler_tma_basis,
)

cpasync.sm120_tma_load_2d(
    sT.iterator,
    desc_ptr,
    pipe.producer_get_barrier(producer_state),
    d_coord,
    seq_coord,
)
```

The key requirement is that the descriptor’s SMEM layout and the destination SMEM pointer agree about the swizzle. The smoke test reads back through the same swizzled CuTe tensor view.

## New API

cpasync.get_tma_desc_addr(tma_atom)

Returns the tiled TMA descriptor address associated with a TMA copy atom.

```python
cpasync.sm120_tma_load_2d(
    dst_smem_ptr,
    tma_desc_ptr,
    tma_bar_ptr,
    coord0,
    coord1,
    *,
    cache_policy=None,
    already_elected=False,
    tile_mode=False,
)
```

Issues a CTA-local SM120 rank-2 TMA load. By default it performs warp election internally, so callers do not accidentally issue multiple TMA transactions for one mbarrier phase.

```python
cpasync.make_sm120_tma_load_2d_atom(
    gmem_tensor,
    smem_layout,
    cta_tiler,
    *,
    internal_type=None,
)
```

Builds a narrow direct-basis rank-2 SM120 TMA load atom and returns:

```python
(tma_atom, tma_tensor, desc_ptr)
```

This helper deliberately does not canonicalize or logicalize modes. Callers must pass a direct-basis tensor where mode 0 is physically contiguous.

## Validation

Added a standalone SM120 smoke script:

```python
CUTE_DSL_ARCH=sm_120 python test/examples/CuTeDSL/sm_120a/sm120_direct_tma_smoke.py
```

It validates:

CuTe-generated direct-basis rank-2 descriptors
cpasync.get_tma_desc_addr(...)
cpasync.sm120_tma_load_2d(...)
PipelineTmaAsync
FP32 and BF16 coordinate sweeps with nonzero {d, seq} coordinates
.tile + .L2::cache_hint instruction spelling
FA-like K/V direct-basis loads for FP16/BF16 with D = 64, 96, 128 and seq_tile = 64, 128
SW128 swizzled SMEM load/readback for FP16/BF16 64x64 tiles

Local result:

SM120 direct TMA smoke passed

Also checked syntax with:

```python
python -m py_compile \
  python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py \
  python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py \
  test/examples/CuTeDSL/sm_120a/sm120_direct_tma_smoke.py
```

The swizzled coverage is intentionally conservative. The local SM120 setup has a 99 KiB shared-memory limit, so the committed smoke keeps individual tested tiles below a
64 KiB budget:

```python
FP32 64x64              = 16 KiB
BF16/FP16 64x64         = 8 KiB
BF16/FP16 96x128        = 24 KiB
BF16/FP16 128x128       = 32 KiB
BF16/FP16 64x64 swizzled = 8 KiB
```

Larger swizzled shapes are not claimed by this PR and should be validated separately.

## Scope

This is intentionally narrow:

supported:   SM120/SM120a CTA-local rank-2 G2S TMA
supported:   direct-basis descriptors where mode 0 is physically contiguous
supported:   optional swizzled SMEM when descriptor layout and destination pointer swizzle match
not added:   multicast
not added:   CTA group 2
not added:   arbitrary ND TMA
not added:   automatic (seq, d) -> (d, seq) canonicalize/logicalize routing
not changed: generic cute.copy TMA lowering

The underlying _cute_nvgpu executable TMA lowering should still be fixed separately. This PR gives CuTe DSL users a tested SM120 rank-2 path in the meantime, including the SMEM swizzle contract needed for optimized shared-memory staging.

## Agent disclosure

This work was created with OpenAI Codex CLI agent, but directed, supervised, and every line reviewed by a human.

## Issue repro

```
#!/usr/bin/env python3
"""Minimal SM120 rank-2 TMA `cute.copy` timeout repro.

Run from the CUTLASS repo root:

    CUTE_DSL_ARCH=sm_120 timeout 90s python agent_space/sm120_cute_copy_tma_timeout_repro.py

Expected affected behavior:

    launching SM120 rank-2 TMA cute.copy repro; expected failure is timeout...
    # process hangs in torch.cuda.synchronize(), then timeout exits with status 124
"""

import os

import torch

import cutlass
import cutlass.cute as cute
import cutlass.pipeline
import cutlass.utils
from cutlass.cute.nvgpu import cpasync
from cutlass.cute.runtime import from_dlpack
from cutlass.pipeline.sm90 import PipelineTmaAsync, make_pipeline_state


@cute.kernel
def _copy1d_kernel(tma_atom: cute.CopyAtom, tma_tensor: cute.Tensor, out: cute.Tensor):
    smem = cutlass.utils.SmemAllocator()
    smem_tile = smem.allocate_tensor(cutlass.Float32, cute.make_layout(64))
    mbar = smem.allocate_tensor(cutlass.Int64, cute.make_layout(2), byte_alignment=8)

    tidx, _, _ = cute.arch.thread_idx()
    warp = tidx // 32
    lane = tidx % 32

    pipe = PipelineTmaAsync.create(
        barrier_storage=mbar.iterator,
        num_stages=1,
        producer_group=cutlass.pipeline.CooperativeGroup(
            cutlass.pipeline.Agent.Thread, 1
        ),
        consumer_group=cutlass.pipeline.CooperativeGroup(
            cutlass.pipeline.Agent.Thread, 1
        ),
        tx_count=64 * cutlass.Float32.width // 8,
        defer_sync=False,
    )

    g_tile = cute.zipped_divide(tma_tensor, (64,))[(None,), 1]
    g_tile = cute.group_modes(g_tile, 0, cute.rank(g_tile))
    tma_s, tma_g = cpasync.tma_partition(
        tma_atom,
        cutlass.Int32(0),
        cute.make_layout(1),
        cute.group_modes(smem_tile, 0, cute.rank(smem_tile)),
        g_tile,
    )

    if warp == 0:
        with cute.arch.elect_one():
            cpasync.prefetch_descriptor(tma_atom)

        producer_state = make_pipeline_state(
            cutlass.pipeline.PipelineUserType.Producer, 1
        )
        pipe.producer_acquire(producer_state)
        with cute.arch.elect_one():
            cute.copy(
                tma_atom,
                tma_g,
                tma_s,
                tma_bar_ptr=pipe.producer_get_barrier(producer_state),
            )
        producer_state.advance()
        pipe.producer_tail(producer_state)

    if warp == 1:
        consumer_state = make_pipeline_state(
            cutlass.pipeline.PipelineUserType.Consumer, 1
        )
        pipe.consumer_wait(consumer_state)
        cute.arch.fence_view_async_shared()
        pipe.consumer_release(consumer_state)
        out[lane] = smem_tile[lane]


@cute.kernel
def _copy2d_kernel(tma_atom: cute.CopyAtom, tma_tensor: cute.Tensor):
    smem = cutlass.utils.SmemAllocator()
    smem_tile = smem.allocate_tensor(cutlass.Float32, cute.make_layout((64, 64)))
    mbar = smem.allocate_tensor(cutlass.Int64, cute.make_layout(2), byte_alignment=8)

    tidx, _, _ = cute.arch.thread_idx()
    warp = tidx // 32

    pipe = PipelineTmaAsync.create(
        barrier_storage=mbar.iterator,
        num_stages=1,
        producer_group=cutlass.pipeline.CooperativeGroup(
            cutlass.pipeline.Agent.Thread, 1
        ),
        consumer_group=cutlass.pipeline.CooperativeGroup(
            cutlass.pipeline.Agent.Thread, 1
        ),
        tx_count=64 * 64 * cutlass.Float32.width // 8,
        defer_sync=False,
    )

    g_tile = cute.local_tile(tma_tensor, (64, 64), (0, 1))
    tma_s, tma_g = cpasync.tma_partition(
        tma_atom,
        cutlass.Int32(0),
        cute.make_layout(1),
        cute.group_modes(smem_tile, 0, 2),
        cute.group_modes(g_tile, 0, 2),
    )

    if warp == 0:
        with cute.arch.elect_one():
            cpasync.prefetch_descriptor(tma_atom)

        producer_state = make_pipeline_state(
            cutlass.pipeline.PipelineUserType.Producer, 1
        )
        pipe.producer_acquire(producer_state)
        with cute.arch.elect_one():
            cute.copy(
                tma_atom,
                tma_g,
                tma_s,
                tma_bar_ptr=pipe.producer_get_barrier(producer_state),
            )
        producer_state.advance()
        pipe.producer_tail(producer_state)

    if warp == 1:
        consumer_state = make_pipeline_state(
            cutlass.pipeline.PipelineUserType.Consumer, 1
        )
        pipe.consumer_wait(consumer_state)
        cute.arch.fence_view_async_shared()
        pipe.consumer_release(consumer_state)


@cute.jit
def _launch_1d(src: cute.Tensor, out: cute.Tensor):
    tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
        cpasync.CopyBulkTensorTileG2SOp(),
        src,
        cute.make_layout((64,)),
        (64,),
        1,
    )
    _copy1d_kernel(tma_atom, tma_tensor, out).launch(
        grid=[1, 1, 1],
        block=[64, 1, 1],
        smem=64 * cutlass.Float32.width // 8 + 16,
    )


@cute.jit
def _launch_2d(src: cute.Tensor):
    direct_src = cute.make_tensor(
        src.iterator,
        cute.make_layout((128, 128), stride=(1, 128)),
    )
    tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
        cpasync.CopyBulkTensorTileG2SOp(),
        direct_src,
        cute.make_layout((64, 64)),
        (64, 64),
        1,
    )
    _copy2d_kernel(tma_atom, tma_tensor).launch(
        grid=[1, 1, 1],
        block=[64, 1, 1],
        smem=64 * 64 * cutlass.Float32.width // 8 + 16,
    )


def main():
    os.environ.setdefault("CUTE_DSL_ARCH", "sm_120")
    assert torch.cuda.is_available(), "CUDA is required"
    major, minor = torch.cuda.get_device_capability()
    assert major >= 12, f"SM120/SM120a required, got SM{major}{minor}"

    src_1d = torch.arange(128, device="cuda", dtype=torch.float32)
    out_1d = torch.empty(32, device="cuda", dtype=torch.float32)
    args_1d = (
        from_dlpack(src_1d, assumed_align=16),
        from_dlpack(out_1d, assumed_align=16),
    )

    print("compiling rank-1 TMA cute.copy control...", flush=True)
    cute.compile(_launch_1d, *args_1d)
    print("rank-1 control compiled", flush=True)

    src_2d = torch.arange(128 * 128, device="cuda", dtype=torch.float32).reshape(
        128, 128
    )
    args_2d = (from_dlpack(src_2d, assumed_align=16),)

    print(
        "launching SM120 rank-2 TMA cute.copy repro; expected failure is timeout...",
        flush=True,
    )
    cute.compile(_launch_2d, *args_2d)(*args_2d)

    # Affected behavior: hangs here until the shell-level `timeout` kills it.
    torch.cuda.synchronize()
    print("unexpectedly completed")


if __name__ == "__main__":
    main()
```
