### PR TITLE
FMHA examples: use cute::min in device functions

### DIFF
--- a/examples/77_blackwell_fmha/collective/fmha_fusion.hpp
+++ b/examples/77_blackwell_fmha/collective/fmha_fusion.hpp
@@ -206,11 +206,11 @@ struct CausalMask : NoMask {
     int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
     if constexpr (IsQBegin) {
       int max_blocks_q = ceil_div((get<0>(blk_coord) + 1) * get<0>(tile_shape), get<1>(tile_shape));
-      return std::min(max_blocks_k, max_blocks_q);
+      return cute::min(max_blocks_k, max_blocks_q);
     } else {
       const int offset_q = get<1>(problem_size) - get<0>(problem_size);
       int max_blocks_q = ceil_div((get<0>(blk_coord) + 1) * get<0>(tile_shape) + offset_q, get<1>(tile_shape));
-      return std::min(max_blocks_k, max_blocks_q);
+      return cute::min(max_blocks_k, max_blocks_q);
     }
   }
 
@@ -223,10 +223,10 @@ struct CausalMask : NoMask {
         
     int trip_count = get_trip_count(blk_coord, tile_shape, problem_size);
     if constexpr (IsQBegin) {
-      return std::min(trip_count, int(ceil_div(size<0>(tile_shape), size<1>(tile_shape))));
+      return cute::min(trip_count, int(ceil_div(size<0>(tile_shape), size<1>(tile_shape))));
     } else {
       const int offset_tile_q = (get<1>(problem_size) - get<0>(problem_size)) % get<1>(tile_shape);
-      return std::min(trip_count, int(ceil_div(get<0>(tile_shape) + offset_tile_q, get<1>(tile_shape))));
+      return cute::min(trip_count, int(ceil_div(get<0>(tile_shape) + offset_tile_q, get<1>(tile_shape))));
     }
   }
 

--- a/examples/88_hopper_fmha/collective/fmha_fusion.hpp
+++ b/examples/88_hopper_fmha/collective/fmha_fusion.hpp
@@ -142,7 +142,7 @@ struct CausalFusion : DefaultFusion {
     // Again, we'd add the offset_q into the max_blocks_q calculation
     int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
     int max_blocks_q = ceil_div((get<0>(blk_coord) + 1) * get<0>(tile_shape), get<1>(tile_shape));
-    return std::min(max_blocks_k, max_blocks_q);
+    return cute::min(max_blocks_k, max_blocks_q);
   }
 
   template<class BlkCoord, class TileShape, class ProblemSize>


### PR DESCRIPTION
Use `cute::min` instead of `std::min` in FMHA device functions.

These helpers are marked `CUTLASS_DEVICE`, and `cute::min` is already the CuTe/CUTLASS host-device constexpr utility used for this pattern.

This matches the existing CUTLASS/CuTe device-code style and avoids relying on `std::min` in device functions.

Testing:

    cmake -S . -B build \
      -DCMAKE_BUILD_TYPE=Release \
      -DCUTLASS_NVCC_ARCHS=90a \
      -DCUTLASS_ENABLE_TESTS=OFF \
      -DCUTLASS_ENABLE_EXAMPLES=ON

    cmake --build build --target 88_hopper_fmha -j$(nproc)

Result:

    Built target 88_hopper_fmha

I did not build the Blackwell FMHA target locally.
