### PR TITLE
Avoid unordered_map for runtime datatype mapping

### DIFF
--- a/tools/library/src/blockwise_gemm_operation_3x.hpp
+++ b/tools/library/src/blockwise_gemm_operation_3x.hpp
@@ -243,26 +243,39 @@ protected:
       operator_args.mainloop.ptr_A = static_cast<ArrayElementA const *>(arguments->A);
       operator_args.mainloop.ptr_B = static_cast<ArrayElementB const *>(arguments->B);
 
-      std::unordered_map<RuntimeDatatype, cute::UMMA::MXF8F6F4Format> mapping = {
-          {RuntimeDatatype::kE4M3, cute::UMMA::MXF8F6F4Format::E4M3},
-          {RuntimeDatatype::kE5M2, cute::UMMA::MXF8F6F4Format::E5M2}, 
-          {RuntimeDatatype::kE3M2, cute::UMMA::MXF8F6F4Format::E3M2},
-          {RuntimeDatatype::kE2M1, cute::UMMA::MXF8F6F4Format::E2M1}
-      };
+      auto runtime_datatype_to_mxf8f6f4 =
+        [](RuntimeDatatype type, cute::UMMA::MXF8F6F4Format& format) -> Status {
+          switch (type) {
+            case RuntimeDatatype::kE4M3:
+              format = cute::UMMA::MXF8F6F4Format::E4M3;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE5M2:
+              format = cute::UMMA::MXF8F6F4Format::E5M2;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE3M2:
+              format = cute::UMMA::MXF8F6F4Format::E3M2;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE2M1:
+              format = cute::UMMA::MXF8F6F4Format::E2M1;
+              return Status::kSuccess;
+            default:
+              assert(false && "invalid runtime argument for datatype!");
+              return Status::kErrorInvalidProblem;
+          }
+        };
 
-      auto iter_runtime_a = mapping.find(arguments->runtime_input_datatype_a);
-      auto iter_runtime_b = mapping.find(arguments->runtime_input_datatype_b);
-
-      if (iter_runtime_a != mapping.end()) {
-          operator_args.mainloop.runtime_data_type_a = iter_runtime_a->second;
-      } else {
-        assert("invalid runtime argument for datatype A!");
+      status = runtime_datatype_to_mxf8f6f4(
+        arguments->runtime_input_datatype_a,
+        operator_args.mainloop.runtime_data_type_a);
+      if (status != Status::kSuccess) {
+        return status;
       }
 
-      if (iter_runtime_b != mapping.end()) {
-          operator_args.mainloop.runtime_data_type_b = iter_runtime_b->second;
-      } else {
-        assert("invalid runtime argument for datatype B!");
+      status = runtime_datatype_to_mxf8f6f4(
+        arguments->runtime_input_datatype_b,
+        operator_args.mainloop.runtime_data_type_b);
+      if (status != Status::kSuccess) {
+        return status;
       }
 
    }

--- a/tools/library/src/gemm_operation_3x.hpp
+++ b/tools/library/src/gemm_operation_3x.hpp
@@ -47,7 +47,6 @@
 #include "cutlass/util/reference/device/tensor_fill.h"
 #include "cutlass/util/reference/device/tensor_compare.h"
 #include "cute/tensor.hpp"
-#include <unordered_map>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -374,26 +373,39 @@ protected:
       operator_args.mainloop.ptr_A = static_cast<ArrayElementA const *>(arguments->A);
       operator_args.mainloop.ptr_B = static_cast<ArrayElementB const *>(arguments->B);
 
-      std::unordered_map<RuntimeDatatype, cute::UMMA::MXF8F6F4Format> mapping = {
-          {RuntimeDatatype::kE4M3, cute::UMMA::MXF8F6F4Format::E4M3},
-          {RuntimeDatatype::kE5M2, cute::UMMA::MXF8F6F4Format::E5M2},
-          {RuntimeDatatype::kE3M2, cute::UMMA::MXF8F6F4Format::E3M2},
-          {RuntimeDatatype::kE2M1, cute::UMMA::MXF8F6F4Format::E2M1}
-      };
+      auto runtime_datatype_to_mxf8f6f4 =
+        [](RuntimeDatatype type, cute::UMMA::MXF8F6F4Format& format) -> Status {
+          switch (type) {
+            case RuntimeDatatype::kE4M3:
+              format = cute::UMMA::MXF8F6F4Format::E4M3;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE5M2:
+              format = cute::UMMA::MXF8F6F4Format::E5M2;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE3M2:
+              format = cute::UMMA::MXF8F6F4Format::E3M2;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE2M1:
+              format = cute::UMMA::MXF8F6F4Format::E2M1;
+              return Status::kSuccess;
+            default:
+              assert(false && "invalid runtime argument for datatype!");
+              return Status::kErrorInvalidProblem;
+          }
+        };
 
-      auto iter_runtime_a = mapping.find(arguments->runtime_input_datatype_a);
-      auto iter_runtime_b = mapping.find(arguments->runtime_input_datatype_b);
-
-      if (iter_runtime_a != mapping.end()) {
-          operator_args.mainloop.runtime_data_type_a = iter_runtime_a->second;
-      } else {
-        assert("invalid runtime argument for datatype A!");
+      status = runtime_datatype_to_mxf8f6f4(
+        arguments->runtime_input_datatype_a,
+        operator_args.mainloop.runtime_data_type_a);
+      if (status != Status::kSuccess) {
+        return status;
       }
 
-      if (iter_runtime_b != mapping.end()) {
-          operator_args.mainloop.runtime_data_type_b = iter_runtime_b->second;
-      } else {
-        assert("invalid runtime argument for datatype B!");
+      status = runtime_datatype_to_mxf8f6f4(
+        arguments->runtime_input_datatype_b,
+        operator_args.mainloop.runtime_data_type_b);
+      if (status != Status::kSuccess) {
+        return status;
       }
 
     }

--- a/tools/library/src/sparse_gemm_operation_3x.hpp
+++ b/tools/library/src/sparse_gemm_operation_3x.hpp
@@ -51,7 +51,6 @@
 #include "cutlass/util/reference/device/tensor_fill.h"
 #include "cutlass/util/reference/device/tensor_compare.h"
 #include "cute/tensor.hpp"
-#include <unordered_map>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -196,26 +195,39 @@ protected:
       operator_args.mainloop.ptr_A = static_cast<ArrayElementA const *>(device_a_compressed_ptr);
       operator_args.mainloop.ptr_B = static_cast<ArrayElementB const *>(arguments->B);
 
-      std::unordered_map<RuntimeDatatype, cute::UMMA::MXF8F6F4Format> mapping = {
-          {RuntimeDatatype::kE4M3, cute::UMMA::MXF8F6F4Format::E4M3},
-          {RuntimeDatatype::kE5M2, cute::UMMA::MXF8F6F4Format::E5M2},
-          {RuntimeDatatype::kE3M2, cute::UMMA::MXF8F6F4Format::E3M2},
-          {RuntimeDatatype::kE2M1, cute::UMMA::MXF8F6F4Format::E2M1}
-      };
+      auto runtime_datatype_to_mxf8f6f4 =
+        [](RuntimeDatatype type, cute::UMMA::MXF8F6F4Format& format) -> Status {
+          switch (type) {
+            case RuntimeDatatype::kE4M3:
+              format = cute::UMMA::MXF8F6F4Format::E4M3;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE5M2:
+              format = cute::UMMA::MXF8F6F4Format::E5M2;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE3M2:
+              format = cute::UMMA::MXF8F6F4Format::E3M2;
+              return Status::kSuccess;
+            case RuntimeDatatype::kE2M1:
+              format = cute::UMMA::MXF8F6F4Format::E2M1;
+              return Status::kSuccess;
+            default:
+              assert(false && "invalid runtime argument for datatype!");
+              return Status::kErrorInvalidProblem;
+          }
+        };
 
-      auto iter_runtime_a = mapping.find(arguments->runtime_input_datatype_a);
-      auto iter_runtime_b = mapping.find(arguments->runtime_input_datatype_b);
-
-      if (iter_runtime_a != mapping.end()) {
-          operator_args.mainloop.runtime_data_type_a = iter_runtime_a->second;
-      } else {
-        assert("invalid runtime argument for datatype A!");
+      status = runtime_datatype_to_mxf8f6f4(
+        arguments->runtime_input_datatype_a,
+        operator_args.mainloop.runtime_data_type_a);
+      if (status != Status::kSuccess) {
+        return status;
       }
 
-      if (iter_runtime_b != mapping.end()) {
-          operator_args.mainloop.runtime_data_type_b = iter_runtime_b->second;
-      } else {
-        assert("invalid runtime argument for datatype B!");
+      status = runtime_datatype_to_mxf8f6f4(
+        arguments->runtime_input_datatype_b,
+        operator_args.mainloop.runtime_data_type_b);
+      if (status != Status::kSuccess) {
+        return status;
       }
 
     }


### PR DESCRIPTION
## Summary

Replace per-call `std::unordered_map` construction used for `RuntimeDatatype` to `cute::UMMA::MXF8F6F4Format` conversion in GEMM operation wrappers with a switch-based local helper.

The mapping is fixed and small, so this avoids constructing a temporary hash map during argument update while preserving the supported mappings for:

- `RuntimeDatatype::kE4M3`
- `RuntimeDatatype::kE5M2`
- `RuntimeDatatype::kE3M2`
- `RuntimeDatatype::kE2M1`

This also fixes the unsupported runtime datatype path by replacing the previous assert string expression with a real debug assertion and an explicit `Status::kErrorInvalidProblem` return.

## Changed files

- `tools/library/src/gemm_operation_3x.hpp`
- `tools/library/src/sparse_gemm_operation_3x.hpp`
- `tools/library/src/blockwise_gemm_operation_3x.hpp`

## Local validation

- `git diff --check HEAD~1..HEAD`
- Verified no remaining `RuntimeDatatype` `std::unordered_map` mapping in the touched files
- Verified the corrected debug assertion path appears once in each touched file

Full local CUTLASS builds are not practical on my machine, so I am relying on project CI and maintainer review for full validation.
