### PR TITLE
[CuTe][SM70] Add comment clarifying signed cast requirement for blockIdx coords

### DIFF
--- a/include/cutlass/gemm/kernel/sm70_gemm.hpp
+++ b/include/cutlass/gemm/kernel/sm70_gemm.hpp
@@ -210,7 +210,7 @@ static_assert(is_valid_tile_scheduler, "SM70 kernel does not support specializin
     int thread_idx = int(threadIdx.x);
     auto blk_shape = TileShape{};                                                                // (BLK_M,BLK_N,BLK_K)
     auto [m_coord, n_coord, l_coord] = static_cast<uint3>(blockIdx);
-    auto blk_coord_mnkl = make_coord(int(m_coord), int(n_coord), _, int(l_coord));                         // (m,n,k,l)
+    auto blk_coord_mnkl = make_coord(int(m_coord), int(n_coord), _, int(l_coord));  // (m,n,k,l) NOTE: int() cast needed; unsigned coords cause underflow in residue computation for small problem shapes.
 
     // Represent the full tensors
     Tensor mA_mkl = make_tensor(make_gmem_ptr(params.mainloop.ptr_A), make_shape(M,K,L), params.mainloop.dA); //(m,k,l)

--- a/include/cutlass/gemm/kernel/sm70_gemm_array.hpp
+++ b/include/cutlass/gemm/kernel/sm70_gemm_array.hpp
@@ -217,7 +217,7 @@ static_assert(is_valid_tile_scheduler, "SM70 kernel does not support specializin
     int thread_idx = int(threadIdx.x);
     auto blk_shape = TileShape{};                                                                // (BLK_M,BLK_N,BLK_K)
     auto [m_coord, n_coord, l_coord] = static_cast<uint3>(blockIdx);
-    auto blk_coord_mnkl = make_coord(int(m_coord), int(n_coord), _, int(l_coord));                         // (m,n,k,l)
+    auto blk_coord_mnkl = make_coord(int(m_coord), int(n_coord), _, int(l_coord));  // (m,n,k,l) NOTE: int() cast needed; unsigned coords cause underflow in residue computation for small problem shapes.
 
     // Represent the full tensors
     Tensor mA_mkl = make_tensor(make_gmem_ptr(params.mainloop.ptr_A[l_coord]), make_shape(M,K,1), params.mainloop.dA); //(m,k,l)


### PR DESCRIPTION
### Problem

blockIdx returns uint3, so m_coord, n_coord, and l_coord are unsigned. When these are passed directly to make_coord, the tile residue calculations:

```cpp
auto m_max_coord = size<0>(shape_MNKL) - size<0>(gA) * get<0>(cta_coord);
auto n_max_coord = size<1>(shape_MNKL) - size<0>(gB) * get<1>(cta_coord);
```

can produce negative values for small problem shapes (e.g. M=8, N=8 with TileShape=128x128). With unsigned arithmetic, these wrap around to large positive values, causing incorrect predication and wrong results.

### Fix

The int() cast in make_coord was already present in `sm70_gemm.hpp` and `sm70_gemm_array.hpp`, but without explanation. This PR adds a comment to clarify why the cast is necessary, so users writing custom kernels based on these files do not accidentally omit it.

Reported in #3190.