### PR TITLE
[CuTeDSL] Add narrow SM120 NVFP4 79a-style warp MMA/TMA path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 __pycache__/
 cutlass_library.egg-info/
 /build*
+
+# CuTe DSL editable-install payload copied from nvidia-cutlass-dsl-libs-*.
+python/CuTeDSL/VERSION.EDITABLE
+python/CuTeDSL/cutlass/_mlir/
+python/CuTeDSL/cutlass/base_dsl/py.typed
+python/CuTeDSL/cutlass/cute/py.typed
+python/CuTeDSL/lib/
+python/CuTeDSL/nvidia_cutlass_dsl.egg-info/

--- a/examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py
@@ -1,0 +1,462 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Compile-time SM120 MXF4NVF4 mainloop scaffold."""
+
+import argparse
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import pipeline
+from cutlass.base_dsl.common import CudaDriverDependencyError
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack, make_fake_compact_tensor
+from cutlass.utils.gemm import sm120
+
+
+@cute.kernel
+def _mainloop_kernel(
+    tma_atom_a: cute.CopyAtom,
+    tma_tensor_a: cute.Tensor,
+    tma_atom_b: cute.CopyAtom,
+    tma_tensor_b: cute.Tensor,
+    tma_atom_sfa: cute.CopyAtom,
+    tma_tensor_sfa: cute.Tensor,
+    tma_atom_sfb: cute.CopyAtom,
+    tma_tensor_sfb: cute.Tensor,
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    desc_sfa: cute.Tensor,
+    desc_sfb: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
+        smem
+    )
+    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
+        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFA_scratch_all, sSFB_scratch_all = sm120.allocate_mxf4nvf4_scale_fragment_scratch(
+        smem
+    )
+    sSFA_scratch, sSFB_scratch = sm120.make_mxf4nvf4_scale_fragment_scratch_views(
+        sSFA_scratch_all, sSFB_scratch_all, cutlass.Int32(0)
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+
+    tAsA, tAgA = cpasync.tma_partition(
+        tma_atom_a,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sA_tma, 0, 2),
+        cute.group_modes(tma_tensor_a, 0, 2),
+    )
+    tBsB, tBgB = cpasync.tma_partition(
+        tma_atom_b,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sB_tma, 0, 2),
+        cute.group_modes(tma_tensor_b, 0, 2),
+    )
+    tSFAs, tSFAg = cpasync.tma_partition(
+        tma_atom_sfa,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sSFA, 0, 2),
+        cute.group_modes(tma_tensor_sfa, 0, 2),
+    )
+    tSFBs, tSFBg = cpasync.tma_partition(
+        tma_atom_sfb,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sSFB, 0, 2),
+        cute.group_modes(tma_tensor_sfb, 0, 2),
+    )
+
+    pipe = pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+        consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+        tx_count=sm120.mxf4nvf4_full_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+    pipe.producer_acquire(producer_state, pipe.producer_try_acquire(producer_state))
+    bar = pipe.producer_get_barrier(producer_state)
+
+    desc_a_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_a)
+    desc_b_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_b)
+    desc_sfa_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_sfa)
+    desc_sfb_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_sfb)
+
+    cute.copy(
+        tma_atom_a,
+        tAgA[(None, 0)],
+        tAsA[(None, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_a_ptr,
+    )
+    cute.copy(
+        tma_atom_b,
+        tBgB[(None, 0)],
+        tBsB[(None, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_b_ptr,
+    )
+    cute.copy(
+        tma_atom_sfa,
+        tSFAg[(None, 0, 0)],
+        tSFAs[(None, 0, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_sfa_ptr,
+    )
+    cute.copy(
+        tma_atom_sfb,
+        tSFBg[(None, 0, 0)],
+        tSFBs[(None, 0, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_sfb_ptr,
+    )
+    pipe.producer_commit(producer_state)
+    consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+    pipe.consumer_wait(consumer_state, pipe.consumer_try_wait(consumer_state))
+    cute.arch.sync_threads()
+
+    sm120.stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch(
+        sSFA,
+        sSFB,
+        sSFA_scratch,
+        sSFB_scratch,
+        lane_idx=tidx,
+    )
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a_frag = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b_frag = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_C((16, 8)), cutlass.Float32
+    )
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
+            sA_tma,
+            sB_tma,
+            sA_ldsm_scratch,
+            sB_ldsm_scratch,
+            k_block_idx=k_block_idx,
+            lane_idx=tidx,
+        )
+        cute.arch.sync_threads()
+        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
+            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a_frag, b_frag, tidx
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_fragment_views_from_scratch(
+            sSFA_scratch, sSFB_scratch, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a_frag, sfa), (b_frag, sfb), acc)
+        cute.arch.sync_threads()
+    pipe.consumer_release(consumer_state)
+    out[0] = acc[0].to(cutlass.BFloat16)
+
+
+@cute.jit
+def _launch(
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    desc_sfa: cute.Tensor,
+    desc_sfb: cute.Tensor,
+    gA: cute.Tensor,
+    gB: cute.Tensor,
+    gSFA: cute.Tensor,
+    gSFB: cute.Tensor,
+    out: cute.Tensor,
+):
+    ab_smem_layout = sm120.make_mxf4nvf4_ab_tma_physical_layout_staged()
+    scale_smem_layout = sm120.make_mxf4nvf4_scale_tma_physical_layout_staged()
+    tma_atom_a, tma_tensor_a = sm120.make_mxf4nvf4_tiled_tma_atom_a(
+        gA, ab_smem_layout
+    )
+    tma_atom_b, tma_tensor_b = sm120.make_mxf4nvf4_tiled_tma_atom_b(
+        gB, ab_smem_layout
+    )
+    tma_atom_sfa, tma_tensor_sfa = sm120.make_mxf4nvf4_sfa_tiled_tma_atom(
+        gSFA, scale_smem_layout
+    )
+    tma_atom_sfb, tma_tensor_sfb = sm120.make_mxf4nvf4_sfb_tiled_tma_atom(
+        gSFB, scale_smem_layout
+    )
+    _mainloop_kernel(
+        tma_atom_a,
+        tma_tensor_a,
+        tma_atom_b,
+        tma_tensor_b,
+        tma_atom_sfa,
+        tma_tensor_sfa,
+        tma_atom_sfb,
+        tma_tensor_sfb,
+        desc_a,
+        desc_b,
+        desc_sfa,
+        desc_sfb,
+        out,
+    ).launch(grid=[1, 1, 1], block=[32, 1, 1], smem=65536)
+
+
+def fake_inputs():
+    desc = make_fake_compact_tensor(
+        cutlass.Uint8,
+        (sm120.MXF4NVF4_TMA_DESC_BYTES,),
+        memspace=cute.AddressSpace.gmem,
+        assumed_align=128,
+    )
+    g_ab = make_fake_compact_tensor(
+        cutlass.Uint8,
+        (128, 128, 2),
+        memspace=cute.AddressSpace.gmem,
+        assumed_align=32,
+    )
+    g_scale = make_fake_compact_tensor(
+        cutlass.Uint8,
+        (128, sm120.MXF4NVF4_SCALE_K, 2, 2),
+        memspace=cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    out = make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (1,),
+        memspace=cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    return desc, desc, desc, desc, g_ab, g_ab, g_scale, g_scale, out
+
+
+def compile_mainloop(*, keep_ptx: bool = True, keep_cubin: bool = False):
+    options = "--gpu-arch=sm_120a --enable-tvm-ffi"
+    if keep_ptx:
+        options += " --keep-ptx"
+    if keep_cubin:
+        options += " --keep-cubin"
+    return cute.compile(_launch, *fake_inputs(), options=options)
+
+
+def inspect_ptx(ptx: str) -> None:
+    required = [
+        "cp.async.bulk.tensor.3d.shared::cta.global.tile",
+        "cp.async.bulk.tensor.4d.shared::cta.global.tile",
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16",
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::4X",
+    ]
+    forbidden = ["b4x16_p64", "shared::cluster", ".multicast", "tcgen05"]
+    for needle in required:
+        if needle not in ptx:
+            raise AssertionError(f"missing expected PTX: {needle}")
+    for needle in forbidden:
+        if needle in ptx:
+            raise AssertionError(f"unexpected PTX: {needle}")
+
+
+@cute.kernel
+def _runtime_check_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range_constexpr(8):
+        sSFA_f8[(0, i, 0, 0)] = cutlass.Float8E4M3FN(1.0 if i < 4 else 2.0)
+        sSFB_f8[(0, i, 0, 0)] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+
+    cute.recast_tensor(a, cutlass.Int32).fill(0x22222222)
+    cute.recast_tensor(b, cutlass.Int32).fill(0x22222222)
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_runtime_check(out: cute.Tensor):
+    _runtime_check_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def runtime_check() -> None:
+    torch = __import__("torch")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA device unavailable")
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(_launch_runtime_check, cute_out, options="--keep-ptx")
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    expected = torch.full_like(out, 192.0)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+@cute.kernel
+def _runtime_tma_copy_kernel(desc: cute.Tensor, out: cute.Tensor):
+    smem = cutlass.utils.SmemAllocator()
+    smem_tensor = smem.allocate_tensor(
+        cutlass.Uint8, cute.make_layout(17408), byte_alignment=128
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+    tidx, _, _ = cute.arch.thread_idx()
+
+    for i in cutlass.range(tidx, 17408, 32):
+        smem_tensor[i] = cutlass.Uint8(0xCD)
+    cute.arch.sync_threads()
+
+    pipe = pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+        consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+        tx_count=sm120.mxf4nvf4_ab_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+    consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+    pipeline.producer_acquire_issue_tma_load_3d(
+        pipe,
+        producer_state,
+        None,
+        smem_tensor.iterator,
+        desc.iterator,
+        0,
+        0,
+        0,
+        already_elected=False,
+    )
+    pipe.consumer_wait(consumer_state)
+    cute.arch.sync_threads()
+    for i in cutlass.range(tidx, 17408, 32):
+        out[i] = smem_tensor[i]
+    pipe.consumer_release(consumer_state)
+
+
+@cute.jit
+def _launch_runtime_tma_copy(desc: cute.Tensor, out: cute.Tensor):
+    _runtime_tma_copy_kernel(desc, out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def _aligned_u8_tensor(torch, num_bytes: int, alignment: int):
+    storage = torch.empty(num_bytes + alignment - 1, device="cuda", dtype=torch.uint8)
+    offset = (-storage.data_ptr()) % alignment
+    view = storage[offset : offset + num_bytes]
+    if view.data_ptr() % alignment != 0:
+        raise RuntimeError("failed to create aligned CUDA tensor")
+    return storage, view
+
+
+def _patterned_u8(torch, count: int):
+    values = torch.arange(count, device="cuda", dtype=torch.int32)
+    return torch.bitwise_xor(values, 0x5A).to(torch.uint8)
+
+
+def _expected_rank3_fp4_tma_output(torch, src, output_bytes: int):
+    expected = torch.full((output_bytes,), 0xCD, device="cuda", dtype=torch.uint8)
+    for dst_payload_chunk in range(src.numel() // 8):
+        dst_base = dst_payload_chunk * 16
+        src_swizzle_chunk = dst_payload_chunk ^ ((dst_payload_chunk >> 3) & 0x7)
+        src_base = src_swizzle_chunk * 8
+        expected[dst_base : dst_base + 8] = src[src_base : src_base + 8]
+    return expected
+
+
+def runtime_tma_check() -> None:
+    torch = __import__("torch")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(torch, sm120.MXF4NVF4_AB_TMA_BYTES, 32)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    try:
+        desc_bytes = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(src.data_ptr())
+    except CudaDriverDependencyError as exc:
+        raise RuntimeError(f"CUDA Driver tensor-map encoder unavailable: {exc}") from exc
+    desc_storage, desc = _aligned_u8_tensor(torch, sm120.MXF4NVF4_TMA_DESC_BYTES, 128)
+    desc.copy_(torch.tensor(list(desc_bytes), device="cuda", dtype=torch.uint8))
+    out = torch.empty((17408,), device="cuda", dtype=torch.uint8)
+    cute_desc = from_dlpack(desc, assumed_align=128, enable_tvm_ffi=True)
+    cute_out = from_dlpack(out, assumed_align=16, enable_tvm_ffi=True)
+    cute.compile(
+        _launch_runtime_tma_copy,
+        cute_desc,
+        cute_out,
+        options="--enable-tvm-ffi",
+    )(cute_desc, cute_out)
+    torch.cuda.synchronize()
+    expected = _expected_rank3_fp4_tma_output(torch, src, out.numel())
+    if not torch.equal(out, expected):
+        raise AssertionError("runtime TMA descriptor check copied unexpected bytes")
+    _ = src_storage, desc_storage
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--ptx-inspect", action="store_true")
+    parser.add_argument("--runtime-check", action="store_true")
+    parser.add_argument("--runtime-tma-check", action="store_true")
+    args = parser.parse_args()
+    if args.runtime_check:
+        runtime_check()
+        return
+    if args.runtime_tma_check:
+        runtime_tma_check()
+        return
+    compiled = compile_mainloop(keep_ptx=args.ptx_inspect)
+    if args.ptx_inspect:
+        inspect_ptx(compiled.__ptx__)
+    if not args.compile_only and not args.ptx_inspect:
+        print("compiled")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py
+++ b/examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py
@@ -31,14 +31,10 @@ def _mainloop_kernel(
     out: cute.Tensor,
 ):
     tidx, _, _ = cute.arch.thread_idx()
+    lane_idx = tidx % 32
     smem = cutlass.utils.SmemAllocator()
     sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
-    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
-        smem
-    )
-    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
-        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
-    )
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
     sSFA = smem.allocate_tensor(
         cutlass.Uint8,
         sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
@@ -140,16 +136,17 @@ def _mainloop_kernel(
         sSFB,
         sSFA_scratch,
         sSFB_scratch,
-        lane_idx=tidx,
+        lane_idx=lane_idx,
     )
     cute.arch.sync_threads()
 
     tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
-    a_frag = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma, sB_tma, sA_consumer, sB_consumer, lane_idx=lane_idx
     )
-    b_frag = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    cute.arch.sync_threads()
+    a_frag, b_frag = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, lane_idx=lane_idx
     )
     acc = cute.make_rmem_tensor(
         tiled_mma.partition_shape_C((16, 8)), cutlass.Float32
@@ -157,24 +154,27 @@ def _mainloop_kernel(
     sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
     acc.fill(0.0)
     for k_block_idx in cutlass.range_constexpr(2):
-        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
-            sA_tma,
-            sB_tma,
-            sA_ldsm_scratch,
-            sB_ldsm_scratch,
-            k_block_idx=k_block_idx,
-            lane_idx=tidx,
-        )
-        cute.arch.sync_threads()
-        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
-            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a_frag, b_frag, tidx
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a_frag,
+            b_frag,
+            lane_idx,
+            k_block_idx,
         )
         sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_fragment_views_from_scratch(
             sSFA_scratch, sSFB_scratch, k_block_idx
         )
         sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
         sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
-        cute.gemm(tiled_mma, acc, (a_frag, sfa), (b_frag, sfb), acc)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a_frag[(None, 0, k_block_idx)], sfa),
+            (b_frag[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
         cute.arch.sync_threads()
     pipe.consumer_release(consumer_state)
     out[0] = acc[0].to(cutlass.BFloat16)

--- a/python/CuTeDSL/cutlass/base_dsl/common.py
+++ b/python/CuTeDSL/cutlass/base_dsl/common.py
@@ -200,6 +200,14 @@ class DSLRuntimeError(DSLBaseError):
     pass
 
 
+class CudaDriverDependencyError(DSLRuntimeError):
+    """
+    Raised when CUDA Driver dependencies are unavailable.
+    """
+
+    pass
+
+
 def _get_friendly_cuda_error_message(
     error_code: int, error_name: Union[str, bytes]
 ) -> tuple[str, str, Union[str, tuple[str, ...]]]:

--- a/python/CuTeDSL/cutlass/base_dsl/compiler.py
+++ b/python/CuTeDSL/cutlass/base_dsl/compiler.py
@@ -18,15 +18,12 @@ and executes it using MLIR's ExecutionEngine.
 from typing import Any
 import collections.abc
 import os
-import sys
 import inspect
+import importlib
 import types
 from .common import DSLRuntimeError
 from .utils.logger import log
 from .env_manager import EnvironmentVarManager
-
-_SCRIPT_PATH = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(_SCRIPT_PATH)
 
 from .._mlir import ir
 
@@ -477,11 +474,11 @@ class CompileOptions:
         ret = self.options[EnableTVMFFI].value
         if ret:
             try:
-                import tvm_ffi
-            except ModuleNotFoundError:
+                _ = importlib.import_module("tvm_ffi")
+            except Exception as e:
                 raise DSLRuntimeError(
                     "TVM FFI is not installed, please install it via `pip install apache-tvm-ffi`"
-                )
+                ) from e
         return ret
 
     def to_str(self) -> str:
@@ -521,7 +518,6 @@ def _parse_compile_options_from_str(options: str) -> CompileOptions:
         return mapping[option_str]
 
     import argparse
-    import shlex
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--opt-level", nargs="?", type=int, default=3)

--- a/python/CuTeDSL/cutlass/cute/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/__init__.py
@@ -149,6 +149,7 @@ from .tensor import (
     TensorSSA,
     ReductionOp,
     make_tensor,
+    as_position_independent_swizzle_tensor,
     make_identity_tensor,
     make_fragment,
     make_fragment_like,
@@ -286,6 +287,7 @@ __all__ = [
     # Tensor functions
     "make_ptr",
     "make_tensor",
+    "as_position_independent_swizzle_tensor",
     "make_identity_tensor",
     "make_fragment",
     "make_fragment_like",

--- a/python/CuTeDSL/cutlass/cute/algorithm.py
+++ b/python/CuTeDSL/cutlass/cute/algorithm.py
@@ -42,7 +42,6 @@ from .atom import (
     CopyAtom,
     make_atom,
     _normalize_variadic_tensor_operand,
-    copy_atom_call,
 )
 from .nvgpu.common import (
     CacheEvictionPriority,

--- a/python/CuTeDSL/cutlass/cute/algorithm.py
+++ b/python/CuTeDSL/cutlass/cute/algorithm.py
@@ -114,6 +114,16 @@ def gemm(
     a_list = _normalize_variadic_tensor_operand(a, "a")
     b_list = _normalize_variadic_tensor_operand(b, "b")
 
+    if atom.op.supports_operand_bundle(a_list, b_list):
+        return atom.op.gemm_with_operand_bundle(
+            atom, d, a_list, b_list, c, loc=loc, ip=ip
+        )
+    if len(a_list) != len(b_list):
+        raise ValueError(
+            "`a` and `b` must have the same number of tensor operands, "
+            f"but got {len(a_list)} and {len(b_list)}"
+        )
+
     # Rank validations based on the primary A/B tensors (guaranteed non-empty)
     a_rank = rank(a_list[0].shape)
     b_rank = rank(b_list[0].shape)

--- a/python/CuTeDSL/cutlass/cute/atom.py
+++ b/python/CuTeDSL/cutlass/cute/atom.py
@@ -914,6 +914,22 @@ class TiledCopy(CopyAtom):
             ip=ip,
         )
 
+    @dsl_user_op
+    def retile_D(
+        self,
+        src: Any,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Any:
+        """Return the destination-retiled copy view.
+
+        For the SM120 MXF4NVF4 LDSM tiled-copy path, Python CuTe's existing
+        `retile()` lowering is the verified destination-retile operation used
+        by the consumer fragment loader.
+        """
+        return self.retile(src, loc=loc, ip=ip)
+
 
 class ThrCopy(TiledCopy):
     """

--- a/python/CuTeDSL/cutlass/cute/atom.py
+++ b/python/CuTeDSL/cutlass/cute/atom.py
@@ -52,6 +52,30 @@ class MmaOp(Op, metaclass=ABCMeta):
     MMA Operation abstract base class.
     """
 
+    def supports_operand_bundle(self, a: List[Tensor], b: List[Tensor]) -> bool:
+        """
+        Return whether this MMA op accepts auxiliary register fragments bundled with A/B.
+        """
+        return False
+
+    def gemm_with_operand_bundle(
+        self,
+        atom: "MmaAtom",
+        d: Tensor,
+        a: List[Tensor],
+        b: List[Tensor],
+        c: Tensor,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """
+        Issue GEMM for MMA ops with auxiliary register fragments such as scale operands.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support GEMM operand bundles"
+        )
+
     @abstractmethod
     def _make_trait(
         self,

--- a/python/CuTeDSL/cutlass/cute/core.py
+++ b/python/CuTeDSL/cutlass/cute/core.py
@@ -3603,10 +3603,16 @@ def make_layout(
     shape_val = _pack_shape(shape, loc=loc, ip=ip)
     if stride is not None:
         stride_val = _pack_stride(stride, loc=loc, ip=ip)
-        layout_ty = _cute_ir.LayoutType.get(shape_val.type, stride_val.type)
+        try:
+            layout_ty = _cute_ir.LayoutType.get(shape_val.type, stride_val.type)
+        except TypeError:
+            layout_ty = _cute_ir.LayoutType.get(shape_val, stride_val)
     else:
         stride_val = None
-        layout_ty = _cute_ir.LayoutType.get(shape_val.type)
+        try:
+            layout_ty = _cute_ir.LayoutType.get(shape_val.type)
+        except TypeError:
+            layout_ty = _cute_ir.LayoutType.get(shape_val)
 
     return _cute_ir.make_layout(
         layout_ty, shape=shape_val, stride=stride_val, loc=loc, ip=ip

--- a/python/CuTeDSL/cutlass/cute/experimental/core.py
+++ b/python/CuTeDSL/cutlass/cute/experimental/core.py
@@ -32,6 +32,20 @@ class _SupportsIrValue(Protocol):
 SkipWaitToken: TypeAlias = bool | ir.Value | _SupportsIrValue
 
 
+def _safe_register_value_caster(typeid):
+    def _decorator(cls):
+        if typeid is None:
+            return cls
+        try:
+            return ir.register_value_caster(typeid)(cls)
+        except RuntimeError as exc:
+            if "already registered" in str(exc).lower():
+                return cls
+            raise
+
+    return _decorator
+
+
 @dsl_user_op
 def elect_sync(
     loc: Optional[ir.Location] = None, ip: Optional[ir.InsertionPoint] = None
@@ -51,7 +65,7 @@ def get_mbarrier(
     return cutlass_lir_ir.GetMbarrierOp(stage_token, loc=loc, ip=ip)
 
 
-@ir.register_value_caster(cutlass_lir_ir.PipelineStateType.get_static_typeid())
+@_safe_register_value_caster(cutlass_lir_ir.PipelineStateType.get_static_typeid())
 class PipelineState(ir.Value):
     def __init__(self, value: ir.Value) -> None:
         if isinstance(value, ir.Value):
@@ -372,8 +386,10 @@ def get_pipeline_consume_stage(
     return op.stage_token, op.stage_index
 
 
-@ir.register_value_caster(
+@_safe_register_value_caster(
     cutlass_lir_ir.CircularBufferPipelineStateType.get_static_typeid()
+    if hasattr(cutlass_lir_ir, "CircularBufferPipelineStateType")
+    else None
 )
 class CircularBufferPipelineState(ir.Value):
     def __init__(self, value: ir.Value) -> None:

--- a/python/CuTeDSL/cutlass/cute/experimental/math.py
+++ b/python/CuTeDSL/cutlass/cute/experimental/math.py
@@ -28,6 +28,10 @@ def dot_block_scaled(
     loc: Optional[ir.Location] = None,
     ip: Optional[ir.InsertionPoint] = None,
 ) -> None:
+    if mma_atom.op.supports_operand_bundle([a, sfa], [b, sfb]):
+        return mma_atom.op.gemm_with_operand_bundle(
+            mma_atom, c, [a, sfa], [b, sfb], c, loc=loc, ip=ip
+        )
     cutlass_lir.DotBlockScaledOp(
         mma_atom._unpack(),
         a.value,
@@ -57,5 +61,4 @@ def dot(
         loc=loc,
         ip=ip,
     )
-
 

--- a/python/CuTeDSL/cutlass/cute/nvgpu/common.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/common.py
@@ -17,6 +17,7 @@ from cutlass.cutlass_dsl import DSLBaseError, DSLRuntimeError
 
 import cutlass._mlir.dialects.cute as _cute_ir
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
+import cutlass._mlir.dialects.nvvm as _nvvm_ir
 from cutlass._mlir import ir
 
 from .. import atom
@@ -272,12 +273,18 @@ class MemoryScope(enum.Enum):
         return self.value
 
 
+if hasattr(_cute_ir, "L2PrefetchSize"):
+    _L2PrefetchSize = _cute_ir.L2PrefetchSize
+else:
+    _L2PrefetchSize = _nvvm_ir.L2PrefetchSize
+
+
 class L2PrefetchSize(enum.Enum):
-    NONE = _cute_ir.L2PrefetchSize.NONE
-    RESERVED = _cute_ir.L2PrefetchSize.RESERVED
-    SIZE_64B = _cute_ir.L2PrefetchSize.SIZE_64B
-    SIZE_128B = _cute_ir.L2PrefetchSize.SIZE_128B
-    SIZE_256B = _cute_ir.L2PrefetchSize.SIZE_256B
+    NONE = _L2PrefetchSize.NONE
+    RESERVED = _L2PrefetchSize.RESERVED
+    SIZE_64B = _L2PrefetchSize.SIZE_64B
+    SIZE_128B = _L2PrefetchSize.SIZE_128B
+    SIZE_256B = _L2PrefetchSize.SIZE_256B
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
@@ -285,7 +292,7 @@ class L2PrefetchSize(enum.Enum):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}.{self.name}>"
 
-    def _to_ir(self) -> _cute_ir.L2PrefetchSize:
+    def _to_ir(self) -> _L2PrefetchSize:
         return self.value
 
 
@@ -323,12 +330,23 @@ class LoadCacheMode(enum.Enum):
         return self.value
 
 
+if hasattr(_cute_nvgpu_ir, "StoreCacheMode"):
+    _StoreCacheMode = _cute_nvgpu_ir.StoreCacheMode
+else:
+    class _StoreCacheMode(enum.Enum):
+        write_back = "write_back"
+        global_ = "global"
+        streaming = "streaming"
+        write_through = "write_through"
+        none = "none"
+
+
 class StoreCacheMode(enum.Enum):
-    WRITE_BACK = _cute_nvgpu_ir.StoreCacheMode.write_back
-    GLOBAL = _cute_nvgpu_ir.StoreCacheMode.global_
-    STREAMING = _cute_nvgpu_ir.StoreCacheMode.streaming
-    WRITE_THROUGH = _cute_nvgpu_ir.StoreCacheMode.write_through
-    NONE = _cute_nvgpu_ir.StoreCacheMode.none
+    WRITE_BACK = _StoreCacheMode.write_back
+    GLOBAL = _StoreCacheMode.global_
+    STREAMING = _StoreCacheMode.streaming
+    WRITE_THROUGH = _StoreCacheMode.write_through
+    NONE = _StoreCacheMode.none
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
@@ -336,13 +354,21 @@ class StoreCacheMode(enum.Enum):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}.{self.name}>"
 
-    def _to_ir(self) -> _cute_nvgpu_ir.StoreCacheMode:
+    def _to_ir(self) -> _StoreCacheMode:
         return self.value
 
 
 class SharedSpace(enum.Enum):
-    CTA = _cute_nvgpu_ir.SharedSpace.CTA
-    CLUSTER = _cute_nvgpu_ir.SharedSpace.CLUSTER
+    CTA = (
+        _cute_nvgpu_ir.SharedSpace.CTA
+        if hasattr(_cute_nvgpu_ir, "SharedSpace")
+        else _nvvm_ir.SharedSpace.shared_cta
+    )
+    CLUSTER = (
+        _cute_nvgpu_ir.SharedSpace.CLUSTER
+        if hasattr(_cute_nvgpu_ir, "SharedSpace")
+        else _nvvm_ir.SharedSpace.shared_cluster
+    )
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
@@ -350,7 +376,7 @@ class SharedSpace(enum.Enum):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}.{self.name}>"
 
-    def _to_ir(self) -> _cute_nvgpu_ir.SharedSpace:
+    def _to_ir(self) -> Any:
         return self.value
 
 

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "TmaInfo",
     "make_tiled_tma_atom",
     "tma_partition",
+    "tma_partition_s2g_tile",
     "create_tma_multicast_mask",
     "prefetch_descriptor",
     "copy_tensormap",

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/__init__.py
@@ -44,5 +44,8 @@ __all__ = [
     "fence_tma_desc_acquire",
     "cp_fence_tma_desc_release",
     "fence_tma_desc_release",
+    "sm120_tma_load_2d",
+    "sm120_tma_load_3d",
+    "sm120_tma_load_4d",
     "group_bulk_copy_modes",
 ]

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/copy.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/copy.py
@@ -18,6 +18,7 @@ from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import BaseDSL
 
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
+from cutlass._mlir.dialects import llvm
 from cutlass._mlir.dialects.nvvm import ReductionOp as ReductionOp
 from cutlass._mlir import ir
 
@@ -33,6 +34,26 @@ from ..tcgen05.mma import CtaGroup
 # Asynchronous copies
 #
 ####################################################################################################
+
+
+def _fence_tma_desc_acquire(
+    tma_desc_ptr: Pointer,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    tma_desc_ptr_i64 = tma_desc_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    llvm.inline_asm(
+        None,
+        [tma_desc_ptr_i64],
+        "fence.proxy.tensormap::generic.acquire.gpu [$0], 128;",
+        "l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
 
 
 @deprecated(
@@ -270,6 +291,7 @@ class CopyBulkTensorTileG2SNonExecTrait(Trait):
 
         The non-multicast TMA load requires a `tma_bar_ptr` keyword argument to be provided when
         using `cute.copy`. `cache_policy` keyword argument to be provided to set the l2 cache eviction priority.
+        When `tma_desc_ptr` is provided, this path emits a tensor-map acquire fence before the copy.
         Any other kw arguments will be ignored instead of triggering an error.
         """
         if not isinstance(tma_bar_ptr, Pointer):
@@ -283,6 +305,7 @@ class CopyBulkTensorTileG2SNonExecTrait(Trait):
             exec_value, attr, tma_bar_ptr.value, loc=loc, ip=ip
         )
         if isinstance(tma_desc_ptr, Pointer):
+            _fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
             attr_str = f"#cute_nvgpu.atom_copy_field_tmaload<{TMA_DESC_PTR_FIELD_NAME}>"
             attr = ir.Attribute.parse(attr_str)
             exec_value = _cute_nvgpu_ir.atom_set_value(
@@ -394,6 +417,7 @@ class CopyBulkTensorIm2ColG2SNonExecTrait(Trait):
 
         The non-multicast TMA load requires a `tma_bar_ptr` keyword argument to be provided when
         using `cute.copy`. `cache_policy` keyword argument to be provided to set the l2 cache eviction priority.
+        When `tma_desc_ptr` is provided, this path emits a tensor-map acquire fence before the copy.
         Any other kw arguments will be ignored instead of triggering an error.
         """
         if not isinstance(tma_bar_ptr, Pointer):
@@ -412,6 +436,7 @@ class CopyBulkTensorIm2ColG2SNonExecTrait(Trait):
             exec_value, attr, tma_bar_ptr.value, loc=loc, ip=ip
         )
         if isinstance(tma_desc_ptr, Pointer):
+            _fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
             attr_str = f"#cute_nvgpu.atom_copy_field_tmaload<{TMA_DESC_PTR_FIELD_NAME}>"
             attr = ir.Attribute.parse(attr_str)
             exec_value = _cute_nvgpu_ir.atom_set_value(
@@ -527,7 +552,8 @@ class CopyBulkTensorIm2ColG2SMulticastNonExecTrait(Trait):
 
         The multicast TMA load requires a `tma_bar_ptr`  and a `mcast_mask` keyword arguments to be
         provided when using `cute.copy`. `cache_policy` keyword argument to be provided to set the
-        l2 cache eviction priority.
+        l2 cache eviction priority. When `tma_desc_ptr` is provided, this path emits a tensor-map
+        acquire fence before the copy.
         """
         if not isinstance(tma_bar_ptr, Pointer):
             raise ValueError(
@@ -549,6 +575,7 @@ class CopyBulkTensorIm2ColG2SMulticastNonExecTrait(Trait):
             exec_value, attr, Int16(mcast_mask).ir_value(loc=loc, ip=ip), loc=loc, ip=ip
         )
         if isinstance(tma_desc_ptr, Pointer):
+            _fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
             attr_str = f"#cute_nvgpu.atom_copy_field_tmaload<{TMA_DESC_PTR_FIELD_NAME}>"
             attr = ir.Attribute.parse(attr_str)
             exec_value = _cute_nvgpu_ir.atom_set_value(
@@ -780,7 +807,8 @@ class CopyBulkTensorTileG2SMulticastNonExecTrait(Trait):
 
         The multicast TMA load requires a `tma_bar_ptr`  and a `mcast_mask` keyword arguments to be
         provided when using `cute.copy`. `cache_policy` keyword argument to be provided to set the
-        l2 cache eviction priority.
+        l2 cache eviction priority. When `tma_desc_ptr` is provided, this path emits a tensor-map
+        acquire fence before the copy.
         """
         if not isinstance(tma_bar_ptr, Pointer):
             raise ValueError(
@@ -797,6 +825,7 @@ class CopyBulkTensorTileG2SMulticastNonExecTrait(Trait):
             exec_value, attr, Int16(mcast_mask).ir_value(loc=loc, ip=ip), loc=loc, ip=ip
         )
         if isinstance(tma_desc_ptr, Pointer):
+            _fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
             attr_str = f"#cute_nvgpu.atom_copy_field_tmaload<{TMA_DESC_PTR_FIELD_NAME}>"
             attr = ir.Attribute.parse(attr_str)
             exec_value = _cute_nvgpu_ir.atom_set_value(
@@ -1540,5 +1569,3 @@ class CopyDsmemStoreTrait(Trait):
             ip=ip,
         )
         return val
-
-

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
@@ -175,6 +175,22 @@ TMAOp = Union[
 ]
 
 
+_S2G_TMA_PARTITION_ERROR = (
+    "S2G TMA store partition failed. For tiled S2G TMA store atoms, the "
+    "GMEM tensor passed to cpasync.tma_partition should be derived from the "
+    "TMA tensor returned by cpasync.make_tiled_tma_atom(...), not from a "
+    "manually tiled view of the original GMEM tensor. If the returned TMA "
+    "tensor was already used, this is likely an internal verifier/lowering "
+    "issue for the S2G TMA store partition path."
+)
+
+
+def _is_s2g_tma_atom(copy_atom: atom.CopyAtom) -> bool:
+    return isinstance(
+        copy_atom.op, (CopyBulkTensorTileS2GOp, CopyReduceBulkTensorTileS2GOp)
+    )
+
+
 def _check_sm120_tma_load_supported() -> None:
     BaseDSL._get_dsl().check_arch(lambda arch: arch >= Arch.sm_120)
 
@@ -802,6 +818,27 @@ def make_tiled_tma_atom(
        TMA unit. TMA tensors contain basis stride elements that enable their associated layout to \
        compute coordinates. Like other CuTe tensors, TMA tensors can be partitioned.
 
+    For S2G TMA stores, partition the returned TMA tensor instead of a manually
+    tiled view of the original GMEM tensor. The returned tensor carries the TMA
+    basis layout required by the non-exec tiled TMA store atom. For example::
+
+        tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(), d, epi_smem_layout, d_cta_tiler
+        )
+        tD_mn = tma_tensor_d[None, None, batch_idx]
+        tD_tile = cute.local_tile(tD_mn, tile_shape_mn, tile_coord_mn)
+        tD_epi = cute.flat_divide(tD_tile, epi_tile)
+        tDsD, tDgD = cpasync.tma_partition(
+            tma_atom_d,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sD, 0, 2),
+            cute.group_modes(tD_epi, 0, 2),
+        )
+
+    :func:`tma_partition_s2g_tile` wraps this recipe for common epilogue-store
+    tiles.
+
     :param op:            The TMA Copy Operation to construct an Atom
     :type op:             TMAOp
     :param gmem_tensor:   The GMEM tensor involved in the Copy
@@ -952,27 +989,85 @@ def tma_partition(
     """
     cta_coord_val = core._pack_coord(cta_coord, loc=loc, ip=ip)
     gmem_keyword = _atom_tma_partition_gmem_keyword()
-    if gmem_keyword == "gmem_tensor":
-        s, d = _cute_nvgpu_ir.atom_tma_partition(
-            atom._trait.value,
-            cta_coord=cta_coord_val,
-            cta_layout=cta_layout,
-            smem_tensor=cast(Any, smem_tensor).value,
-            gmem_tensor=cast(Any, gmem_tensor).value,
-            loc=loc,
-            ip=ip,
-        )
-    else:
-        s, d = _cute_nvgpu_ir.atom_tma_partition(
-            atom._trait.value,
-            cta_coord=cta_coord_val,
-            cta_layout=cta_layout,
-            smem_tensor=cast(Any, smem_tensor).value,
-            target_tensors=[cast(Any, gmem_tensor).value],
-            loc=loc,
-            ip=ip,
-        )
+    try:
+        if gmem_keyword == "gmem_tensor":
+            s, d = _cute_nvgpu_ir.atom_tma_partition(
+                atom._trait.value,
+                cta_coord=cta_coord_val,
+                cta_layout=cta_layout,
+                smem_tensor=cast(Any, smem_tensor).value,
+                gmem_tensor=cast(Any, gmem_tensor).value,
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            s, d = _cute_nvgpu_ir.atom_tma_partition(
+                atom._trait.value,
+                cta_coord=cta_coord_val,
+                cta_layout=cta_layout,
+                smem_tensor=cast(Any, smem_tensor).value,
+                target_tensors=[cast(Any, gmem_tensor).value],
+                loc=loc,
+                ip=ip,
+            )
+    except ValueError as exc:
+        if _is_s2g_tma_atom(atom):
+            raise ValueError(_S2G_TMA_PARTITION_ERROR) from exc
+        raise
     return s, d
+
+
+@dsl_user_op
+def tma_partition_s2g_tile(
+    tma_atom: atom.CopyAtom,
+    tma_tensor: Tensor,
+    smem_tensor: Tensor,
+    tile_shape_mn: Tiler,
+    epi_tile: Tiler,
+    tile_coord_mnkl: Coord,
+    *,
+    cta_coord: Coord = 0,
+    cta_layout: Optional[Layout] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[Tensor, Tensor]:
+    """
+    Partition one rank-3 MN/L S2G TMA epilogue-store tile.
+
+    ``tma_tensor`` must be the tensor returned by
+    :func:`make_tiled_tma_atom` for ``tma_atom``. This helper intentionally
+    derives the GMEM partition from that tensor, not from the original GMEM
+    output tensor, so the partition carries the TMA basis layout required by
+    non-exec tiled TMA store atoms. ``tile_coord_mnkl`` follows the GEMM
+    epilogue tile-coordinate convention; this helper uses its M/N entries to
+    select the tile and its L entry to select the rank-3 output batch.
+    """
+    if not _is_s2g_tma_atom(tma_atom):
+        raise ValueError(
+            "tma_partition_s2g_tile expects a CopyBulkTensorTileS2GOp or "
+            "CopyReduceBulkTensorTileS2GOp atom"
+        )
+    if core.rank(tile_coord_mnkl) < 4:
+        raise ValueError(
+            "tile_coord_mnkl must have at least four modes (M, N, K, L), "
+            f"but got {core.pretty_str(tile_coord_mnkl)}"
+        )
+    tD_mn = tma_tensor[None, None, tile_coord_mnkl[3]]
+    tD_tile = core.local_tile(
+        tD_mn, tile_shape_mn, tile_coord_mnkl[:2], loc=loc, ip=ip
+    )
+    tD_epi = core.flat_divide(tD_tile, epi_tile, loc=loc, ip=ip)
+    if cta_layout is None:
+        cta_layout = core.make_layout(1, loc=loc, ip=ip)
+    return tma_partition(
+        tma_atom,
+        cta_coord,
+        cta_layout,
+        core.group_modes(smem_tensor, 0, 2, loc=loc, ip=ip),
+        core.group_modes(tD_epi, 0, 2, loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
 
 
 @dsl_user_op

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
@@ -9,6 +9,8 @@
 # and related documentation outside the scope permitted by the EULA
 # is strictly prohibited.
 
+import inspect
+from functools import lru_cache
 from typing import Any, Iterator, List, Optional, Tuple, Type, Union, cast
 from typing_extensions import deprecated
 
@@ -201,6 +203,19 @@ def _sm120_tma_ptx(rank: int, *, tile_mode: bool, cache_policy: bool) -> str:
 
 def _sm120_coord_asm(rank: int) -> str:
     return "{" + ", ".join(f"${i}" for i in range(2, 2 + rank)) + "}"
+
+
+@lru_cache(maxsize=1)
+def _atom_tma_partition_gmem_keyword() -> str:
+    params = inspect.signature(_cute_nvgpu_ir.atom_tma_partition).parameters
+    if "gmem_tensor" in params:
+        return "gmem_tensor"
+    if "target_tensors" in params:
+        return "target_tensors"
+    raise TypeError(
+        "atom_tma_partition binding exposes neither `gmem_tensor` nor "
+        "`target_tensors`"
+    )
 
 
 @dsl_user_op
@@ -936,15 +951,27 @@ def tma_partition(
     Tiles the GMEM and SMEM tensors for the provided TMA Copy Atom.
     """
     cta_coord_val = core._pack_coord(cta_coord, loc=loc, ip=ip)
-    s, d = _cute_nvgpu_ir.atom_tma_partition(
-        atom._trait.value,
-        cta_coord=cta_coord_val,
-        cta_layout=cta_layout,
-        smem_tensor=cast(Any, smem_tensor).value,
-        target_tensors=[cast(Any, gmem_tensor).value],
-        loc=loc,
-        ip=ip,
-    )
+    gmem_keyword = _atom_tma_partition_gmem_keyword()
+    if gmem_keyword == "gmem_tensor":
+        s, d = _cute_nvgpu_ir.atom_tma_partition(
+            atom._trait.value,
+            cta_coord=cta_coord_val,
+            cta_layout=cta_layout,
+            smem_tensor=cast(Any, smem_tensor).value,
+            gmem_tensor=cast(Any, gmem_tensor).value,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        s, d = _cute_nvgpu_ir.atom_tma_partition(
+            atom._trait.value,
+            cta_coord=cta_coord_val,
+            cta_layout=cta_layout,
+            smem_tensor=cast(Any, smem_tensor).value,
+            target_tensors=[cast(Any, gmem_tensor).value],
+            loc=loc,
+            ip=ip,
+        )
     return s, d
 
 

--- a/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/cpasync/helpers.py
@@ -12,7 +12,10 @@
 from typing import Any, Iterator, List, Optional, Tuple, Type, Union, cast
 from typing_extensions import deprecated
 
+from cutlass import const_expr
+from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import (
+    BaseDSL,
     dsl_user_op,
     extract_mlir_attributes,
     extract_mlir_values,
@@ -31,10 +34,14 @@ from ...typing import (
     Tiler,
     Pointer,
     Int16,
+    Int32,
+    Int64,
     Numeric,
     NumericMeta,
     IntTuple,
+    AddressSpace,
 )
+from ... import arch as cute_arch
 from ... import core, atom
 from .copy import (
     CopyBulkTensorTileG2SOp,
@@ -164,6 +171,354 @@ TMAOp = Union[
     CopyBulkTensorIm2ColS2GOp,
     CopyReduceBulkTensorTileS2GOp,
 ]
+
+
+def _check_sm120_tma_load_supported() -> None:
+    BaseDSL._get_dsl().check_arch(lambda arch: arch >= Arch.sm_120)
+
+
+def _check_pointer_address_space(
+    ptr: Pointer,
+    expected: Tuple[AddressSpace, ...],
+    name: str,
+) -> None:
+    memspace = ptr.memspace
+    if memspace not in expected:
+        expected_names = ", ".join(space.name for space in expected)
+        raise ValueError(
+            f"`{name}` must be in address space {expected_names}, but got {memspace.name}"
+        )
+
+
+def _sm120_tma_ptx(rank: int, *, tile_mode: bool, cache_policy: bool) -> str:
+    tile = ".tile" if tile_mode else ""
+    cache = ".L2::cache_hint" if cache_policy else ""
+    return (
+        f"cp.async.bulk.tensor.{rank}d.shared::cta.global{tile}"
+        f".mbarrier::complete_tx::bytes{cache}"
+    )
+
+
+def _sm120_coord_asm(rank: int) -> str:
+    return "{" + ", ".join(f"${i}" for i in range(2, 2 + rank)) + "}"
+
+
+@dsl_user_op
+def _sm120_issue_tma_load_2d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    tile_mode: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    _check_sm120_tma_load_supported()
+    fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
+    dst_smem_i32 = dst_smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    tma_desc_i64 = tma_desc_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    coord0_i32 = Int32(coord0).ir_value(loc=loc, ip=ip)
+    coord1_i32 = Int32(coord1).ir_value(loc=loc, ip=ip)
+    tma_bar_i32 = tma_bar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    ptx = _sm120_tma_ptx(2, tile_mode=tile_mode, cache_policy=cache_policy is not None)
+    operands = [dst_smem_i32, tma_desc_i64, coord0_i32, coord1_i32, tma_bar_i32]
+    if cache_policy is None:
+        asm = f"{ptx} [$0], [$1, {_sm120_coord_asm(2)}], [$4];"
+        constraints = "r,l,r,r,r"
+    else:
+        operands.append(Int64(cache_policy).ir_value(loc=loc, ip=ip))
+        asm = f"{ptx} [$0], [$1, {_sm120_coord_asm(2)}], [$4], $5;"
+        constraints = "r,l,r,r,r,l"
+    llvm.inline_asm(
+        None,
+        operands,
+        asm,
+        constraints,
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _sm120_issue_tma_load_3d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    tile_mode: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    _check_sm120_tma_load_supported()
+    fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
+    dst_smem_i32 = dst_smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    tma_desc_i64 = tma_desc_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    coord0_i32 = Int32(coord0).ir_value(loc=loc, ip=ip)
+    coord1_i32 = Int32(coord1).ir_value(loc=loc, ip=ip)
+    coord2_i32 = Int32(coord2).ir_value(loc=loc, ip=ip)
+    tma_bar_i32 = tma_bar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    ptx = _sm120_tma_ptx(3, tile_mode=tile_mode, cache_policy=cache_policy is not None)
+    operands = [
+        dst_smem_i32,
+        tma_desc_i64,
+        coord0_i32,
+        coord1_i32,
+        coord2_i32,
+        tma_bar_i32,
+    ]
+    if cache_policy is None:
+        asm = f"{ptx} [$0], [$1, {_sm120_coord_asm(3)}], [$5];"
+        constraints = "r,l,r,r,r,r"
+    else:
+        operands.append(Int64(cache_policy).ir_value(loc=loc, ip=ip))
+        asm = f"{ptx} [$0], [$1, {_sm120_coord_asm(3)}], [$5], $6;"
+        constraints = "r,l,r,r,r,r,l"
+    llvm.inline_asm(
+        None,
+        operands,
+        asm,
+        constraints,
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _sm120_issue_tma_load_4d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    coord3: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    tile_mode: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    _check_sm120_tma_load_supported()
+    fence_tma_desc_acquire(tma_desc_ptr, loc=loc, ip=ip)
+    dst_smem_i32 = dst_smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    tma_desc_i64 = tma_desc_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    coord0_i32 = Int32(coord0).ir_value(loc=loc, ip=ip)
+    coord1_i32 = Int32(coord1).ir_value(loc=loc, ip=ip)
+    coord2_i32 = Int32(coord2).ir_value(loc=loc, ip=ip)
+    coord3_i32 = Int32(coord3).ir_value(loc=loc, ip=ip)
+    tma_bar_i32 = tma_bar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    ptx = _sm120_tma_ptx(4, tile_mode=tile_mode, cache_policy=cache_policy is not None)
+    operands = [
+        dst_smem_i32,
+        tma_desc_i64,
+        coord0_i32,
+        coord1_i32,
+        coord2_i32,
+        coord3_i32,
+        tma_bar_i32,
+    ]
+    if cache_policy is None:
+        asm = f"{ptx} [$0], [$1, {_sm120_coord_asm(4)}], [$6];"
+        constraints = "r,l,r,r,r,r,r"
+    else:
+        operands.append(Int64(cache_policy).ir_value(loc=loc, ip=ip))
+        asm = f"{ptx} [$0], [$1, {_sm120_coord_asm(4)}], [$6], $7;"
+        constraints = "r,l,r,r,r,r,r,l"
+    llvm.inline_asm(
+        None,
+        operands,
+        asm,
+        constraints,
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def sm120_tma_load_2d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue a CTA-local SM120 rank-2 TMA load from an external descriptor.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    The destination and barrier pointers must be shared-memory pointers. The descriptor pointer must address
+    global or generic memory containing a 128-byte tensor-map descriptor. This helper issues a
+    ``fence.proxy.tensormap::generic.acquire.gpu`` before the TMA instruction so descriptor bytes written
+    before the call are visible to the async/TMA proxy.
+    """
+    _check_pointer_address_space(dst_smem_ptr, (AddressSpace.smem,), "dst_smem_ptr")
+    _check_pointer_address_space(
+        tma_desc_ptr, (AddressSpace.gmem, AddressSpace.generic), "tma_desc_ptr"
+    )
+    _check_pointer_address_space(tma_bar_ptr, (AddressSpace.smem,), "tma_bar_ptr")
+    if const_expr(already_elected):
+        _sm120_issue_tma_load_2d(
+            dst_smem_ptr,
+            tma_desc_ptr,
+            tma_bar_ptr,
+            coord0,
+            coord1,
+            cache_policy=cache_policy,
+            tile_mode=tile_mode,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        with cute_arch.elect_one(loc=loc, ip=ip):
+            _sm120_issue_tma_load_2d(
+                dst_smem_ptr,
+                tma_desc_ptr,
+                tma_bar_ptr,
+                coord0,
+                coord1,
+                cache_policy=cache_policy,
+                tile_mode=tile_mode,
+                loc=loc,
+                ip=ip,
+            )
+
+
+@dsl_user_op
+def sm120_tma_load_3d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue a CTA-local SM120 rank-3 TMA load from an external descriptor.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    The destination and barrier pointers must be shared-memory pointers. The descriptor pointer must address
+    global or generic memory containing a 128-byte tensor-map descriptor. This helper issues a
+    ``fence.proxy.tensormap::generic.acquire.gpu`` before the TMA instruction so descriptor bytes written
+    before the call are visible to the async/TMA proxy.
+    """
+    _check_pointer_address_space(dst_smem_ptr, (AddressSpace.smem,), "dst_smem_ptr")
+    _check_pointer_address_space(
+        tma_desc_ptr, (AddressSpace.gmem, AddressSpace.generic), "tma_desc_ptr"
+    )
+    _check_pointer_address_space(tma_bar_ptr, (AddressSpace.smem,), "tma_bar_ptr")
+    if const_expr(already_elected):
+        _sm120_issue_tma_load_3d(
+            dst_smem_ptr,
+            tma_desc_ptr,
+            tma_bar_ptr,
+            coord0,
+            coord1,
+            coord2,
+            cache_policy=cache_policy,
+            tile_mode=tile_mode,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        with cute_arch.elect_one(loc=loc, ip=ip):
+            _sm120_issue_tma_load_3d(
+                dst_smem_ptr,
+                tma_desc_ptr,
+                tma_bar_ptr,
+                coord0,
+                coord1,
+                coord2,
+                cache_policy=cache_policy,
+                tile_mode=tile_mode,
+                loc=loc,
+                ip=ip,
+            )
+
+
+@dsl_user_op
+def sm120_tma_load_4d(
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    tma_bar_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    coord3: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue a CTA-local SM120 rank-4 TMA load from an external descriptor.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    The destination and barrier pointers must be shared-memory pointers. The descriptor pointer must address
+    global or generic memory containing a 128-byte tensor-map descriptor. This helper issues a
+    ``fence.proxy.tensormap::generic.acquire.gpu`` before the TMA instruction so descriptor bytes written
+    before the call are visible to the async/TMA proxy.
+    """
+    _check_pointer_address_space(dst_smem_ptr, (AddressSpace.smem,), "dst_smem_ptr")
+    _check_pointer_address_space(
+        tma_desc_ptr, (AddressSpace.gmem, AddressSpace.generic), "tma_desc_ptr"
+    )
+    _check_pointer_address_space(tma_bar_ptr, (AddressSpace.smem,), "tma_bar_ptr")
+    if const_expr(already_elected):
+        _sm120_issue_tma_load_4d(
+            dst_smem_ptr,
+            tma_desc_ptr,
+            tma_bar_ptr,
+            coord0,
+            coord1,
+            coord2,
+            coord3,
+            cache_policy=cache_policy,
+            tile_mode=tile_mode,
+            loc=loc,
+            ip=ip,
+        )
+    else:
+        with cute_arch.elect_one(loc=loc, ip=ip):
+            _sm120_issue_tma_load_4d(
+                dst_smem_ptr,
+                tma_desc_ptr,
+                tma_bar_ptr,
+                coord0,
+                coord1,
+                coord2,
+                coord3,
+                cache_policy=cache_policy,
+                tile_mode=tile_mode,
+                loc=loc,
+                ip=ip,
+            )
 
 
 @dsl_user_op

--- a/python/CuTeDSL/cutlass/cute/nvgpu/warp/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/warp/__init__.py
@@ -21,6 +21,11 @@ __all__ = [
     "MmaFP8Op",
     "MmaMXF4Op",
     "MmaMXF4NVF4Op",
+    "make_mxf4nvf4_sfa_layout",
+    "make_mxf4nvf4_sfb_layout",
+    "make_mxf4nvf4_sfa_fragment",
+    "make_mxf4nvf4_sfb_fragment",
+    "mma_unpack",
     # copy.py
     "LdMatrix8x8x16bOp",
     "LdMatrix16x8x8bOp",

--- a/python/CuTeDSL/cutlass/cute/nvgpu/warp/mma.py
+++ b/python/CuTeDSL/cutlass/cute/nvgpu/warp/mma.py
@@ -10,14 +10,15 @@
 # is strictly prohibited.
 
 from dataclasses import dataclass
-from typing import Any, Optional, Type
+from typing import Any, List, Optional, Tuple, Type, Union
 
 import enum
+from cutlass import cute
 from cutlass.base_dsl.arch import Arch
-from cutlass.cutlass_dsl import BaseDSL
+from cutlass.cutlass_dsl import BaseDSL, dsl_user_op
 
 
-from ..common import OpError
+from ..common import OpError, normalize_field_to_ir_name
 from ...typing import (
     Shape,
     Float4E2M1FN,
@@ -27,6 +28,8 @@ from ...typing import (
     Float16,
     BFloat16,
     Float32,
+    Boolean,
+    Int32,
     Numeric,
     Pointer,
 )
@@ -35,6 +38,7 @@ from ...typing import Tensor
 from ...atom import MmaOp, Trait, make_atom
 
 from cutlass._mlir import ir
+import cutlass._mlir.dialects.cute as _cute_ir
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
 
 
@@ -207,7 +211,6 @@ class MmaFP8Op(WarpMmaOp):
     ) -> None:
         pass
 
-
 class MmaFP8Trait(Trait):
     pass
 
@@ -301,6 +304,32 @@ class MmaSM120BlockScaledOp(MmaOp):
     ) -> None:
         pass
 
+    def supports_operand_bundle(self, a: List[Tensor], b: List[Tensor]) -> bool:
+        return (
+            len(a) == 2
+            and len(b) == 2
+            and self.shape_mnk == (16, 8, 64)
+            and self.ab_dtype == Float4E2M1FN
+            and self.acc_dtype == Float32
+            and self.sf_type == Float8E4M3FN
+            and self.sf_vec_size == 16
+        )
+
+    def gemm_with_operand_bundle(
+        self,
+        atom: cute.MmaAtom,
+        d: Tensor,
+        a: List[Tensor],
+        b: List[Tensor],
+        c: Tensor,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        if not self.supports_operand_bundle(a, b):
+            raise TypeError(f"{self} does not support GEMM operand bundles")
+        return mma_unpack(atom, d, a, b, c, loc=loc, ip=ip)
+
 
 class Field(enum.Enum):
     """
@@ -323,9 +352,13 @@ class Field(enum.Enum):
 
 class MmaBlockScaledTrait(Trait):
     admissible_fields = [
+        Field.ACCUMULATE,
         Field.SFA,
         Field.SFB,
     ]
+
+    def _normalize_field_name(self, field: Any) -> str:
+        return normalize_field_to_ir_name(field, self.admissible_fields)
 
     def set(
         self,
@@ -335,22 +368,28 @@ class MmaBlockScaledTrait(Trait):
         loc: Optional[ir.Location] = None,
         ip: Optional[ir.InsertionPoint] = None,
     ) -> None:
-        if field not in self.admissible_fields:
-            raise ValueError(
-                f"expects field to be one of {self.admissible_fields}, but got {field}"
-            )
-        if field in [Field.SFA, Field.SFB]:
+        field_ir_name = self._normalize_field_name(field)
+        if field_ir_name == Field.ACCUMULATE.value:
+            value = Boolean(value).ir_value(loc=loc, ip=ip)
+        elif field_ir_name in [Field.SFA.value, Field.SFB.value]:
             if not isinstance(value, Pointer):
                 raise ValueError(
                     f"expects value to be a pointer for {field}, but got {type(value).__name__}"
                 )
             value = value.value
 
-        field_name = f"#cute_nvgpu.atom_mma_field_sm120_block_scaled<{field._to_ir_field_name()}>"
-        attr = ir.Attribute.parse(field_name)
-        self.value = _cute_nvgpu_ir.atom_set_value(
-            self.value, attr, value, loc=loc, ip=ip
-        )
+        try:
+            self.value = _cute_nvgpu_ir.atom_set_value(
+                self.value, field_ir_name, value, loc=loc, ip=ip
+            )
+        except (TypeError, AttributeError):
+            field_name = (
+                f"#cute_nvgpu.atom_mma_field_sm120_block_scaled<{field_ir_name}>"
+            )
+            attr = ir.Attribute.parse(field_name)
+            self.value = _cute_nvgpu_ir.atom_set_value(
+                self.value, attr, value, loc=loc, ip=ip
+            )
 
     def get(
         self,
@@ -359,7 +398,21 @@ class MmaBlockScaledTrait(Trait):
         loc: Optional[ir.Location] = None,
         ip: Optional[ir.InsertionPoint] = None,
     ) -> Any:
-        raise ValueError(f"the get method for {field} is not supported")
+        field_ir_name = self._normalize_field_name(field)
+        if field_ir_name != Field.ACCUMULATE.value:
+            raise ValueError(f"the get method for {field} is not supported")
+        try:
+            return _cute_nvgpu_ir.atom_get_value(
+                Boolean.mlir_type, self.value, field_ir_name, loc=loc, ip=ip
+            )
+        except (TypeError, AttributeError):
+            field_name = (
+                f"#cute_nvgpu.atom_mma_field_sm120_block_scaled<{field_ir_name}>"
+            )
+            attr = ir.Attribute.parse(field_name)
+            return _cute_nvgpu_ir.atom_get_value(
+                Boolean.mlir_type, self.value, attr, loc=loc, ip=ip
+            )
 
 
 #
@@ -474,3 +527,229 @@ class MmaMXF4NVF4Op(MmaSM120BlockScaledOp):
 
 class MmaMXF4NVF4Trait(MmaBlockScaledTrait):
     pass
+
+
+def _normalize_mxf4nvf4_operand(
+    operand: Union[List[Tensor], Tuple[Tensor, ...]],
+    name: str,
+) -> Tuple[Tensor, Tensor]:
+    if not isinstance(operand, (list, tuple)) or len(operand) != 2:
+        raise TypeError(f"`{name}` must be a two-tensor sequence `(fragment, scale)`")
+    fragment, scale = operand
+    if not isinstance(fragment, Tensor) or not isinstance(scale, Tensor):
+        raise TypeError(f"`{name}` must contain only Tensor operands")
+    return fragment, scale
+
+
+def _require_rmem(tensor: Tensor, name: str) -> None:
+    if tensor.memspace != cute.AddressSpace.rmem:
+        raise ValueError(f"`{name}` must be register-resident")
+
+
+def _require_static_size(actual: Any, expected: int, name: str) -> None:
+    if actual != expected:
+        raise ValueError(f"`{name}` must have static size {expected}, but got {actual}")
+
+
+def _validate_mxf4nvf4_packed_fragment_layout(
+    fragment: Tensor,
+    name: str,
+    *,
+    expected_logical_size: int,
+    expected_i32_size: int,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tensor:
+    _require_rmem(fragment, name)
+    if fragment.element_type != Float4E2M1FN:
+        raise TypeError(f"`{name}` must have element type {Float4E2M1FN}")
+    _require_static_size(
+        cute.size(fragment, loc=loc, ip=ip), expected_logical_size, name
+    )
+
+    compact = cute.filter_zeros(fragment, loc=loc, ip=ip)
+    i32_fragment = cute.recast_tensor(compact, Int32, loc=loc, ip=ip)
+    _require_static_size(
+        cute.size(i32_fragment, loc=loc, ip=ip),
+        expected_i32_size,
+        f"packed `{name}`",
+    )
+    return i32_fragment
+
+
+def _validate_mxf4nvf4_accumulator_layout(
+    accumulator: Tensor,
+    name: str,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    _require_rmem(accumulator, name)
+    if accumulator.element_type != Float32:
+        raise TypeError(f"`{name}` must have element type {Float32}")
+    _require_static_size(cute.size(accumulator, loc=loc, ip=ip), 4, name)
+
+
+def _validate_mxf4nvf4_scale_fragment_layout(
+    scale: Tensor,
+    name: str,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tensor:
+    _require_rmem(scale, name)
+    if scale.element_type != Float8E4M3FN:
+        raise TypeError(f"`{name}` must have element type {Float8E4M3FN}")
+    _require_static_size(cute.size(scale, loc=loc, ip=ip), 64, name)
+
+    compact = cute.filter_zeros(scale, loc=loc, ip=ip)
+    _require_static_size(
+        cute.cosize(compact.layout, loc=loc, ip=ip),
+        4,
+        f"compact `{name}`",
+    )
+    i32_scale = cute.recast_tensor(compact, Int32, loc=loc, ip=ip)
+    _require_static_size(
+        cute.size(i32_scale, loc=loc, ip=ip),
+        1,
+        f"packed `{name}`",
+    )
+    return compact
+
+
+def _validate_mxf4nvf4_atom(atom: cute.MmaAtom) -> MmaSM120BlockScaledOp:
+    op = getattr(atom, "op", None)
+    if not isinstance(op, MmaSM120BlockScaledOp):
+        raise TypeError("`mma_unpack` expects an SM120 warp blockscaled MMA atom")
+    if not op.supports_operand_bundle([None, None], [None, None]):  # type: ignore[list-item]
+        raise ValueError(
+            "SM120 NVFP4 MMA requires Float4E2M1FN A/B, Float32 accumulators, "
+            "Float8E4M3FN scales, shape (16, 8, 64), and scale_vec::4X"
+        )
+    return op
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfa_layout(
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the SM120 MXF4NVF4 SFA register scale-fragment layout."""
+    return cute.make_layout(((16, 4),), stride=((0, 1),), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfb_layout(
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the SM120 MXF4NVF4 SFB register scale-fragment layout."""
+    return cute.make_layout(((16, 4),), stride=((0, 1),), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfa_fragment(
+    dtype: Type[Numeric] = Float8E4M3FN,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tensor:
+    """Return an SM120 MXF4NVF4 SFA register scale fragment."""
+    if dtype != Float8E4M3FN:
+        raise TypeError("SM120 MXF4NVF4 SFA fragments require Float8E4M3FN")
+    return cute.make_rmem_tensor(
+        make_mxf4nvf4_sfa_layout(loc=loc, ip=ip), dtype, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfb_fragment(
+    dtype: Type[Numeric] = Float8E4M3FN,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tensor:
+    """Return an SM120 MXF4NVF4 SFB register scale fragment."""
+    if dtype != Float8E4M3FN:
+        raise TypeError("SM120 MXF4NVF4 SFB fragments require Float8E4M3FN")
+    return cute.make_rmem_tensor(
+        make_mxf4nvf4_sfb_layout(loc=loc, ip=ip), dtype, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def mma_unpack(
+    atom: cute.MmaAtom,
+    d: Tensor,
+    a: Union[List[Tensor], Tuple[Tensor, ...]],
+    b: Union[List[Tensor], Tuple[Tensor, ...]],
+    c: Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue SM120 MXF4NVF4 warp MMA with bundled FP4 and E4M3 scale fragments."""
+    _validate_mxf4nvf4_atom(atom)
+    a_fragment, sfa = _normalize_mxf4nvf4_operand(a, "a")
+    b_fragment, sfb = _normalize_mxf4nvf4_operand(b, "b")
+
+    a_i32 = _validate_mxf4nvf4_packed_fragment_layout(
+        a_fragment,
+        "a fragment",
+        expected_logical_size=32,
+        expected_i32_size=4,
+        loc=loc,
+        ip=ip,
+    )
+    b_i32 = _validate_mxf4nvf4_packed_fragment_layout(
+        b_fragment,
+        "b fragment",
+        expected_logical_size=16,
+        expected_i32_size=2,
+        loc=loc,
+        ip=ip,
+    )
+    _validate_mxf4nvf4_accumulator_layout(d, "d", loc=loc, ip=ip)
+    _validate_mxf4nvf4_accumulator_layout(c, "c", loc=loc, ip=ip)
+
+    compact_sfa = _validate_mxf4nvf4_scale_fragment_layout(
+        sfa, "sfa", loc=loc, ip=ip
+    )
+    compact_sfb = _validate_mxf4nvf4_scale_fragment_layout(
+        sfb, "sfb", loc=loc, ip=ip
+    )
+
+    sfa_i32 = cute.recast_tensor(compact_sfa, Int32, loc=loc, ip=ip)
+    sfb_i32 = cute.recast_tensor(compact_sfb, Int32, loc=loc, ip=ip)
+
+    a_vec = a_i32.load(loc=loc, ip=ip)
+    b_vec = b_i32.load(loc=loc, ip=ip)
+    c_vec = c.load(loc=loc, ip=ip)
+    shape_mnk = _pack_shape((16, 8, 64), loc=loc, ip=ip)
+    result = _cute_nvgpu_ir.arch_mma_SM120_block_scaled(
+        c_vec.type,
+        shape_mnk.type.attribute,
+        16,
+        ir.TypeAttr.get(Float4E2M1FN.mlir_type),
+        ir.TypeAttr.get(Float4E2M1FN.mlir_type),
+        ir.TypeAttr.get(Float8E4M3FN.mlir_type),
+        a_vec,
+        b_vec,
+        c_vec,
+        Int32(sfa_i32[0]).ir_value(loc=loc, ip=ip),
+        Int32(sfb_i32[0]).ir_value(loc=loc, ip=ip),
+        # This helper accepts only the canonical register fragments produced by
+        # partition_shape_A/B for the single-instruction SM120 MXF4NVF4 form.
+        # Their physical layout carries the lane/byte mapping, so the
+        # instruction's immediate byte/thread selectors stay at the canonical
+        # zero values.
+        byte_id_a=0,
+        byte_id_b=0,
+        thread_id_a=0,
+        thread_id_b=0,
+        loc=loc,
+        ip=ip,
+    )
+    d.store(cute.TensorSSA(result, d.shape, Float32, loc=loc, ip=ip), loc=loc, ip=ip)

--- a/python/CuTeDSL/cutlass/cute/tensor.py
+++ b/python/CuTeDSL/cutlass/cute/tensor.py
@@ -68,6 +68,8 @@ from .core import (
     append,
     depth,
     flatten,
+    get_nonswizzle_portion,
+    get_swizzle_portion,
     has_underscore,
     make_layout,
     select,
@@ -95,6 +97,7 @@ __all__ = [
     "make_fragment_like",
     "make_rmem_tensor_like",
     "make_rmem_tensor",
+    "as_position_independent_swizzle_tensor",
     "recast_tensor",
     "domain_offset",
     "print_tensor",
@@ -905,6 +908,36 @@ def make_fragment(
     ip: Optional[ir.InsertionPoint] = None,
 ) -> Tensor:
     return make_rmem_tensor(layout_or_shape, dtype, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def as_position_independent_swizzle_tensor(
+    src: Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tensor:
+    """Return a shared-memory tensor with layout swizzle moved onto the pointer.
+
+    This mirrors the C++ CuTe helper used before `partition_S()` in LDSM copy
+    paths. It preserves the logical tensor shape and element type; no data is
+    moved.
+    """
+    if not isinstance(src, Tensor):
+        raise TypeError(f"expects a Tensor, but got {type(src)}")
+    if src.memspace != AddressSpace.smem:
+        raise TypeError("expects a shared-memory tensor")
+
+    swizzle = get_swizzle_portion(src.layout, loc=loc, ip=ip)
+    layout = get_nonswizzle_portion(src.layout, loc=loc, ip=ip)
+    ptr = recast_ptr(
+        src.iterator,
+        swizzle_=swizzle,
+        dtype=src.element_type,
+        loc=loc,
+        ip=ip,
+    )
+    return make_tensor(ptr, layout, loc=loc, ip=ip)
 
 
 @dsl_user_op

--- a/python/CuTeDSL/cutlass/cute/typing.py
+++ b/python/CuTeDSL/cutlass/cute/typing.py
@@ -511,11 +511,23 @@ class TypedTensor:
 
     @property
     def mlir_type(self) -> ir.Type:
-        shape_ty = _cute_ir.ShapeType.get_from_x_tuple(ir.Context.current, self._shape)
-        stride_ty = _cute_ir.StrideType.get_from_x_tuple(
-            ir.Context.current, self._stride
-        )
-        layout_ty = _cute_ir.LayoutType.get(shape_ty, stride_ty)
+        if hasattr(_cute_ir.ShapeType, "get_from_x_tuple"):
+            shape_ty = _cute_ir.ShapeType.get_from_x_tuple(
+                ir.Context.current, self._shape
+            )
+            stride_ty = _cute_ir.StrideType.get_from_x_tuple(
+                ir.Context.current, self._stride
+            )
+        else:
+            shape_ty = _cute_ir.ShapeType.get(str(self._shape).replace(" ", ""))
+            stride_ty = _cute_ir.StrideType.get(str(self._stride).replace(" ", ""))
+        try:
+            layout_ty = _cute_ir.LayoutType.get(shape_ty, stride_ty)
+        except TypeError:
+            layout_ty = ir.Type.parse(
+                f'!cute.layout<"{str(self._shape).replace(" ", "")}:'
+                f'{str(self._stride).replace(" ", "")}">'
+            )
 
         # Boolean types are stored as i8 in memory
         elem_type = T.i8() if self._dtype.width == 1 else self._dtype.mlir_type

--- a/python/CuTeDSL/cutlass/pipeline/__init__.py
+++ b/python/CuTeDSL/cutlass/pipeline/__init__.py
@@ -49,6 +49,14 @@ from .sm100 import (
     PipelineTmaMultiConsumersAsync,
 )
 
+from .sm120 import (
+    PipelineTmaWarpMma,
+    issue_tma_load_3d,
+    issue_tma_load_4d,
+    producer_acquire_issue_tma_load_3d,
+    producer_acquire_issue_tma_load_4d,
+)
+
 __all__ = [
     "Agent",
     "CooperativeGroup",
@@ -68,9 +76,14 @@ __all__ = [
     "PipelineUmmaAsync",
     "PipelineClcFetchAsync",
     "PipelineTmaMultiConsumersAsync",
+    "PipelineTmaWarpMma",
     "PipelineTmaStore",
     "PipelineProducer",
     "PipelineConsumer",
+    "issue_tma_load_3d",
+    "issue_tma_load_4d",
+    "producer_acquire_issue_tma_load_3d",
+    "producer_acquire_issue_tma_load_4d",
     "make_pipeline_state",
     "pipeline_init_arrive",
     "pipeline_init_wait",

--- a/python/CuTeDSL/cutlass/pipeline/sm120.py
+++ b/python/CuTeDSL/cutlass/pipeline/sm120.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""SM120 CTA-local TMA pipeline helpers."""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from cutlass.cutlass_dsl import Boolean, Int32, Int64, dsl_user_op
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.typing import Pointer
+from cutlass.pipeline import CooperativeGroup, PipelineState
+from cutlass.pipeline.sm90 import PipelineTmaAsync
+
+
+@dataclass(frozen=True)
+class PipelineTmaWarpMma(PipelineTmaAsync):
+    """SM120 CTA-local TMA pipeline for warp-level MMA consumers."""
+
+    @staticmethod
+    def create(
+        *,
+        num_stages: int,
+        producer_group: CooperativeGroup,
+        consumer_group: CooperativeGroup,
+        tx_count: int,
+        barrier_storage: Optional[Pointer] = None,
+        cta_layout_vmnk=None,
+        tidx: Optional[Int32] = None,
+        mcast_mode_mn: Tuple[int, int] = (1, 1),
+        defer_sync: bool = False,
+    ) -> "PipelineTmaWarpMma":
+        base = PipelineTmaAsync.create(
+            num_stages=num_stages,
+            producer_group=producer_group,
+            consumer_group=consumer_group,
+            tx_count=tx_count,
+            barrier_storage=barrier_storage,
+            cta_layout_vmnk=cta_layout_vmnk,
+            tidx=tidx,
+            mcast_mode_mn=mcast_mode_mn,
+            defer_sync=defer_sync,
+        )
+        return PipelineTmaWarpMma(
+            base.sync_object_full,
+            base.sync_object_empty,
+            base.num_stages,
+            base.producer_mask,
+            base.consumer_mask,
+            base.is_signalling_thread,
+        )
+
+
+@dsl_user_op
+def issue_tma_load_3d(
+    pipe: PipelineTmaWarpMma,
+    producer_state: PipelineState,
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """Issue one SM120 rank-3 TMA load on a pipeline barrier.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    Descriptor-memory visibility is handled by the SM120 raw TMA helper, which emits a tensor-map acquire fence before issue.
+    """
+    cpasync.sm120_tma_load_3d(
+        dst_smem_ptr,
+        tma_desc_ptr,
+        pipe.producer_get_barrier(producer_state),
+        coord0,
+        coord1,
+        coord2,
+        cache_policy=cache_policy,
+        already_elected=already_elected,
+        tile_mode=tile_mode,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def issue_tma_load_4d(
+    pipe: PipelineTmaWarpMma,
+    producer_state: PipelineState,
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    coord3: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """Issue one SM120 rank-4 TMA load on a pipeline barrier.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    Descriptor-memory visibility is handled by the SM120 raw TMA helper, which emits a tensor-map acquire fence before issue.
+    """
+    cpasync.sm120_tma_load_4d(
+        dst_smem_ptr,
+        tma_desc_ptr,
+        pipe.producer_get_barrier(producer_state),
+        coord0,
+        coord1,
+        coord2,
+        coord3,
+        cache_policy=cache_policy,
+        already_elected=already_elected,
+        tile_mode=tile_mode,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def producer_acquire_issue_tma_load_3d(
+    pipe: PipelineTmaWarpMma,
+    producer_state: PipelineState,
+    try_acquire_token: Optional[Boolean],
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """Acquire a producer stage and issue one SM120 rank-3 TMA load.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    Descriptor-memory visibility is handled by the SM120 raw TMA helper, which emits a tensor-map acquire fence before issue.
+    """
+    pipe.producer_acquire(producer_state, try_acquire_token, loc=loc, ip=ip)
+    issue_tma_load_3d(
+        pipe,
+        producer_state,
+        dst_smem_ptr,
+        tma_desc_ptr,
+        coord0,
+        coord1,
+        coord2,
+        cache_policy=cache_policy,
+        already_elected=already_elected,
+        tile_mode=tile_mode,
+        loc=loc,
+        ip=ip,
+    )
+    pipe.producer_commit(producer_state, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def producer_acquire_issue_tma_load_4d(
+    pipe: PipelineTmaWarpMma,
+    producer_state: PipelineState,
+    try_acquire_token: Optional[Boolean],
+    dst_smem_ptr: Pointer,
+    tma_desc_ptr: Pointer,
+    coord0: Int32,
+    coord1: Int32,
+    coord2: Int32,
+    coord3: Int32,
+    *,
+    cache_policy: Optional[Int64] = None,
+    already_elected: bool = False,
+    tile_mode: bool = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """Acquire a producer stage and issue one SM120 rank-4 TMA load.
+
+    Coordinates are passed directly to the tensor-map instruction and must match the external descriptor's rank and basis.
+    Descriptor-memory visibility is handled by the SM120 raw TMA helper, which emits a tensor-map acquire fence before issue.
+    """
+    pipe.producer_acquire(producer_state, try_acquire_token, loc=loc, ip=ip)
+    issue_tma_load_4d(
+        pipe,
+        producer_state,
+        dst_smem_ptr,
+        tma_desc_ptr,
+        coord0,
+        coord1,
+        coord2,
+        coord3,
+        cache_policy=cache_policy,
+        already_elected=already_elected,
+        tile_mode=tile_mode,
+        loc=loc,
+        ip=ip,
+    )
+    pipe.producer_commit(producer_state, loc=loc, ip=ip)
+
+
+__all__ = [
+    "PipelineTmaWarpMma",
+    "issue_tma_load_3d",
+    "issue_tma_load_4d",
+    "producer_acquire_issue_tma_load_3d",
+    "producer_acquire_issue_tma_load_4d",
+]

--- a/python/CuTeDSL/cutlass/utils/__init__.py
+++ b/python/CuTeDSL/cutlass/utils/__init__.py
@@ -70,8 +70,15 @@ from .grouped_gemm_persistent_tile_scheduler import (
 )
 
 from .tensormap_manager import (
+    SM120_MXF4NVF4_SCALE_K_GRANULARITY,
+    SM120_MXF4NVF4_TENSOR_MAP_BYTES,
     TensorMapUpdateMode,
     TensorMapManager,
+    make_sm120_mxf4nvf4_scale_tma_desc_bytes,
+    make_sm120_mxf4nvf4_tma_desc_bytes,
+    sm120_mxf4nvf4_padded_scale_k_extent,
+    validate_sm120_mxf4nvf4_scale_tma_desc,
+    validate_sm120_mxf4nvf4_tma_desc,
 )
 
 from .smem_allocator import SmemAllocator, get_smem_capacity_in_bytes
@@ -136,6 +143,13 @@ __all__ = [
     "StaticPersistentRuntimeTileScheduler",
     "TensorMapUpdateMode",
     "TensorMapManager",
+    "SM120_MXF4NVF4_TENSOR_MAP_BYTES",
+    "SM120_MXF4NVF4_SCALE_K_GRANULARITY",
+    "make_sm120_mxf4nvf4_tma_desc_bytes",
+    "make_sm120_mxf4nvf4_scale_tma_desc_bytes",
+    "validate_sm120_mxf4nvf4_tma_desc",
+    "validate_sm120_mxf4nvf4_scale_tma_desc",
+    "sm120_mxf4nvf4_padded_scale_k_extent",
     "GroupSearchResult",
     "GroupedGemmGroupSearchState",
     "create_initial_search_state",

--- a/python/CuTeDSL/cutlass/utils/__init__.py
+++ b/python/CuTeDSL/cutlass/utils/__init__.py
@@ -122,6 +122,7 @@ from . import distributed
 
 from . import hopper_helpers as sm90
 from . import blackwell_helpers as sm100
+from . import blackwell_geforce_helpers as sm120
 from .print_latex import print_latex, print_latex_tv
 
 from .tensor_helpers import (
@@ -189,6 +190,7 @@ __all__ = [
     "sm90_make_trivial_tiled_mma",
     "sm90",
     "sm100",
+    "sm120",
     "gemm",
     "ClcDynamicPersistentTileSchedulerParams",
     "ClcDynamicPersistentTileScheduler",

--- a/python/CuTeDSL/cutlass/utils/blackwell_geforce_helpers.py
+++ b/python/CuTeDSL/cutlass/utils/blackwell_geforce_helpers.py
@@ -1,7 +1,356 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Blackwell GeForce SM120 helper aliases."""
+"""Blackwell GeForce / SM120 CuTe DSL helper utilities.
 
-from cutlass.utils.gemm.sm120 import *  # noqa: F403
-from cutlass.utils.gemm.sm120 import __all__
+This module is the SM120-facing peer to ``blackwell_helpers``. It exposes the
+narrow SM120 NVFP4 warp-MMA/TMA helper surface without adding SM100
+tcgen05/TMEM concepts that are not part of the SM120 path.
+"""
+
+from typing import Optional, Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir import ir
+from cutlass.base_dsl.typing import Numeric
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.utils.gemm import sm120 as _sm120
+from cutlass.utils.smem_allocator import SmemAllocator
+
+
+def _require_cluster_1x1x1(cluster_shape_mnk: cute.Shape) -> None:
+    if tuple(cluster_shape_mnk) != (1, 1, 1):
+        raise ValueError(
+            "SM120 Blackwell GeForce NVFP4 supports only "
+            "cluster_shape_mnk=(1, 1, 1)"
+        )
+
+
+@dsl_user_op
+def make_blockscaled_trivial_tiled_mma(
+    a_dtype: Type[Numeric] = cutlass.Float4E2M1FN,
+    b_dtype: Type[Numeric] = cutlass.Float4E2M1FN,
+    acc_dtype: Type[Numeric] = cutlass.Float32,
+    sf_dtype: Type[Numeric] = cutlass.Float8E4M3FN,
+    sf_vec_size: int = _sm120.MXF4NVF4_SCALE_VEC_SIZE,
+    atom_layout_mnk: Tuple[int, int, int] = (1, 1, 1),
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.TiledMma:
+    """Create the supported SM120 NVFP4 blockscaled tiled MMA."""
+    if a_dtype != cutlass.Float4E2M1FN:
+        raise ValueError("SM120 NVFP4 A operands require Float4E2M1FN")
+    if b_dtype != cutlass.Float4E2M1FN:
+        raise ValueError("SM120 NVFP4 B operands require Float4E2M1FN")
+    if acc_dtype != cutlass.Float32:
+        raise ValueError("SM120 NVFP4 accumulation requires Float32")
+    if sf_dtype != cutlass.Float8E4M3FN:
+        raise ValueError("SM120 NVFP4 scale operands require Float8E4M3FN")
+    if sf_vec_size != _sm120.MXF4NVF4_SCALE_VEC_SIZE:
+        raise ValueError(
+            "SM120 NVFP4 scale operands require sf_vec_size="
+            f"{_sm120.MXF4NVF4_SCALE_VEC_SIZE}"
+        )
+    return _sm120.make_mxf4nvf4_tiled_mma(
+        atom_layout_mnk=atom_layout_mnk, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_smem_layout_a_tma_physical(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    return _sm120.make_mxf4nvf4_ab_tma_physical_layout_staged(
+        major_extent, tile_k, num_stages, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_smem_layout_b_tma_physical(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    return _sm120.make_mxf4nvf4_ab_tma_physical_layout_staged(
+        major_extent, tile_k, num_stages, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_smem_layout_a_consumer(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.ComposedLayout:
+    return _sm120.make_mxf4nvf4_a_consumer_smem_layout_staged(
+        major_extent, tile_k, num_stages, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_smem_layout_b_consumer(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.ComposedLayout:
+    return _sm120.make_mxf4nvf4_b_consumer_smem_layout_staged(
+        major_extent, tile_k, num_stages, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_smem_layout_scale_tma_physical(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    sf_vec_size: int = _sm120.MXF4NVF4_SCALE_VEC_SIZE,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    return _sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(
+        major_extent,
+        tile_k,
+        sf_vec_size,
+        num_stages,
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_smem_layouts_ab(
+    *,
+    num_stages: int = 1,
+    tile_m: int = 128,
+    tile_n: int = 128,
+    tile_k: int = 128,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Return physical and consumer A/B layouts for SM120 NVFP4."""
+    return (
+        make_smem_layout_a_tma_physical(tile_m, tile_k, num_stages, loc=loc, ip=ip),
+        make_smem_layout_b_tma_physical(tile_n, tile_k, num_stages, loc=loc, ip=ip),
+        make_smem_layout_a_consumer(tile_m, tile_k, num_stages, loc=loc, ip=ip),
+        make_smem_layout_b_consumer(tile_n, tile_k, num_stages, loc=loc, ip=ip),
+    )
+
+
+def make_ab_smem_views(
+    smem: SmemAllocator,
+    *,
+    num_stages: int = 1,
+    tile_m: int = 128,
+    tile_n: int = 128,
+    tile_k: int = 128,
+):
+    return _sm120.make_mxf4nvf4_ab_smem_views(
+        smem, num_stages=num_stages, tile_m=tile_m, tile_n=tile_n, tile_k=tile_k
+    )
+
+
+def make_ab_consumer_smem_views(
+    smem: SmemAllocator,
+    *,
+    num_stages: int = 1,
+    tile_m: int = 128,
+    tile_n: int = 128,
+    tile_k: int = 128,
+):
+    return _sm120.make_mxf4nvf4_ab_consumer_smem_views(
+        smem, num_stages=num_stages, tile_m=tile_m, tile_n=tile_n, tile_k=tile_k
+    )
+
+
+@dsl_user_op
+def cluster_shape_to_tma_atom_A(
+    cluster_shape_mnk: cute.Shape,
+    atom_thr_id=None,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cpasync.CopyBulkTensorTileG2SOp:
+    _require_cluster_1x1x1(cluster_shape_mnk)
+    return cpasync.CopyBulkTensorTileG2SOp()
+
+
+@dsl_user_op
+def cluster_shape_to_tma_atom_B(
+    cluster_shape_mnk: cute.Shape,
+    atom_thr_id=None,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cpasync.CopyBulkTensorTileG2SOp:
+    _require_cluster_1x1x1(cluster_shape_mnk)
+    return cpasync.CopyBulkTensorTileG2SOp()
+
+
+@dsl_user_op
+def cluster_shape_to_tma_atom_SFA(
+    cluster_shape_mnk: cute.Shape,
+    atom_thr_id=None,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cpasync.CopyBulkTensorTileG2SOp:
+    _require_cluster_1x1x1(cluster_shape_mnk)
+    return cpasync.CopyBulkTensorTileG2SOp()
+
+
+@dsl_user_op
+def cluster_shape_to_tma_atom_SFB(
+    cluster_shape_mnk: cute.Shape,
+    atom_thr_id=None,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cpasync.CopyBulkTensorTileG2SOp:
+    _require_cluster_1x1x1(cluster_shape_mnk)
+    return cpasync.CopyBulkTensorTileG2SOp()
+
+
+def make_tiled_tma_atom_A(gA: cute.Tensor, smem_layout=None, *args, **kwargs):
+    return _sm120.make_mxf4nvf4_tiled_tma_atom_a(gA, smem_layout, *args, **kwargs)
+
+
+def make_tiled_tma_atom_B(gB: cute.Tensor, smem_layout=None, *args, **kwargs):
+    return _sm120.make_mxf4nvf4_tiled_tma_atom_b(gB, smem_layout, *args, **kwargs)
+
+
+def make_tiled_tma_atom_SFA(gSFA: cute.Tensor, smem_layout=None, *args, **kwargs):
+    return _sm120.make_mxf4nvf4_sfa_tiled_tma_atom(gSFA, smem_layout, *args, **kwargs)
+
+
+def make_tiled_tma_atom_SFB(gSFB: cute.Tensor, smem_layout=None, *args, **kwargs):
+    return _sm120.make_mxf4nvf4_sfb_tiled_tma_atom(gSFB, smem_layout, *args, **kwargs)
+
+
+def get_ab_tma_tx_bytes() -> int:
+    return _sm120.mxf4nvf4_ab_tma_tx_bytes()
+
+
+def get_scale_tma_tx_bytes() -> int:
+    return _sm120.mxf4nvf4_scale_tma_tx_bytes()
+
+
+def get_full_tma_tx_bytes() -> int:
+    return _sm120.mxf4nvf4_full_tma_tx_bytes()
+
+
+def get_tma_desc_bytes() -> int:
+    return _sm120.MXF4NVF4_TMA_DESC_BYTES
+
+
+def stage_ab_tma_physical_to_consumer_smem(*args, **kwargs):
+    return _sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(*args, **kwargs)
+
+
+def make_ab_consumer_microtile_views(*args, **kwargs):
+    return _sm120.make_mxf4nvf4_ab_consumer_microtile_views(*args, **kwargs)
+
+
+def make_ab_fragments_from_consumer_smem(*args, **kwargs):
+    return _sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(*args, **kwargs)
+
+
+def load_ab_fragments_from_consumer_smem(*args, **kwargs):
+    return _sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(*args, **kwargs)
+
+
+def allocate_scale_fragment_scratch(*args, **kwargs):
+    return _sm120.allocate_mxf4nvf4_scale_fragment_scratch(*args, **kwargs)
+
+
+def make_scale_fragment_scratch_views(*args, **kwargs):
+    return _sm120.make_mxf4nvf4_scale_fragment_scratch_views(*args, **kwargs)
+
+
+def stage_scale_tma_physical_to_fragment_scratch(*args, **kwargs):
+    return _sm120.stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch(*args, **kwargs)
+
+
+def make_scale_fragment_views_from_scratch(*args, **kwargs):
+    return _sm120.make_mxf4nvf4_scale_fragment_views_from_scratch(*args, **kwargs)
+
+
+def make_scale_fragments(*args, **kwargs):
+    return _sm120.make_mxf4nvf4_scale_fragments(*args, **kwargs)
+
+
+def load_sfa_fragment(*args, **kwargs):
+    return _sm120.load_mxf4nvf4_sfa_fragment(*args, **kwargs)
+
+
+def load_sfb_fragment(*args, **kwargs):
+    return _sm120.load_mxf4nvf4_sfb_fragment(*args, **kwargs)
+
+
+def make_external_tma_desc_ptr(*args, **kwargs):
+    return _sm120.make_mxf4nvf4_external_tma_desc_ptr(*args, **kwargs)
+
+
+def validate_ab_tma_contract(*args, **kwargs):
+    return _sm120.validate_mxf4nvf4_ab_tma_contract(*args, **kwargs)
+
+
+def validate_scale_tma_contract(*args, **kwargs):
+    return _sm120.validate_mxf4nvf4_scale_tma_contract(*args, **kwargs)
+
+
+_facade_all = [
+    "allocate_scale_fragment_scratch",
+    "cluster_shape_to_tma_atom_A",
+    "cluster_shape_to_tma_atom_B",
+    "cluster_shape_to_tma_atom_SFA",
+    "cluster_shape_to_tma_atom_SFB",
+    "get_ab_tma_tx_bytes",
+    "get_full_tma_tx_bytes",
+    "get_scale_tma_tx_bytes",
+    "get_tma_desc_bytes",
+    "load_ab_fragments_from_consumer_smem",
+    "load_sfa_fragment",
+    "load_sfb_fragment",
+    "make_external_tma_desc_ptr",
+    "make_ab_consumer_microtile_views",
+    "make_ab_consumer_smem_views",
+    "make_ab_fragments_from_consumer_smem",
+    "make_ab_smem_views",
+    "make_blockscaled_trivial_tiled_mma",
+    "make_scale_fragment_scratch_views",
+    "make_scale_fragment_views_from_scratch",
+    "make_scale_fragments",
+    "make_smem_layout_a_consumer",
+    "make_smem_layout_a_tma_physical",
+    "make_smem_layout_b_consumer",
+    "make_smem_layout_b_tma_physical",
+    "make_smem_layout_scale_tma_physical",
+    "make_smem_layouts_ab",
+    "make_tiled_tma_atom_A",
+    "make_tiled_tma_atom_B",
+    "make_tiled_tma_atom_SFA",
+    "make_tiled_tma_atom_SFB",
+    "stage_ab_tma_physical_to_consumer_smem",
+    "stage_scale_tma_physical_to_fragment_scratch",
+    "validate_ab_tma_contract",
+    "validate_scale_tma_contract",
+]
+
+__all__ = sorted(_facade_all)

--- a/python/CuTeDSL/cutlass/utils/blackwell_geforce_helpers.py
+++ b/python/CuTeDSL/cutlass/utils/blackwell_geforce_helpers.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Blackwell GeForce SM120 helper aliases."""
+
+from cutlass.utils.gemm.sm120 import *  # noqa: F403
+from cutlass.utils.gemm.sm120 import __all__

--- a/python/CuTeDSL/cutlass/utils/gemm/__init__.py
+++ b/python/CuTeDSL/cutlass/utils/gemm/__init__.py
@@ -10,7 +10,9 @@
 # is strictly prohibited.
 
 from . import sm100
+from . import sm120
 
 __all__ = [
     "sm100",
+    "sm120",
 ]

--- a/python/CuTeDSL/cutlass/utils/gemm/sm120.py
+++ b/python/CuTeDSL/cutlass/utils/gemm/sm120.py
@@ -1,0 +1,1113 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""SM120 MXF4NVF4 warp-GEMM helper API."""
+
+from typing import Optional, Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import const_expr
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.extras import types as T
+from cutlass.base_dsl.typing import Numeric
+from cutlass.cute.nvgpu import cpasync, warp
+from cutlass.cutlass_dsl import dsl_user_op, for_generate, yield_out
+from cutlass.utils import blockscaled_layout
+from cutlass.utils.smem_allocator import SmemAllocator
+from cutlass.utils.tensormap_manager import (
+    SM120_MXF4NVF4_TENSOR_MAP_BYTES,
+    TensorMapManager,
+    TensorMapUpdateMode,
+    validate_sm120_mxf4nvf4_scale_tma_desc,
+    validate_sm120_mxf4nvf4_tma_desc,
+)
+
+
+MXF4NVF4_CTA_SHAPE_MNK = (128, 128, 128)
+MXF4NVF4_MMA_SHAPE_MNK = (16, 8, 64)
+MXF4NVF4_SCALE_VEC_SIZE = 16
+MXF4NVF4_SCALE_K = MXF4NVF4_CTA_SHAPE_MNK[2] // MXF4NVF4_SCALE_VEC_SIZE
+MXF4NVF4_AB_TMA_BYTES = MXF4NVF4_CTA_SHAPE_MNK[0] * MXF4NVF4_CTA_SHAPE_MNK[2] // 2
+MXF4NVF4_AB_SMEM_BYTES = MXF4NVF4_CTA_SHAPE_MNK[0] * MXF4NVF4_CTA_SHAPE_MNK[2]
+MXF4NVF4_SCALE_TMA_BYTES = MXF4NVF4_CTA_SHAPE_MNK[0] * MXF4NVF4_SCALE_K
+MXF4NVF4_FULL_TMA_BYTES = 2 * MXF4NVF4_AB_TMA_BYTES + 2 * MXF4NVF4_SCALE_TMA_BYTES
+MXF4NVF4_TMA_DESC_BYTES = SM120_MXF4NVF4_TENSOR_MAP_BYTES
+
+
+def _check_positive(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError(f"`{name}` must be positive, but got {value}")
+
+
+def _check_default_tile(tile_mn: int, tile_k: int, sf_vec_size: int) -> None:
+    _check_positive("tile_mn", tile_mn)
+    _check_positive("tile_k", tile_k)
+    _check_positive("sf_vec_size", sf_vec_size)
+    if tile_k != 128:
+        raise ValueError("SM120 MXF4NVF4 helpers currently support tile_k=128")
+    if sf_vec_size != MXF4NVF4_SCALE_VEC_SIZE:
+        raise ValueError("SM120 MXF4NVF4 helpers currently support sf_vec_size=16")
+
+
+def _require_zero_scale_major_offset(name: str, value: cutlass.Int32 | int) -> None:
+    raw_value = getattr(value, "value", value)
+    if raw_value != 0:
+        raise ValueError(
+            f"`{name}` is not supported by this helper; encode the global major "
+            "tile in the TMA descriptor coordinates and stage the local 128-major tile"
+        )
+
+
+def mxf4nvf4_ab_tma_tx_bytes(tile_mn: int = 128, tile_k: int = 128) -> int:
+    """Return bytes completed by one A or B full-tile TMA transaction."""
+    _check_default_tile(tile_mn, tile_k, MXF4NVF4_SCALE_VEC_SIZE)
+    return tile_mn * tile_k // 2
+
+
+def mxf4nvf4_scale_tma_tx_bytes(
+    tile_mn: int = 128,
+    tile_k: int = 128,
+    sf_vec_size: int = MXF4NVF4_SCALE_VEC_SIZE,
+) -> int:
+    """Return bytes completed by one SFA or SFB full-tile TMA transaction."""
+    _check_default_tile(tile_mn, tile_k, sf_vec_size)
+    return tile_mn * (tile_k // sf_vec_size)
+
+
+def mxf4nvf4_full_tma_tx_bytes(
+    tile_m: int = 128,
+    tile_n: int = 128,
+    tile_k: int = 128,
+    sf_vec_size: int = MXF4NVF4_SCALE_VEC_SIZE,
+) -> int:
+    """Return the barrier transaction byte count for A/B/SFA/SFB TMA."""
+    return (
+        mxf4nvf4_ab_tma_tx_bytes(tile_m, tile_k)
+        + mxf4nvf4_ab_tma_tx_bytes(tile_n, tile_k)
+        + mxf4nvf4_scale_tma_tx_bytes(tile_m, tile_k, sf_vec_size)
+        + mxf4nvf4_scale_tma_tx_bytes(tile_n, tile_k, sf_vec_size)
+    )
+
+
+def validate_mxf4nvf4_ab_tma_contract(
+    *,
+    base_ptr: int,
+    desc_ptr: int | None = None,
+    global_dim: tuple[int, int, int] = (128, 128, 1),
+    global_strides_bytes: tuple[int, int] = (64, 8192),
+    box_dim: tuple[int, int, int] = (128, 128, 1),
+    element_strides: tuple[int, int, int] = (1, 1, 1),
+    tx_count: int | None = MXF4NVF4_AB_TMA_BYTES,
+    dtype: Type[Numeric] = cutlass.Float4E2M1FN,
+    align16: bool = True,
+) -> None:
+    """Validate the public SM120 MXF4NVF4 A/B descriptor contract."""
+    if dtype != cutlass.Float4E2M1FN:
+        raise ValueError("SM120 MXF4NVF4 A/B descriptors require packed Float4E2M1FN")
+    validate_sm120_mxf4nvf4_tma_desc(
+        base_ptr=base_ptr,
+        desc_ptr=desc_ptr,
+        global_dim=global_dim,
+        global_strides_bytes=global_strides_bytes,
+        box_dim=box_dim,
+        element_strides=element_strides,
+        tx_count=tx_count,
+        align16=align16,
+    )
+
+
+def validate_mxf4nvf4_scale_tma_contract(
+    *,
+    base_ptr: int,
+    desc_ptr: int | None = None,
+    global_dim: tuple[int, int, int, int] = (128, 16, 1, 1),
+    global_strides_bytes: tuple[int, int, int] = (128, 2048, 2048),
+    box_dim: tuple[int, int, int, int] = (128, 8, 1, 1),
+    element_strides: tuple[int, int, int, int] = (1, 1, 1, 1),
+    tx_count: int | None = MXF4NVF4_SCALE_TMA_BYTES,
+    dtype: Type[Numeric] = cutlass.Uint8,
+) -> None:
+    """Validate the public SM120 MXF4NVF4 scale descriptor contract."""
+    if dtype != cutlass.Uint8:
+        raise ValueError("SM120 MXF4NVF4 scale descriptors require UINT8")
+    validate_sm120_mxf4nvf4_scale_tma_desc(
+        base_ptr=base_ptr,
+        desc_ptr=desc_ptr,
+        global_dim=global_dim,
+        global_strides_bytes=global_strides_bytes,
+        box_dim=box_dim,
+        element_strides=element_strides,
+        tx_count=tx_count,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_tiled_mma(
+    atom_layout_mnk: Tuple[int, int, int] = (1, 1, 1),
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.TiledMma:
+    """Create the SM120 warp-level MXF4NVF4 tiled MMA."""
+    mma_op = warp.MmaMXF4NVF4Op(
+        cutlass.Float4E2M1FN,
+        cutlass.Float32,
+        cutlass.Float8E4M3FN,
+    )
+    return cute.make_tiled_mma(
+        mma_op, atom_layout_mnk=atom_layout_mnk, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ab_tma_physical_layout_staged(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the A/B physical SMEM byte layout populated by external TMA."""
+    _check_default_tile(major_extent, tile_k, MXF4NVF4_SCALE_VEC_SIZE)
+    _check_positive("num_stages", num_stages)
+    return cute.make_layout(
+        (major_extent, tile_k, num_stages),
+        stride=(tile_k, 1, major_extent * tile_k),
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_mxf4nvf4_smem_layout_staged(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Compatibility alias for the A/B TMA physical SMEM layout."""
+    return make_mxf4nvf4_ab_tma_physical_layout_staged(
+        major_extent, tile_k, num_stages, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ab_ldsm_scratch_layout(
+    major_extent: int = 128,
+    k_block: int = MXF4NVF4_MMA_SHAPE_MNK[2],
+    num_warps: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the LDSM-compatible A/B scratch layout for one K64 substep."""
+    _check_positive("major_extent", major_extent)
+    if k_block != MXF4NVF4_MMA_SHAPE_MNK[2]:
+        raise ValueError("SM120 MXF4NVF4 LDSM scratch currently supports k_block=64")
+    _check_positive("num_warps", num_warps)
+    return cute.make_layout(
+        (major_extent, k_block, num_warps),
+        stride=(k_block, 1, major_extent * k_block),
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_mxf4nvf4_ab_smem_views(
+    smem: SmemAllocator,
+    *,
+    num_stages: int = 1,
+    tile_m: int = 128,
+    tile_n: int = 128,
+    tile_k: int = 128,
+) -> Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]:
+    """Allocate A/B TMA physical storage views.
+
+    The returned LDSM views are compatibility aliases of the physical views.
+    New kernels should use `allocate_mxf4nvf4_ldsm_scratch()` and stage from
+    TMA physical storage into scratch before loading fragments.
+    """
+    layout_a = make_mxf4nvf4_ab_tma_physical_layout_staged(tile_m, tile_k, num_stages)
+    layout_b = make_mxf4nvf4_ab_tma_physical_layout_staged(tile_n, tile_k, num_stages)
+    sA_tma = smem.allocate_tensor(cutlass.Uint8, layout_a, byte_alignment=128)
+    sB_tma = smem.allocate_tensor(cutlass.Uint8, layout_b, byte_alignment=128)
+    sA_ldsm = sA_tma
+    sB_ldsm = sB_tma
+    return sA_tma, sA_ldsm, sB_tma, sB_ldsm
+
+
+def allocate_mxf4nvf4_ldsm_scratch(
+    smem: SmemAllocator,
+    num_warps: int = 1,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Allocate CUTLASS-owned A/B LDSM scratch storage."""
+    layout = make_mxf4nvf4_ab_ldsm_scratch_layout(num_warps=num_warps)
+    return (
+        smem.allocate_tensor(cutlass.Uint8, layout, byte_alignment=128),
+        smem.allocate_tensor(cutlass.Uint8, layout, byte_alignment=128),
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ldsm_scratch_views(
+    scratch_a_all: cute.Tensor,
+    scratch_b_all: cute.Tensor,
+    consumer_warp: cutlass.Int32,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Return one consumer warp's A/B LDSM scratch views.
+
+    `consumer_warp` must be compile-time constant. Preserving the base pointer
+    for warp 0 keeps the 128-byte SMEM allocation alignment visible to LDSM.
+    """
+    warp_stride = MXF4NVF4_CTA_SHAPE_MNK[0] * MXF4NVF4_MMA_SHAPE_MNK[2]
+    layout = make_mxf4nvf4_ab_ldsm_scratch_layout(loc=loc, ip=ip)
+    consumer_warp_value = getattr(consumer_warp, "value", consumer_warp)
+    if not isinstance(consumer_warp_value, int):
+        raise ValueError("consumer_warp must be compile-time constant")
+    scratch_a_ptr = scratch_a_all.iterator
+    scratch_b_ptr = scratch_b_all.iterator
+    if consumer_warp_value != 0:
+        scratch_a_ptr = scratch_a_ptr + consumer_warp * warp_stride
+        scratch_b_ptr = scratch_b_ptr + consumer_warp * warp_stride
+    return (
+        cute.make_tensor(
+            scratch_a_ptr,
+            layout,
+            loc=loc,
+            ip=ip,
+        ),
+        cute.make_tensor(
+            scratch_b_ptr,
+            layout,
+            loc=loc,
+            ip=ip,
+        ),
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfa_smem_layout_staged(
+    tiled_mma: Optional[cute.TiledMma] = None,
+    tile_shape_mnk: cute.Tile = MXF4NVF4_CTA_SHAPE_MNK,
+    sf_vec_size: int = MXF4NVF4_SCALE_VEC_SIZE,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the staged SFA SMEM layout for SM120 MXF4NVF4."""
+    tiled_mma = (
+        make_mxf4nvf4_tiled_mma(loc=loc, ip=ip) if tiled_mma is None else tiled_mma
+    )
+    return blockscaled_layout.sm120_make_smem_layout_sfa(
+        tiled_mma,
+        tile_shape_mnk,
+        sf_vec_size,
+        num_stages,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfb_smem_layout_staged(
+    tiled_mma: Optional[cute.TiledMma] = None,
+    tile_shape_mnk: cute.Tile = MXF4NVF4_CTA_SHAPE_MNK,
+    sf_vec_size: int = MXF4NVF4_SCALE_VEC_SIZE,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the staged SFB SMEM layout for SM120 MXF4NVF4."""
+    tiled_mma = (
+        make_mxf4nvf4_tiled_mma(loc=loc, ip=ip) if tiled_mma is None else tiled_mma
+    )
+    return blockscaled_layout.sm120_make_smem_layout_sfb(
+        tiled_mma,
+        tile_shape_mnk,
+        sf_vec_size,
+        num_stages,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_scale_tma_physical_layout_staged(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    sf_vec_size: int = MXF4NVF4_SCALE_VEC_SIZE,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return the rank-4 scale TMA physical destination layout."""
+    _check_default_tile(major_extent, tile_k, sf_vec_size)
+    _check_positive("num_stages", num_stages)
+    scale_k = tile_k // sf_vec_size
+    return cute.make_layout(
+        (major_extent, scale_k, 1, num_stages),
+        stride=(scale_k, 1, major_extent * scale_k, major_extent * scale_k),
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_mxf4nvf4_tma_scale_layout_staged(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    sf_vec_size: int = MXF4NVF4_SCALE_VEC_SIZE,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Compatibility alias for the scale TMA physical SMEM layout."""
+    return make_mxf4nvf4_scale_tma_physical_layout_staged(
+        major_extent, tile_k, sf_vec_size, num_stages, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_scale_fragment_scratch_layout(
+    major_extent: int = 128,
+    scale_k: int = MXF4NVF4_SCALE_K,
+    num_warps: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Layout:
+    """Return fragment-compatible scale scratch layout."""
+    _check_positive("major_extent", major_extent)
+    if scale_k != MXF4NVF4_SCALE_K:
+        raise ValueError("SM120 MXF4NVF4 scale scratch currently supports scale_k=8")
+    _check_positive("num_warps", num_warps)
+    return cute.make_layout(
+        (major_extent, scale_k, num_warps),
+        stride=(scale_k, 1, major_extent * scale_k),
+        loc=loc,
+        ip=ip,
+    )
+
+
+def allocate_mxf4nvf4_scale_fragment_scratch(
+    smem: SmemAllocator,
+    num_warps: int = 1,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Allocate CUTLASS-owned SFA/SFB fragment-compatible scale scratch."""
+    layout = make_mxf4nvf4_scale_fragment_scratch_layout(num_warps=num_warps)
+    return (
+        smem.allocate_tensor(cutlass.Uint8, layout, byte_alignment=128),
+        smem.allocate_tensor(cutlass.Uint8, layout, byte_alignment=128),
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_scale_fragment_scratch_views(
+    scratch_sfa_all: cute.Tensor,
+    scratch_sfb_all: cute.Tensor,
+    consumer_warp: cutlass.Int32,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Return one consumer warp's SFA/SFB scale fragment scratch views."""
+    warp_stride = MXF4NVF4_SCALE_TMA_BYTES
+    layout = make_mxf4nvf4_scale_fragment_scratch_layout(loc=loc, ip=ip)
+    return (
+        cute.make_tensor(
+            scratch_sfa_all.iterator + consumer_warp * warp_stride,
+            layout,
+            loc=loc,
+            ip=ip,
+        ),
+        cute.make_tensor(
+            scratch_sfb_all.iterator + consumer_warp * warp_stride,
+            layout,
+            loc=loc,
+            ip=ip,
+        ),
+    )
+
+
+def _make_mxf4nvf4_tiled_tma_atom(
+    gmem_tensor: cute.Tensor,
+    smem_layout: cute.Layout,
+    cta_tiler: cute.Tile,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    op = cpasync.CopyBulkTensorTileG2SOp()
+    return cpasync.make_tiled_tma_atom(
+        op,
+        gmem_tensor,
+        smem_layout,
+        cta_tiler,
+        internal_type=cutlass.Uint8,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_tiled_tma_atom_a(
+    gmem_tensor: cute.Tensor,
+    smem_layout: Optional[cute.Layout] = None,
+    cta_tiler: cute.Tile = (128, 128, 1),
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Create the layout-aware TMA atom/tensor for one A tile."""
+    if const_expr(smem_layout is None):
+        smem_layout = make_mxf4nvf4_smem_layout_staged(loc=loc, ip=ip)
+    return _make_mxf4nvf4_tiled_tma_atom(
+        gmem_tensor, smem_layout, cta_tiler, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_tiled_tma_atom_b(
+    gmem_tensor: cute.Tensor,
+    smem_layout: Optional[cute.Layout] = None,
+    cta_tiler: cute.Tile = (128, 128, 1),
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Create the layout-aware TMA atom/tensor for one B tile."""
+    if const_expr(smem_layout is None):
+        smem_layout = make_mxf4nvf4_smem_layout_staged(loc=loc, ip=ip)
+    return _make_mxf4nvf4_tiled_tma_atom(
+        gmem_tensor, smem_layout, cta_tiler, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfa_tiled_tma_atom(
+    gmem_tensor: cute.Tensor,
+    smem_layout: Optional[cute.Layout] = None,
+    cta_tiler: cute.Tile = (128, 8, 1, 1),
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Create the layout-aware TMA atom/tensor for one SFA tile."""
+    if const_expr(smem_layout is None):
+        smem_layout = make_mxf4nvf4_tma_scale_layout_staged(loc=loc, ip=ip)
+    return _make_mxf4nvf4_tiled_tma_atom(
+        gmem_tensor, smem_layout, cta_tiler, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_sfb_tiled_tma_atom(
+    gmem_tensor: cute.Tensor,
+    smem_layout: Optional[cute.Layout] = None,
+    cta_tiler: cute.Tile = (128, 8, 1, 1),
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Create the layout-aware TMA atom/tensor for one SFB tile."""
+    if const_expr(smem_layout is None):
+        smem_layout = make_mxf4nvf4_tma_scale_layout_staged(loc=loc, ip=ip)
+    return _make_mxf4nvf4_tiled_tma_atom(
+        gmem_tensor, smem_layout, cta_tiler, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ldsm_copy_atom(
+    *,
+    transpose: bool = False,
+    dtype: Type[Numeric] = cutlass.Uint8,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.CopyAtom:
+    """Create the packed 16-bit LDSM atom used by SM120 MXF4NVF4 A/B loads."""
+    return cute.make_copy_atom(
+        warp.LdMatrix8x8x16bOp(transpose=transpose, num_matrices=4),
+        dtype,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ab_ldsm_copy_views(
+    tiled_mma: cute.TiledMma,
+    sA_ldsm: cute.Tensor,
+    sB_ldsm: cute.Tensor,
+    a_frag: cute.Tensor,
+    b_frag: cute.Tensor,
+    tidx: cutlass.Int32,
+    *,
+    a_transpose: bool = False,
+    b_transpose: bool = True,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Return packed-LDSM source views and destination register fragments.
+
+    The SM120 MXF4NVF4 consumer path uses packed FP4 bytes in SMEM but the
+    hardware load is a 16-bit `ldmatrix.x4` operation. This helper keeps the
+    public call site in CuTe-style terms while the paired load helper owns the
+    exact scratch mapping and inline instruction form.
+    """
+    lane_row = tidx % 16
+    lane_smem_offset = lane_row * 16
+    sA_lane = cute.make_tensor(
+        sA_ldsm.iterator + lane_smem_offset, sA_ldsm.layout, loc=loc, ip=ip
+    )
+    sB_lane = cute.make_tensor(
+        sB_ldsm.iterator + lane_smem_offset, sB_ldsm.layout, loc=loc, ip=ip
+    )
+    return (
+        make_mxf4nvf4_ldsm_copy_atom(
+            transpose=a_transpose, dtype=cutlass.Int32, loc=loc, ip=ip
+        ),
+        sA_lane,
+        a_frag,
+        make_mxf4nvf4_ldsm_copy_atom(
+            transpose=b_transpose, dtype=cutlass.Int32, loc=loc, ip=ip
+        ),
+        sB_lane,
+        b_frag,
+    )
+
+
+make_mxf4nvf4_ab_ldsm_copy_views_from_scratch = make_mxf4nvf4_ab_ldsm_copy_views
+
+
+def stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch(
+    sA_tma_physical: cute.Tensor,
+    sA_ldsm_scratch: cute.Tensor,
+    *,
+    k_block_idx: cutlass.Constexpr[int],
+    a_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage one K64 A block from TMA physical SMEM into LDSM scratch."""
+    loop_start = lane_idx if lane_idx is not None else 0
+    loop_step = 32 if lane_idx is not None else 1
+    src = cute.make_tensor(
+        sA_tma_physical.iterator, cute.make_layout(MXF4NVF4_AB_SMEM_BYTES)
+    )
+    dst = cute.make_tensor(
+        sA_ldsm_scratch.iterator, cute.make_layout(MXF4NVF4_AB_SMEM_BYTES // 2)
+    )
+    for i in for_generate(
+        loop_start, MXF4NVF4_AB_SMEM_BYTES // 2, loop_step, loc=loc, ip=ip
+    ):
+        major = i // MXF4NVF4_MMA_SHAPE_MNK[2]
+        byte_in_major = i % MXF4NVF4_MMA_SHAPE_MNK[2]
+        payload_byte = (
+            (a_major_tile + major) * (MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+            + k_block_idx * (MXF4NVF4_MMA_SHAPE_MNK[2] // 2)
+            + byte_in_major % (MXF4NVF4_MMA_SHAPE_MNK[2] // 2)
+        )
+        payload_chunk = payload_byte // 8
+        payload_byte_in_chunk = payload_byte % 8
+        physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+        dst[i] = src[physical_chunk * 16 + payload_byte_in_chunk]
+        yield_out()
+
+
+def stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch(
+    sB_tma_physical: cute.Tensor,
+    sB_ldsm_scratch: cute.Tensor,
+    *,
+    k_block_idx: cutlass.Constexpr[int],
+    b_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage one K64 B block from TMA physical SMEM into LDSM scratch."""
+    loop_start = lane_idx if lane_idx is not None else 0
+    loop_step = 32 if lane_idx is not None else 1
+    src = cute.make_tensor(
+        sB_tma_physical.iterator, cute.make_layout(MXF4NVF4_AB_SMEM_BYTES)
+    )
+    dst = cute.make_tensor(
+        sB_ldsm_scratch.iterator, cute.make_layout(MXF4NVF4_AB_SMEM_BYTES // 2)
+    )
+    for i in for_generate(
+        loop_start, MXF4NVF4_AB_SMEM_BYTES // 2, loop_step, loc=loc, ip=ip
+    ):
+        major = i // MXF4NVF4_MMA_SHAPE_MNK[2]
+        byte_in_major = i % MXF4NVF4_MMA_SHAPE_MNK[2]
+        payload_byte = (
+            (b_major_tile + major) * (MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+            + k_block_idx * (MXF4NVF4_MMA_SHAPE_MNK[2] // 2)
+            + byte_in_major % (MXF4NVF4_MMA_SHAPE_MNK[2] // 2)
+        )
+        payload_chunk = payload_byte // 8
+        payload_byte_in_chunk = payload_byte % 8
+        physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+        dst[i] = src[physical_chunk * 16 + payload_byte_in_chunk]
+        yield_out()
+
+
+def stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
+    sA_tma_physical: cute.Tensor,
+    sB_tma_physical: cute.Tensor,
+    sA_ldsm_scratch: cute.Tensor,
+    sB_ldsm_scratch: cute.Tensor,
+    *,
+    k_block_idx: cutlass.Constexpr[int],
+    a_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    b_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage one K64 A/B block from TMA physical SMEM into LDSM scratch."""
+    stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch(
+        sA_tma_physical,
+        sA_ldsm_scratch,
+        k_block_idx=k_block_idx,
+        a_major_tile=a_major_tile,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+    stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch(
+        sB_tma_physical,
+        sB_ldsm_scratch,
+        k_block_idx=k_block_idx,
+        b_major_tile=b_major_tile,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _ldmatrix_x4_shared_b16(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    transpose: bool = False,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    ptx = "ldmatrix.sync.aligned.m8n8.x4"
+    if const_expr(transpose):
+        ptx += ".trans"
+    ptx += ".shared.b16 {$0, $1, $2, $3}, [$4];"
+    src_smem_addr = src.iterator.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    regs = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32,i32,i32,i32)>"),
+        [src_smem_addr],
+        ptx,
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+    dst_i32 = cute.recast_tensor(dst, cutlass.Int32, loc=loc, ip=ip)
+    dst_i32_size = cute.size(dst_i32, loc=loc, ip=ip)
+    for i in range(dst_i32_size):
+        dst_i32[i] = cutlass.Int32(llvm.extractvalue(T.i32(), regs, [i]))
+
+
+@dsl_user_op
+def load_mxf4nvf4_packed_ldsm_kblock_fragments(
+    copy_a: cute.CopyAtom,
+    tCsA: cute.Tensor,
+    tCrA: cute.Tensor,
+    copy_b: cute.CopyAtom,
+    tCsB: cute.Tensor,
+    tCrB: cute.Tensor,
+    k_block_idx: int,
+    stage_idx: int = 0,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Load one K64 block of packed A/B fragments from SMEM to registers."""
+    a_src = tCsA[(None, k_block_idx * 64, stage_idx)]
+    b_src = tCsB[(None, k_block_idx * 64, stage_idx)]
+    _ldmatrix_x4_shared_b16(a_src, tCrA, transpose=False, loc=loc, ip=ip)
+    _ldmatrix_x4_shared_b16(
+        b_src,
+        tCrB,
+        transpose=getattr(copy_b.op, "transpose", True),
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def load_mxf4nvf4_ldsm_scratch_fragments(
+    tiled_mma: cute.TiledMma,
+    sA_ldsm_scratch: cute.Tensor,
+    sB_ldsm_scratch: cute.Tensor,
+    a_frag: cute.Tensor,
+    b_frag: cute.Tensor,
+    lane_idx: cutlass.Int32,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Load A/B fragments from one staged K64 LDSM scratch tile."""
+    copy_a, tCsA, tCrA, copy_b, tCsB, tCrB = (
+        make_mxf4nvf4_ab_ldsm_copy_views_from_scratch(
+            tiled_mma,
+            sA_ldsm_scratch,
+            sB_ldsm_scratch,
+            a_frag,
+            b_frag,
+            lane_idx,
+            loc=loc,
+            ip=ip,
+        )
+    )
+    load_mxf4nvf4_packed_ldsm_kblock_fragments(
+        copy_a, tCsA, tCrA, copy_b, tCsB, tCrB, 0, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_scale_smem_fragment_views(
+    sSFA: cute.Tensor,
+    sSFB: cute.Tensor,
+    k_block_idx: int,
+    stage_idx: int = 0,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Return SFA/SFB source views for one K64 block from staged scale SMEM."""
+    scale_k_offset = k_block_idx * (
+        MXF4NVF4_MMA_SHAPE_MNK[2] // MXF4NVF4_SCALE_VEC_SIZE
+    )
+    stage_offset = stage_idx * MXF4NVF4_SCALE_TMA_BYTES
+    sfa_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN, loc=loc, ip=ip)
+    sfb_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN, loc=loc, ip=ip)
+    sfa_ptr = sfa_f8.iterator + scale_k_offset + stage_offset
+    sfb_ptr = sfb_f8.iterator + scale_k_offset + stage_offset
+    return (
+        cute.make_tensor(
+            sfa_ptr, warp.make_mxf4nvf4_sfa_layout(loc=loc, ip=ip), loc=loc, ip=ip
+        ),
+        cute.make_tensor(
+            sfb_ptr, warp.make_mxf4nvf4_sfb_layout(loc=loc, ip=ip), loc=loc, ip=ip
+        ),
+    )
+
+
+make_mxf4nvf4_scale_fragment_views_from_compact_smem = (
+    make_mxf4nvf4_scale_smem_fragment_views
+)
+
+
+@dsl_user_op
+def make_mxf4nvf4_scale_fragment_views_from_scratch(
+    sSFA_frag_scratch: cute.Tensor,
+    sSFB_frag_scratch: cute.Tensor,
+    k_block_idx: int,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Return SFA/SFB source views from fragment-compatible scratch."""
+    return make_mxf4nvf4_scale_smem_fragment_views(
+        sSFA_frag_scratch, sSFB_frag_scratch, k_block_idx, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def mxf4nvf4_scale_tma_physical_offset(
+    major: cutlass.Int32,
+    scale_col: cutlass.Int32,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cutlass.Int32:
+    """Return rank-4 scale TMA physical byte offset for one logical scale."""
+    payload_idx = scale_col * 128 + major
+    chunk = payload_idx // 16
+    byte = payload_idx % 16
+    phys_chunk = chunk ^ (chunk >> 3)
+    return phys_chunk * 16 + byte
+
+
+def stage_mxf4nvf4_sfa_tma_physical_to_fragment_scratch(
+    sSFA_tma_physical: cute.Tensor,
+    sSFA_frag_scratch: cute.Tensor,
+    *,
+    sfa_major_offset: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage SFA rank-4 TMA physical SMEM into fragment-compatible scratch.
+
+    The source tensor is one local 128-major TMA tile. Global major-tile
+    selection belongs to the TMA descriptor coordinates, so the physical byte
+    remap below intentionally uses local major coordinates only. The
+    `sfa_major_offset` argument is rejected when nonzero; callers should encode
+    global major offsets in the TMA coordinates.
+    """
+    _require_zero_scale_major_offset("sfa_major_offset", sfa_major_offset)
+    loop_start = lane_idx if lane_idx is not None else 0
+    loop_step = 32 if lane_idx is not None else 1
+    src = cute.make_tensor(
+        sSFA_tma_physical.iterator,
+        cute.make_layout(MXF4NVF4_SCALE_TMA_BYTES),
+        loc=loc,
+        ip=ip,
+    )
+    dst = cute.make_tensor(
+        sSFA_frag_scratch.iterator,
+        cute.make_layout(MXF4NVF4_SCALE_TMA_BYTES),
+        loc=loc,
+        ip=ip,
+    )
+    for i in for_generate(
+        loop_start, MXF4NVF4_SCALE_TMA_BYTES, loop_step, loc=loc, ip=ip
+    ):
+        local_major = i // MXF4NVF4_SCALE_K
+        scale_col = i % MXF4NVF4_SCALE_K
+        phys = mxf4nvf4_scale_tma_physical_offset(
+            local_major, scale_col, loc=loc, ip=ip
+        )
+        dst[i] = src[phys]
+        yield_out()
+
+
+def stage_mxf4nvf4_sfb_tma_physical_to_fragment_scratch(
+    sSFB_tma_physical: cute.Tensor,
+    sSFB_frag_scratch: cute.Tensor,
+    *,
+    sfb_major_offset: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage SFB rank-4 TMA physical SMEM into fragment-compatible scratch.
+
+    The source tensor is one local 128-major TMA tile. Global major-tile
+    selection belongs to the TMA descriptor coordinates, so the physical byte
+    remap below intentionally uses local major coordinates only. The
+    `sfb_major_offset` argument is rejected when nonzero; callers should encode
+    global major offsets in the TMA coordinates.
+    """
+    _require_zero_scale_major_offset("sfb_major_offset", sfb_major_offset)
+    loop_start = lane_idx if lane_idx is not None else 0
+    loop_step = 32 if lane_idx is not None else 1
+    src = cute.make_tensor(
+        sSFB_tma_physical.iterator,
+        cute.make_layout(MXF4NVF4_SCALE_TMA_BYTES),
+        loc=loc,
+        ip=ip,
+    )
+    dst = cute.make_tensor(
+        sSFB_frag_scratch.iterator,
+        cute.make_layout(MXF4NVF4_SCALE_TMA_BYTES),
+        loc=loc,
+        ip=ip,
+    )
+    for i in for_generate(
+        loop_start, MXF4NVF4_SCALE_TMA_BYTES, loop_step, loc=loc, ip=ip
+    ):
+        local_major = i // MXF4NVF4_SCALE_K
+        scale_col = i % MXF4NVF4_SCALE_K
+        phys = mxf4nvf4_scale_tma_physical_offset(
+            local_major, scale_col, loc=loc, ip=ip
+        )
+        dst[i] = src[phys]
+        yield_out()
+
+
+def stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch(
+    sSFA_tma_physical: cute.Tensor,
+    sSFB_tma_physical: cute.Tensor,
+    sSFA_frag_scratch: cute.Tensor,
+    sSFB_frag_scratch: cute.Tensor,
+    *,
+    sfa_major_offset: cutlass.Int32 = cutlass.Int32(0),
+    sfb_major_offset: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage SFA/SFB TMA physical SMEM into fragment-compatible scratch."""
+    stage_mxf4nvf4_sfa_tma_physical_to_fragment_scratch(
+        sSFA_tma_physical,
+        sSFA_frag_scratch,
+        sfa_major_offset=sfa_major_offset,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+    stage_mxf4nvf4_sfb_tma_physical_to_fragment_scratch(
+        sSFB_tma_physical,
+        sSFB_frag_scratch,
+        sfb_major_offset=sfb_major_offset,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_mxf4nvf4_scale_fragment_views_from_tma_physical(
+    sSFA_tma_physical: cute.Tensor,
+    sSFB_tma_physical: cute.Tensor,
+    sSFA_frag_scratch: cute.Tensor,
+    sSFB_frag_scratch: cute.Tensor,
+    k_block_idx: int,
+    *,
+    sfa_major_offset: cutlass.Int32 = cutlass.Int32(0),
+    sfb_major_offset: cutlass.Int32 = cutlass.Int32(0),
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Stage scale TMA physical SMEM into scratch and return fragment views.
+
+    When `lane_idx` is provided, this helper synchronizes the CTA after
+    cooperative staging so the returned views are ready for fragment loads.
+    """
+    stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch(
+        sSFA_tma_physical,
+        sSFB_tma_physical,
+        sSFA_frag_scratch,
+        sSFB_frag_scratch,
+        sfa_major_offset=sfa_major_offset,
+        sfb_major_offset=sfb_major_offset,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+    if lane_idx is not None:
+        cute.arch.sync_threads()
+    return make_mxf4nvf4_scale_fragment_views_from_scratch(
+        sSFA_frag_scratch,
+        sSFB_frag_scratch,
+        k_block_idx,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_scale_fragments(
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Create SFA and SFB register fragments for bundled SM120 MXF4NVF4 MMA."""
+    return (
+        warp.make_mxf4nvf4_sfa_fragment(loc=loc, ip=ip),
+        warp.make_mxf4nvf4_sfb_fragment(loc=loc, ip=ip),
+    )
+
+
+@dsl_user_op
+def load_mxf4nvf4_sfa_fragment(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Load a prepartitioned SFA scale view into its register fragment."""
+    dst.store(src.load(loc=loc, ip=ip), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def load_mxf4nvf4_sfb_fragment(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Load a prepartitioned SFB scale view into its register fragment."""
+    dst.store(src.load(loc=loc, ip=ip), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def make_mxf4nvf4_external_tma_desc_ptr(
+    desc_tensor: cute.Tensor,
+    memspace: cute.AddressSpace = cute.AddressSpace.generic,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Pointer:
+    """Return an address-space-qualified pointer to a 128-byte tensor-map descriptor."""
+    manager = TensorMapManager(TensorMapUpdateMode.GMEM, MXF4NVF4_TMA_DESC_BYTES)
+    return manager.get_tensormap_ptr(desc_tensor.iterator, memspace, loc=loc, ip=ip)
+
+
+__all__ = [
+    "MXF4NVF4_AB_TMA_BYTES",
+    "MXF4NVF4_AB_SMEM_BYTES",
+    "MXF4NVF4_CTA_SHAPE_MNK",
+    "MXF4NVF4_FULL_TMA_BYTES",
+    "MXF4NVF4_MMA_SHAPE_MNK",
+    "MXF4NVF4_SCALE_K",
+    "MXF4NVF4_SCALE_TMA_BYTES",
+    "MXF4NVF4_SCALE_VEC_SIZE",
+    "MXF4NVF4_TMA_DESC_BYTES",
+    "allocate_mxf4nvf4_ldsm_scratch",
+    "allocate_mxf4nvf4_scale_fragment_scratch",
+    "load_mxf4nvf4_ldsm_scratch_fragments",
+    "load_mxf4nvf4_packed_ldsm_kblock_fragments",
+    "load_mxf4nvf4_sfa_fragment",
+    "load_mxf4nvf4_sfb_fragment",
+    "make_mxf4nvf4_ab_ldsm_copy_views",
+    "make_mxf4nvf4_ab_ldsm_copy_views_from_scratch",
+    "make_mxf4nvf4_ab_ldsm_scratch_layout",
+    "make_mxf4nvf4_ab_smem_views",
+    "make_mxf4nvf4_ab_tma_physical_layout_staged",
+    "make_mxf4nvf4_external_tma_desc_ptr",
+    "make_mxf4nvf4_ldsm_copy_atom",
+    "make_mxf4nvf4_ldsm_scratch_views",
+    "make_mxf4nvf4_scale_fragment_scratch_layout",
+    "make_mxf4nvf4_scale_fragment_scratch_views",
+    "make_mxf4nvf4_scale_fragment_views_from_compact_smem",
+    "make_mxf4nvf4_scale_fragment_views_from_scratch",
+    "make_mxf4nvf4_scale_fragment_views_from_tma_physical",
+    "make_mxf4nvf4_scale_fragments",
+    "make_mxf4nvf4_scale_smem_fragment_views",
+    "make_mxf4nvf4_scale_tma_physical_layout_staged",
+    "make_mxf4nvf4_sfa_smem_layout_staged",
+    "make_mxf4nvf4_sfa_tiled_tma_atom",
+    "make_mxf4nvf4_sfb_smem_layout_staged",
+    "make_mxf4nvf4_sfb_tiled_tma_atom",
+    "make_mxf4nvf4_smem_layout_staged",
+    "make_mxf4nvf4_tiled_mma",
+    "make_mxf4nvf4_tiled_tma_atom_a",
+    "make_mxf4nvf4_tiled_tma_atom_b",
+    "make_mxf4nvf4_tma_scale_layout_staged",
+    "mxf4nvf4_scale_tma_physical_offset",
+    "mxf4nvf4_ab_tma_tx_bytes",
+    "mxf4nvf4_full_tma_tx_bytes",
+    "mxf4nvf4_scale_tma_tx_bytes",
+    "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch",
+    "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch",
+    "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch",
+    "stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch",
+    "stage_mxf4nvf4_sfa_tma_physical_to_fragment_scratch",
+    "stage_mxf4nvf4_sfb_tma_physical_to_fragment_scratch",
+    "validate_mxf4nvf4_ab_tma_contract",
+    "validate_mxf4nvf4_scale_tma_contract",
+]

--- a/python/CuTeDSL/cutlass/utils/gemm/sm120.py
+++ b/python/CuTeDSL/cutlass/utils/gemm/sm120.py
@@ -51,13 +51,17 @@ def _check_default_tile(tile_mn: int, tile_k: int, sf_vec_size: int) -> None:
         raise ValueError("SM120 MXF4NVF4 helpers currently support sf_vec_size=16")
 
 
-def _require_zero_scale_major_offset(name: str, value: cutlass.Int32 | int) -> None:
+def _require_zero_major_offset(name: str, value: cutlass.Int32 | int) -> None:
     raw_value = getattr(value, "value", value)
     if raw_value != 0:
         raise ValueError(
             f"`{name}` is not supported by this helper; encode the global major "
             "tile in the TMA descriptor coordinates and stage the local 128-major tile"
         )
+
+
+def _require_zero_scale_major_offset(name: str, value: cutlass.Int32 | int) -> None:
+    _require_zero_major_offset(name, value)
 
 
 def mxf4nvf4_ab_tma_tx_bytes(tile_mn: int = 128, tile_k: int = 128) -> int:
@@ -181,6 +185,121 @@ def make_mxf4nvf4_ab_tma_physical_layout_staged(
     )
 
 
+@dsl_user_op
+def make_mxf4nvf4_consumer_smem_layout_atom_ab(
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.ComposedLayout:
+    """Return the SM120 packed-FP4 consumer SMEM atom layout.
+
+    This mirrors the layout atom selected by the 79a C++ collective:
+    `Sw<2,4,3> o smem_ptr[4b] o (_8,_128):(_128,_1)`.
+    """
+    return cute.make_composed_layout(
+        cute.make_swizzle(2, 4, 3, loc=loc, ip=ip),
+        0,
+        cute.make_layout((8, 128), stride=(128, 1), loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_a_consumer_smem_layout_staged(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.ComposedLayout:
+    """Return the staged 79a-style A consumer SMEM layout."""
+    _check_default_tile(major_extent, tile_k, MXF4NVF4_SCALE_VEC_SIZE)
+    _check_positive("num_stages", num_stages)
+    return cute.tile_to_shape(
+        make_mxf4nvf4_consumer_smem_layout_atom_ab(loc=loc, ip=ip),
+        (major_extent, tile_k, num_stages),
+        (0, 1, 2),
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_b_consumer_smem_layout_staged(
+    major_extent: int = 128,
+    tile_k: int = 128,
+    num_stages: int = 1,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.ComposedLayout:
+    """Return the staged 79a-style B consumer SMEM layout."""
+    _check_default_tile(major_extent, tile_k, MXF4NVF4_SCALE_VEC_SIZE)
+    _check_positive("num_stages", num_stages)
+    return cute.tile_to_shape(
+        make_mxf4nvf4_consumer_smem_layout_atom_ab(loc=loc, ip=ip),
+        (major_extent, tile_k, num_stages),
+        (0, 1, 2),
+        loc=loc,
+        ip=ip,
+    )
+
+
+def make_mxf4nvf4_ab_consumer_smem_views(
+    smem: SmemAllocator,
+    *,
+    num_stages: int = 1,
+    tile_m: int = 128,
+    tile_n: int = 128,
+    tile_k: int = 128,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Allocate A/B SMEM views for the 79a-style consumer LDSM path."""
+    layout_a = make_mxf4nvf4_a_consumer_smem_layout_staged(
+        tile_m, tile_k, num_stages
+    )
+    layout_b = make_mxf4nvf4_b_consumer_smem_layout_staged(
+        tile_n, tile_k, num_stages
+    )
+    return (
+        smem.allocate_tensor(cutlass.Float4E2M1FN, layout_a, byte_alignment=128),
+        smem.allocate_tensor(cutlass.Float4E2M1FN, layout_b, byte_alignment=128),
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ab_consumer_microtile_views(
+    sA_consumer: cute.Tensor,
+    sB_consumer: cute.Tensor,
+    m_atom: cutlass.Int32 | int = 0,
+    n_atom: cutlass.Int32 | int = 0,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Return local 16x8 MMA microtile views from a staged CTA consumer tile.
+
+    Global CTA M/N selection belongs in the tensor-map descriptor coordinates.
+    This helper only selects the local output atom within the already-staged
+    128x128 CTA tile.
+    """
+    return (
+        cute.domain_offset(
+            (m_atom * MXF4NVF4_MMA_SHAPE_MNK[0], 0, 0),
+            sA_consumer,
+            loc=loc,
+            ip=ip,
+        ),
+        cute.domain_offset(
+            (n_atom * MXF4NVF4_MMA_SHAPE_MNK[1], 0, 0),
+            sB_consumer,
+            loc=loc,
+            ip=ip,
+        ),
+    )
+
+
 def make_mxf4nvf4_smem_layout_staged(
     major_extent: int = 128,
     tile_k: int = 128,
@@ -228,8 +347,9 @@ def make_mxf4nvf4_ab_smem_views(
     """Allocate A/B TMA physical storage views.
 
     The returned LDSM views are compatibility aliases of the physical views.
-    New kernels should use `allocate_mxf4nvf4_ldsm_scratch()` and stage from
-    TMA physical storage into scratch before loading fragments.
+    New kernels should stage from TMA physical storage into the SM120 consumer
+    layout with `stage_mxf4nvf4_ab_tma_physical_to_consumer_smem()` before
+    loading fragments.
     """
     layout_a = make_mxf4nvf4_ab_tma_physical_layout_staged(tile_m, tile_k, num_stages)
     layout_b = make_mxf4nvf4_ab_tma_physical_layout_staged(tile_n, tile_k, num_stages)
@@ -545,6 +665,203 @@ def make_mxf4nvf4_ldsm_copy_atom(
 
 
 @dsl_user_op
+def make_mxf4nvf4_ab_smem_copy_atoms(
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.CopyAtom, cute.CopyAtom]:
+    """Return the non-transposed A/B LDSM copy atoms used by the C++ path."""
+    return (
+        make_mxf4nvf4_ldsm_copy_atom(
+            transpose=False, dtype=cutlass.Float4E2M1FN, loc=loc, ip=ip
+        ),
+        make_mxf4nvf4_ldsm_copy_atom(
+            transpose=False, dtype=cutlass.Float4E2M1FN, loc=loc, ip=ip
+        ),
+    )
+
+
+@dsl_user_op
+def make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem(
+    tiled_mma: cute.TiledMma,
+    sA_consumer: cute.Tensor,
+    sB_consumer: cute.Tensor,
+    a_frag: cute.Tensor,
+    b_frag: cute.Tensor,
+    lane_idx: cutlass.Int32,
+    *,
+    m_atom: cutlass.Int32 | int = 0,
+    n_atom: cutlass.Int32 | int = 0,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+):
+    """Return 79a-style A/B tiled-copy views from consumer SMEM.
+
+    Input tensors must use the consumer SMEM layouts produced by
+    `make_mxf4nvf4_ab_consumer_smem_views()` or the corresponding layout
+    helpers. Do not pass raw external-TMA physical SMEM to this helper.
+    `lane_idx` is the warp-local lane index, not the CTA thread index.
+    """
+    sA_consumer, sB_consumer = make_mxf4nvf4_ab_consumer_microtile_views(
+        sA_consumer,
+        sB_consumer,
+        m_atom=m_atom,
+        n_atom=n_atom,
+        loc=loc,
+        ip=ip,
+    )
+    copy_atom_a, copy_atom_b = make_mxf4nvf4_ab_smem_copy_atoms(loc=loc, ip=ip)
+    tiled_copy_a = cute.make_tiled_copy_A(copy_atom_a, tiled_mma, loc=loc, ip=ip)
+    tiled_copy_b = cute.make_tiled_copy_B(copy_atom_b, tiled_mma, loc=loc, ip=ip)
+    thr_copy_a = tiled_copy_a.get_slice(lane_idx)
+    thr_copy_b = tiled_copy_b.get_slice(lane_idx)
+    sA_src = cute.as_position_independent_swizzle_tensor(
+        sA_consumer, loc=loc, ip=ip
+    )
+    sB_src = cute.as_position_independent_swizzle_tensor(
+        sB_consumer, loc=loc, ip=ip
+    )
+    tCsA = thr_copy_a.partition_S(sA_src, loc=loc, ip=ip)
+    tCsB = thr_copy_b.partition_S(sB_src, loc=loc, ip=ip)
+    tCrA = thr_copy_a.retile_D(a_frag, loc=loc, ip=ip)
+    tCrB = thr_copy_b.retile_D(b_frag, loc=loc, ip=ip)
+    return tiled_copy_a, tCsA, tCrA, tiled_copy_b, tCsB, tCrB
+
+
+@dsl_user_op
+def make_mxf4nvf4_ab_fragments_from_consumer_smem(
+    tiled_mma: cute.TiledMma,
+    sA_consumer: cute.Tensor,
+    sB_consumer: cute.Tensor,
+    lane_idx: cutlass.Int32,
+    *,
+    m_atom: cutlass.Int32 | int = 0,
+    n_atom: cutlass.Int32 | int = 0,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[cute.Tensor, cute.Tensor]:
+    """Allocate A/B fragments for one local output atom.
+
+    `lane_idx` is the warp-local lane index. Use `m_atom`/`n_atom` to select
+    the local 16x8 atom inside the staged 128x128 CTA tile.
+    """
+    sA_consumer, sB_consumer = make_mxf4nvf4_ab_consumer_microtile_views(
+        sA_consumer,
+        sB_consumer,
+        m_atom=m_atom,
+        n_atom=n_atom,
+        loc=loc,
+        ip=ip,
+    )
+    thread_mma = tiled_mma.get_slice(lane_idx)
+    tCsA_mma = thread_mma.partition_A(sA_consumer, loc=loc, ip=ip)
+    tCsB_mma = thread_mma.partition_B(sB_consumer, loc=loc, ip=ip)
+    return (
+        tiled_mma.make_fragment_A(tCsA_mma[None, None, None, 0], loc=loc, ip=ip),
+        tiled_mma.make_fragment_B(tCsB_mma[None, None, None, 0], loc=loc, ip=ip),
+    )
+
+
+@dsl_user_op
+def shift_mxf4nvf4_post_ldsm_fp4_fragment(
+    fragment: cute.Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Validate the FP4 post-LDSM transform point for MXF4NVF4 MMA.
+
+    The C++ path applies an explicit nibble shift after its packed LDSM copy.
+    Python CuTe's typed `Float4E2M1FN` LDSM copy already materializes
+    MMA-ready fragments, so this hook is intentionally a no-op after dtype
+    validation. Keeping the hook explicit makes the consumer path match the C++
+    mainloop structure without corrupting the Python fragment encoding.
+    """
+    if fragment.element_type is not cutlass.Float4E2M1FN:
+        raise TypeError(
+            "SM120 MXF4NVF4 post-LDSM shift expects a Float4E2M1FN fragment, "
+            f"got {fragment.element_type}"
+        )
+
+
+@dsl_user_op
+def fp4_shift_mxf4nvf4_a(
+    fragment: cute.Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Apply the A-fragment FP4 post-LDSM shift."""
+    shift_mxf4nvf4_post_ldsm_fp4_fragment(fragment, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def fp4_shift_mxf4nvf4_b(
+    fragment: cute.Tensor,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Apply the B-fragment FP4 post-LDSM shift."""
+    shift_mxf4nvf4_post_ldsm_fp4_fragment(fragment, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def load_mxf4nvf4_ab_fragments_from_consumer_smem(
+    tiled_mma: cute.TiledMma,
+    sA_consumer: cute.Tensor,
+    sB_consumer: cute.Tensor,
+    a_frag: cute.Tensor,
+    b_frag: cute.Tensor,
+    lane_idx: cutlass.Int32,
+    k_block_idx: int,
+    consumer_stage_idx: int = 0,
+    *,
+    m_atom: cutlass.Int32 | int = 0,
+    n_atom: cutlass.Int32 | int = 0,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Load one K64 A/B block through the 79a-style consumer copy path.
+
+    `lane_idx` is the warp-local lane index. Use `m_atom`/`n_atom` to select
+    the local 16x8 atom inside the staged 128x128 CTA tile.
+    """
+    tiled_copy_a, tCsA, tCrA, tiled_copy_b, tCsB, tCrB = (
+        make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a_frag,
+            b_frag,
+            lane_idx,
+            m_atom=m_atom,
+            n_atom=n_atom,
+            loc=loc,
+            ip=ip,
+        )
+    )
+    tCsA_stage = tCsA[(None, None, None, consumer_stage_idx)]
+    tCsB_stage = tCsB[(None, None, None, consumer_stage_idx)]
+    cute.copy(
+        tiled_copy_a,
+        tCsA_stage[(None, None, k_block_idx)],
+        tCrA[(None, None, k_block_idx)],
+        loc=loc,
+        ip=ip,
+    )
+    cute.copy(
+        tiled_copy_b,
+        tCsB_stage[(None, None, k_block_idx)],
+        tCrB[(None, None, k_block_idx)],
+        loc=loc,
+        ip=ip,
+    )
+    fp4_shift_mxf4nvf4_a(tCrA[(None, None, k_block_idx)], loc=loc, ip=ip)
+    fp4_shift_mxf4nvf4_b(tCrB[(None, None, k_block_idx)], loc=loc, ip=ip)
+
+
+@dsl_user_op
 def make_mxf4nvf4_ab_ldsm_copy_views(
     tiled_mma: cute.TiledMma,
     sA_ldsm: cute.Tensor,
@@ -558,12 +875,13 @@ def make_mxf4nvf4_ab_ldsm_copy_views(
     loc: Optional[ir.Location] = None,
     ip: Optional[ir.InsertionPoint] = None,
 ):
-    """Return packed-LDSM source views and destination register fragments.
+    """Return compatibility packed-LDSM source views and register fragments.
 
-    The SM120 MXF4NVF4 consumer path uses packed FP4 bytes in SMEM but the
-    hardware load is a 16-bit `ldmatrix.x4` operation. This helper keeps the
-    public call site in CuTe-style terms while the paired load helper owns the
-    exact scratch mapping and inline instruction form.
+    This is the older manual inline-LDSM path. New code should use
+    `make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem()` and
+    `load_mxf4nvf4_ab_fragments_from_consumer_smem()`, which mirror the C++
+    tiled-copy consumer contract. This compatibility helper remains available
+    for existing internal canaries and backward compatibility.
     """
     lane_row = tidx % 16
     lane_smem_offset = lane_row * 16
@@ -662,6 +980,112 @@ def stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch(
         yield_out()
 
 
+def stage_mxf4nvf4_a_tma_physical_to_consumer_smem(
+    sA_tma_physical: cute.Tensor,
+    sA_consumer: cute.Tensor,
+    *,
+    a_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    consumer_stage_idx: int = 0,
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage one physical TMA A tile into the SM120 consumer SMEM layout.
+
+    `consumer_stage_idx` selects the destination consumer stage. Pass a
+    physical-stage view as `sA_tma_physical` when staging from a nonzero
+    physical stage.
+    """
+    _require_zero_major_offset("a_major_tile", a_major_tile)
+    loop_start = lane_idx if lane_idx is not None else 0
+    loop_step = 32 if lane_idx is not None else 1
+    src = cute.make_tensor(
+        sA_tma_physical.iterator, cute.make_layout(MXF4NVF4_AB_SMEM_BYTES)
+    )
+    dst = cute.recast_tensor(sA_consumer, cutlass.Uint8, loc=loc, ip=ip)
+    for i in for_generate(loop_start, MXF4NVF4_AB_TMA_BYTES, loop_step, loc=loc, ip=ip):
+        major = i // (MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        k_byte = i % (MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        payload_byte = major * (MXF4NVF4_CTA_SHAPE_MNK[2] // 2) + k_byte
+        payload_chunk = payload_byte // 8
+        payload_byte_in_chunk = payload_byte % 8
+        physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+        dst[(major, k_byte, consumer_stage_idx)] = src[
+            physical_chunk * 16 + payload_byte_in_chunk
+        ]
+        yield_out()
+
+
+def stage_mxf4nvf4_b_tma_physical_to_consumer_smem(
+    sB_tma_physical: cute.Tensor,
+    sB_consumer: cute.Tensor,
+    *,
+    b_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    consumer_stage_idx: int = 0,
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage one physical TMA B tile into the SM120 consumer SMEM layout.
+
+    `consumer_stage_idx` selects the destination consumer stage. Pass a
+    physical-stage view as `sB_tma_physical` when staging from a nonzero
+    physical stage.
+    """
+    _require_zero_major_offset("b_major_tile", b_major_tile)
+    loop_start = lane_idx if lane_idx is not None else 0
+    loop_step = 32 if lane_idx is not None else 1
+    src = cute.make_tensor(
+        sB_tma_physical.iterator, cute.make_layout(MXF4NVF4_AB_SMEM_BYTES)
+    )
+    dst = cute.recast_tensor(sB_consumer, cutlass.Uint8, loc=loc, ip=ip)
+    for i in for_generate(loop_start, MXF4NVF4_AB_TMA_BYTES, loop_step, loc=loc, ip=ip):
+        major = i // (MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        k_byte = i % (MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        payload_byte = major * (MXF4NVF4_CTA_SHAPE_MNK[2] // 2) + k_byte
+        payload_chunk = payload_byte // 8
+        payload_byte_in_chunk = payload_byte % 8
+        physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+        dst[(major, k_byte, consumer_stage_idx)] = src[
+            physical_chunk * 16 + payload_byte_in_chunk
+        ]
+        yield_out()
+
+
+def stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+    sA_tma_physical: cute.Tensor,
+    sB_tma_physical: cute.Tensor,
+    sA_consumer: cute.Tensor,
+    sB_consumer: cute.Tensor,
+    *,
+    a_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    b_major_tile: cutlass.Int32 = cutlass.Int32(0),
+    consumer_stage_idx: int = 0,
+    lane_idx: Optional[cutlass.Int32] = None,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Stage physical TMA A/B tiles into the SM120 consumer SMEM layouts."""
+    stage_mxf4nvf4_a_tma_physical_to_consumer_smem(
+        sA_tma_physical,
+        sA_consumer,
+        a_major_tile=a_major_tile,
+        consumer_stage_idx=consumer_stage_idx,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+    stage_mxf4nvf4_b_tma_physical_to_consumer_smem(
+        sB_tma_physical,
+        sB_consumer,
+        b_major_tile=b_major_tile,
+        consumer_stage_idx=consumer_stage_idx,
+        lane_idx=lane_idx,
+        loc=loc,
+        ip=ip,
+    )
+
+
 def stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
     sA_tma_physical: cute.Tensor,
     sB_tma_physical: cute.Tensor,
@@ -694,7 +1118,6 @@ def stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
         loc=loc,
         ip=ip,
     )
-
 
 @dsl_user_op
 def _ldmatrix_x4_shared_b16(
@@ -740,7 +1163,7 @@ def load_mxf4nvf4_packed_ldsm_kblock_fragments(
     loc: Optional[ir.Location] = None,
     ip: Optional[ir.InsertionPoint] = None,
 ) -> None:
-    """Load one K64 block of packed A/B fragments from SMEM to registers."""
+    """Compatibility manual inline-LDSM load for one K64 A/B block."""
     a_src = tCsA[(None, k_block_idx * 64, stage_idx)]
     b_src = tCsB[(None, k_block_idx * 64, stage_idx)]
     _ldmatrix_x4_shared_b16(a_src, tCrA, transpose=False, loc=loc, ip=ip)
@@ -765,7 +1188,11 @@ def load_mxf4nvf4_ldsm_scratch_fragments(
     loc: Optional[ir.Location] = None,
     ip: Optional[ir.InsertionPoint] = None,
 ) -> None:
-    """Load A/B fragments from one staged K64 LDSM scratch tile."""
+    """Compatibility manual inline-LDSM load from staged scratch.
+
+    New kernels should prefer `load_mxf4nvf4_ab_fragments_from_consumer_smem()`
+    once their A/B data is in the SM120 consumer SMEM layout.
+    """
     copy_a, tCsA, tCrA, copy_b, tCsB, tCrB = (
         make_mxf4nvf4_ab_ldsm_copy_views_from_scratch(
             tiled_mma,
@@ -1067,20 +1494,23 @@ __all__ = [
     "MXF4NVF4_SCALE_TMA_BYTES",
     "MXF4NVF4_SCALE_VEC_SIZE",
     "MXF4NVF4_TMA_DESC_BYTES",
-    "allocate_mxf4nvf4_ldsm_scratch",
     "allocate_mxf4nvf4_scale_fragment_scratch",
-    "load_mxf4nvf4_ldsm_scratch_fragments",
-    "load_mxf4nvf4_packed_ldsm_kblock_fragments",
+    "fp4_shift_mxf4nvf4_a",
+    "fp4_shift_mxf4nvf4_b",
+    "load_mxf4nvf4_ab_fragments_from_consumer_smem",
     "load_mxf4nvf4_sfa_fragment",
     "load_mxf4nvf4_sfb_fragment",
-    "make_mxf4nvf4_ab_ldsm_copy_views",
-    "make_mxf4nvf4_ab_ldsm_copy_views_from_scratch",
-    "make_mxf4nvf4_ab_ldsm_scratch_layout",
+    "make_mxf4nvf4_a_consumer_smem_layout_staged",
+    "make_mxf4nvf4_ab_consumer_microtile_views",
+    "make_mxf4nvf4_ab_consumer_smem_views",
+    "make_mxf4nvf4_ab_fragments_from_consumer_smem",
+    "make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem",
     "make_mxf4nvf4_ab_smem_views",
+    "make_mxf4nvf4_ab_smem_copy_atoms",
     "make_mxf4nvf4_ab_tma_physical_layout_staged",
+    "make_mxf4nvf4_b_consumer_smem_layout_staged",
+    "make_mxf4nvf4_consumer_smem_layout_atom_ab",
     "make_mxf4nvf4_external_tma_desc_ptr",
-    "make_mxf4nvf4_ldsm_copy_atom",
-    "make_mxf4nvf4_ldsm_scratch_views",
     "make_mxf4nvf4_scale_fragment_scratch_layout",
     "make_mxf4nvf4_scale_fragment_scratch_views",
     "make_mxf4nvf4_scale_fragment_views_from_compact_smem",
@@ -1102,9 +1532,10 @@ __all__ = [
     "mxf4nvf4_ab_tma_tx_bytes",
     "mxf4nvf4_full_tma_tx_bytes",
     "mxf4nvf4_scale_tma_tx_bytes",
-    "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch",
-    "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch",
-    "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch",
+    "shift_mxf4nvf4_post_ldsm_fp4_fragment",
+    "stage_mxf4nvf4_a_tma_physical_to_consumer_smem",
+    "stage_mxf4nvf4_ab_tma_physical_to_consumer_smem",
+    "stage_mxf4nvf4_b_tma_physical_to_consumer_smem",
     "stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch",
     "stage_mxf4nvf4_sfa_tma_physical_to_fragment_scratch",
     "stage_mxf4nvf4_sfb_tma_physical_to_fragment_scratch",

--- a/python/CuTeDSL/cutlass/utils/tensormap_manager.py
+++ b/python/CuTeDSL/cutlass/utils/tensormap_manager.py
@@ -11,7 +11,16 @@
 
 from dataclasses import dataclass
 from enum import Enum, auto
+import ctypes
+import ctypes.util
 from typing import Optional, Tuple
+
+from cutlass.base_dsl.common import CudaDriverDependencyError
+
+try:
+    from cuda.bindings import driver as _cuda_driver
+except ImportError:
+    _cuda_driver = None
 
 from cutlass._mlir import ir
 import cutlass._mlir.dialects.cute as _cute_ir
@@ -22,6 +31,366 @@ import cutlass.cute as cute
 from cutlass import const_expr
 from cutlass.cute.core import AddressSpace as _CuteAddressSpace
 from cutlass.cute.core import make_ptr as _cute_make_ptr
+
+
+SM120_MXF4NVF4_TENSOR_MAP_BYTES = 128
+SM120_MXF4NVF4_SCALE_K_GRANULARITY = 16
+
+
+def _cuda_enum_value(enum_value) -> int:
+    """Return the integer ABI value for a cuda.bindings Driver enum."""
+    return int(enum_value.value if hasattr(enum_value, "value") else enum_value)
+
+
+def _require_cuda_bindings_driver():
+    if _cuda_driver is None:
+        raise CudaDriverDependencyError(
+            "SM120 MXF4/NVFP4 tensor-map helpers require cuda.bindings.driver"
+        )
+    return _cuda_driver
+
+
+_CUDA_TENSORMAP_ENCODER = None
+
+
+class _CUtensorMap(ctypes.Structure):
+    _fields_ = [("opaque", ctypes.c_ulonglong * 16)]
+
+
+def _make_aligned_cu_tensor_map():
+    raw = (ctypes.c_ubyte * (ctypes.sizeof(_CUtensorMap) + 63))()
+    base = ctypes.addressof(raw)
+    aligned = (base + 63) & ~63
+    tensor_map = ctypes.cast(aligned, ctypes.POINTER(_CUtensorMap)).contents
+    return raw, tensor_map, aligned
+
+
+def _cu_tensor_map_to_bytes(address: int) -> bytes:
+    return bytes(ctypes.string_at(address, ctypes.sizeof(_CUtensorMap)))
+
+
+def _get_cuda_tensormap_encoder():
+    global _CUDA_TENSORMAP_ENCODER
+    if _CUDA_TENSORMAP_ENCODER is not None:
+        return _CUDA_TENSORMAP_ENCODER
+
+    cuda_library = ctypes.util.find_library("cuda") or "libcuda.so.1"
+    try:
+        libcuda = ctypes.CDLL(cuda_library)
+    except OSError as exc:
+        raise CudaDriverDependencyError(
+            "CUDA Driver API is required to build SM120 MXF4/NVFP4 tensor maps, "
+            f"but {cuda_library!r} could not be loaded"
+        ) from exc
+
+    cu_init = libcuda.cuInit
+    cu_init.argtypes = [ctypes.c_uint]
+    cu_init.restype = ctypes.c_int
+    result = cu_init(0)
+    if result != 0:
+        raise CudaDriverDependencyError(f"cuInit failed with status {result}")
+
+    try:
+        encode = libcuda.cuTensorMapEncodeTiled
+    except AttributeError as exc:
+        raise CudaDriverDependencyError(
+            "CUDA Driver API cuTensorMapEncodeTiled is unavailable for SM120 "
+            "MXF4/NVFP4 tensor maps"
+        ) from exc
+    encode.argtypes = [
+        ctypes.POINTER(_CUtensorMap),
+        ctypes.c_int,
+        ctypes.c_uint,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_ulonglong),
+        ctypes.POINTER(ctypes.c_ulonglong),
+        ctypes.POINTER(ctypes.c_uint),
+        ctypes.POINTER(ctypes.c_uint),
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+    ]
+    encode.restype = ctypes.c_int
+    _CUDA_TENSORMAP_ENCODER = encode
+    return encode
+
+
+def sm120_mxf4nvf4_padded_scale_k_extent(logical_scale_k_extent: int) -> int:
+    """Return the SM120 padded physical scale-K extent for the temporary descriptor path."""
+    if logical_scale_k_extent <= 0:
+        raise ValueError("logical_scale_k_extent must be positive")
+    granularity = SM120_MXF4NVF4_SCALE_K_GRANULARITY
+    return ((logical_scale_k_extent + granularity - 1) // granularity) * granularity
+
+
+def validate_sm120_mxf4nvf4_tma_desc(
+    *,
+    base_ptr: int,
+    desc_ptr: int | None = None,
+    global_dim: tuple[int, int, int],
+    global_strides_bytes: tuple[int, int],
+    box_dim: tuple[int, int, int],
+    element_strides: tuple[int, int, int] = (1, 1, 1),
+    tx_count: int | None = None,
+    align16: bool = True,
+) -> None:
+    """Validate the SM120 temporary Driver API descriptor path for NVFP4 A/B TMA."""
+    if not align16:
+        raise ValueError("SM120 MXF4NVF4 supports only 16U4_ALIGN16B descriptors")
+    if base_ptr % 32 != 0:
+        raise ValueError("SM120 MXF4NVF4 base pointer must be 32B aligned")
+    if desc_ptr is not None and desc_ptr % 64 != 0:
+        raise ValueError("SM120 MXF4NVF4 descriptor storage must be 64B aligned")
+    if len(global_dim) != 3 or len(box_dim) != 3 or len(global_strides_bytes) != 2:
+        raise ValueError("SM120 MXF4NVF4 tensor map expects rank 3")
+    if element_strides != (1, 1, 1):
+        raise ValueError("SM120 MXF4NVF4 element strides must be (1, 1, 1)")
+    if any(dim <= 0 for dim in global_dim + box_dim):
+        raise ValueError("SM120 MXF4NVF4 dimensions must be positive")
+    if any(box > dim for box, dim in zip(box_dim, global_dim)):
+        raise ValueError(
+            "SM120 MXF4NVF4 box dimensions must not exceed global dimensions"
+        )
+    if global_dim[0] % 128 != 0:
+        raise ValueError("SM120 MXF4NVF4 globalDim[0] must be a multiple of 128")
+    if box_dim[0] != 128:
+        raise ValueError("SM120 MXF4NVF4 boxDim[0] must equal 128")
+    if any(stride <= 0 or stride % 32 != 0 for stride in global_strides_bytes):
+        raise ValueError("SM120 MXF4NVF4 byte strides must be multiples of 32")
+    min_major_stride = (global_dim[0] + 1) // 2
+    if global_strides_bytes[0] < min_major_stride:
+        raise ValueError("SM120 MXF4NVF4 major byte stride overlaps K dimension")
+    min_l_stride = global_strides_bytes[0] * global_dim[1]
+    if global_strides_bytes[1] < min_l_stride:
+        raise ValueError("SM120 MXF4NVF4 L byte stride overlaps major dimension")
+    if tx_count is not None:
+        expected_tx = box_dim[0] * box_dim[1] * box_dim[2] // 2
+        if tx_count != expected_tx:
+            raise ValueError(f"SM120 MXF4NVF4 tx_count must be {expected_tx}")
+
+
+def validate_sm120_mxf4nvf4_scale_tma_desc(
+    *,
+    base_ptr: int,
+    desc_ptr: int | None = None,
+    global_dim: tuple[int, int, int, int],
+    global_strides_bytes: tuple[int, int, int],
+    box_dim: tuple[int, int, int, int],
+    element_strides: tuple[int, int, int, int] = (1, 1, 1, 1),
+    tx_count: int | None = None,
+) -> None:
+    """Validate the SM120 temporary Driver API descriptor path for NVFP4 scale TMA."""
+    if base_ptr % 16 != 0:
+        raise ValueError("SM120 MXF4NVF4 scale base pointer must be 16B aligned")
+    if desc_ptr is not None and desc_ptr % 64 != 0:
+        raise ValueError("SM120 MXF4NVF4 descriptor storage must be 64B aligned")
+    if len(global_dim) != 4 or len(box_dim) != 4 or len(global_strides_bytes) != 3:
+        raise ValueError("SM120 MXF4NVF4 scale tensor map expects rank 4")
+    if element_strides != (1, 1, 1, 1):
+        raise ValueError("SM120 MXF4NVF4 scale element strides must be (1, 1, 1, 1)")
+    if any(dim <= 0 for dim in global_dim + box_dim):
+        raise ValueError("SM120 MXF4NVF4 scale dimensions must be positive")
+    if any(box > dim for box, dim in zip(box_dim, global_dim)):
+        raise ValueError(
+            "SM120 MXF4NVF4 scale box dimensions must not exceed global dimensions"
+        )
+    if global_dim[1] % SM120_MXF4NVF4_SCALE_K_GRANULARITY != 0:
+        raise ValueError("SM120 MXF4NVF4 scale-K extent must be padded to 16")
+    if global_dim[1] < SM120_MXF4NVF4_SCALE_K_GRANULARITY:
+        raise ValueError("SM120 MXF4NVF4 scale-K extent must be padded to 16")
+    if box_dim[1] > global_dim[1]:
+        raise ValueError("SM120 MXF4NVF4 logical scale-K box exceeds padded extent")
+    if any(stride <= 0 or stride % 16 != 0 for stride in global_strides_bytes):
+        raise ValueError("SM120 MXF4NVF4 scale byte strides must be multiples of 16")
+    if global_strides_bytes[0] < global_dim[0]:
+        raise ValueError("SM120 MXF4NVF4 scale K byte stride overlaps major dimension")
+    if global_strides_bytes[1] < global_strides_bytes[0] * global_dim[1]:
+        raise ValueError("SM120 MXF4NVF4 scale tile byte stride overlaps scale-K")
+    if global_strides_bytes[2] < global_strides_bytes[1] * global_dim[2]:
+        raise ValueError("SM120 MXF4NVF4 scale L byte stride overlaps tile dimension")
+    if tx_count is not None:
+        expected_tx = box_dim[0] * box_dim[1] * box_dim[2] * box_dim[3]
+        if tx_count != expected_tx:
+            raise ValueError(f"SM120 MXF4NVF4 scale tx_count must be {expected_tx}")
+
+
+def _fp4_stride_elems_to_bytes(stride: int, name: str) -> int:
+    if stride % 2 != 0:
+        raise ValueError(f"{name} must be even for packed FP4")
+    return stride // 2
+
+
+def make_sm120_mxf4nvf4_tma_desc_bytes(
+    global_address: int,
+    *,
+    major_extent: int = 128,
+    k_extent: int = 128,
+    l_extent: int = 1,
+    box_major_extent: int | None = None,
+    major_stride: int | None = None,
+    l_stride: int | None = None,
+    align16: bool = True,
+    l2_promotion_128b: bool = True,
+    swizzle_128b: bool = True,
+) -> bytes:
+    """Build experimental SM120 Driver API descriptor bytes for NVFP4 A/B TMA.
+
+    This is an internal workaround until native CuTe descriptor lowering matches the
+    required SM120 NVFP4 tensor-map encoding.
+    """
+    if any(extent <= 0 for extent in (major_extent, k_extent, l_extent)):
+        raise ValueError("SM120 MXF4NVF4 extents must be positive")
+    box_major_extent = major_extent if box_major_extent is None else box_major_extent
+    if box_major_extent <= 0:
+        raise ValueError("SM120 MXF4NVF4 box_major_extent must be positive")
+    cuda_driver = _require_cuda_bindings_driver()
+    major_stride_elems = k_extent if major_stride is None else major_stride
+    l_stride_elems = (
+        major_stride_elems * major_extent if l_stride is None else l_stride
+    )
+    global_dim = (k_extent, major_extent, l_extent)
+    global_strides_bytes = (
+        _fp4_stride_elems_to_bytes(major_stride_elems, "major_stride"),
+        _fp4_stride_elems_to_bytes(l_stride_elems, "l_stride"),
+    )
+    box_dim = (128, box_major_extent, 1)
+    element_strides = (1, 1, 1)
+    raw, tensor_map, address = _make_aligned_cu_tensor_map()
+    validate_sm120_mxf4nvf4_tma_desc(
+        base_ptr=global_address,
+        desc_ptr=address,
+        global_dim=global_dim,
+        global_strides_bytes=global_strides_bytes,
+        box_dim=box_dim,
+        element_strides=element_strides,
+        tx_count=box_dim[0] * box_dim[1] * box_dim[2] // 2,
+        align16=align16,
+    )
+    encode = _get_cuda_tensormap_encoder()
+    result = encode(
+        ctypes.pointer(tensor_map),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
+        ),
+        3,
+        ctypes.c_void_p(global_address),
+        (ctypes.c_ulonglong * 3)(*global_dim),
+        (ctypes.c_ulonglong * 2)(*global_strides_bytes),
+        (ctypes.c_uint * 3)(*box_dim),
+        (ctypes.c_uint * 3)(*element_strides),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE
+        ),
+        _cuda_enum_value(cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B)
+        if swizzle_128b
+        else _cuda_enum_value(
+            cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_NONE
+        ),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B
+        )
+        if l2_promotion_128b
+        else _cuda_enum_value(
+            cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE
+        ),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+        ),
+    )
+    if result != 0:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with status {result}")
+    _ = raw
+    return _cu_tensor_map_to_bytes(address)
+
+
+def make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+    global_address: int,
+    *,
+    major_extent: int = 128,
+    scale_k_extent: int = 16,
+    logical_scale_k_extent: int = 8,
+    tile_extent: int = 1,
+    l_extent: int = 1,
+    box_major_extent: int | None = None,
+    major_stride: int | None = None,
+    tile_stride: int | None = None,
+    l_stride: int | None = None,
+    l2_promotion_128b: bool = True,
+) -> bytes:
+    """Build experimental SM120 Driver API descriptor bytes for NVFP4 scale TMA.
+
+    This is an internal workaround until native CuTe descriptor lowering matches the
+    required SM120 NVFP4 tensor-map encoding.
+    """
+    if any(
+        extent <= 0
+        for extent in (
+            major_extent,
+            scale_k_extent,
+            logical_scale_k_extent,
+            tile_extent,
+            l_extent,
+        )
+    ):
+        raise ValueError("SM120 MXF4NVF4 scale extents must be positive")
+    padded_scale_k_extent = sm120_mxf4nvf4_padded_scale_k_extent(
+        logical_scale_k_extent
+    )
+    if scale_k_extent != padded_scale_k_extent:
+        raise ValueError(
+            "SM120 MXF4NVF4 scale_k_extent must be the padded physical extent"
+        )
+    box_major_extent = major_extent if box_major_extent is None else box_major_extent
+    if box_major_extent <= 0:
+        raise ValueError("SM120 MXF4NVF4 scale box_major_extent must be positive")
+    cuda_driver = _require_cuda_bindings_driver()
+    major_stride = major_extent if major_stride is None else major_stride
+    tile_stride = major_stride * scale_k_extent if tile_stride is None else tile_stride
+    l_stride = tile_stride * tile_extent if l_stride is None else l_stride
+    global_dim = (major_extent, scale_k_extent, tile_extent, l_extent)
+    global_strides_bytes = (major_stride, tile_stride, l_stride)
+    box_dim = (box_major_extent, logical_scale_k_extent, 1, 1)
+    element_strides = (1, 1, 1, 1)
+    raw, tensor_map, address = _make_aligned_cu_tensor_map()
+    validate_sm120_mxf4nvf4_scale_tma_desc(
+        base_ptr=global_address,
+        desc_ptr=address,
+        global_dim=global_dim,
+        global_strides_bytes=global_strides_bytes,
+        box_dim=box_dim,
+        element_strides=element_strides,
+        tx_count=box_dim[0] * box_dim[1] * box_dim[2] * box_dim[3],
+    )
+    encode = _get_cuda_tensormap_encoder()
+    result = encode(
+        ctypes.pointer(tensor_map),
+        _cuda_enum_value(cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8),
+        4,
+        ctypes.c_void_p(global_address),
+        (ctypes.c_ulonglong * 4)(*global_dim),
+        (ctypes.c_ulonglong * 3)(*global_strides_bytes),
+        (ctypes.c_uint * 4)(*box_dim),
+        (ctypes.c_uint * 4)(*element_strides),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE
+        ),
+        _cuda_enum_value(cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B
+        )
+        if l2_promotion_128b
+        else _cuda_enum_value(
+            cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE
+        ),
+        _cuda_enum_value(
+            cuda_driver.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+        ),
+    )
+    if result != 0:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with status {result}")
+    _ = raw
+    return _cu_tensor_map_to_bytes(address)
 
 
 class TensorMapUpdateMode(Enum):

--- a/python/CuTeDSL/docs/sm120_mxf4nvf4_layout_contract.md
+++ b/python/CuTeDSL/docs/sm120_mxf4nvf4_layout_contract.md
@@ -1,0 +1,92 @@
+# SM120 MXF4NVF4 Layout Contract
+
+This note records the narrow CuTe DSL contract for SM120 MXF4NVF4 helper APIs.
+It is based on the C++ collective path selected by Blackwell GeForce example
+79a, but the Python API names remain generic SM120/MXF4NVF4 names.
+
+## External Descriptor TMA
+
+A/B external descriptors describe a rank-3 logical tile `(K, major, L)`.
+One 128x128 packed FP4 A or B TMA transaction transfers 8192 payload bytes.
+The physical ALIGN16B shared-memory destination occupies 16384 byte slots.
+
+SFA/SFB external descriptors describe a rank-4 scale tile and transfer 1024
+bytes each. A full A/B/SFA/SFB pipeline stage therefore accounts for 18432 TMA
+transaction bytes.
+
+External descriptor TMA issue paths must acquire the tensor-map descriptor
+before issuing the TMA instruction.
+
+## A/B Consumer SMEM
+
+The production A/B consumer path is the C++ collective contract:
+
+```text
+Sw<2,4,3> o smem_ptr[4b] o (_8,_128):(_128,_1)
+```
+
+The source tensor passed to LDSM partitioning is made position independent:
+
+```text
+as_position_independent_swizzle_tensor(sA/sB)
+make_tiled_copy_A/B(non-transposed LDSM_N)
+partition_S(...)
+retile_D(...)
+cute.copy(...)
+fp4_shift_A/B(...)
+bundled MXF4NVF4 cute.gemm(...)
+```
+
+For this SM120 MXF4NVF4 LDSM tiled-copy path, Python CuTe's `retile_D` helper
+aliases the existing `retile()` lowering and is covered by the logical A/B
+consumer tests. It should not be read as a blanket statement about every copy
+atom.
+
+The B operand uses the same non-transposed SM75 `x4` LDSM form as A. Logical B
+major-to-output-N mapping comes from the composed consumer SMEM layout,
+`make_tiled_copy_B`, destination retile, and the post-LDSM FP4 shift.
+In Python CuTe DSL the explicit `fp4_shift_A/B` hook is a validated no-op for
+typed `Float4E2M1FN` LDSM copies because the typed copy already produces the
+fragment encoding consumed by SM120 MXF4NVF4 MMA.
+
+The older manual inline-LDSM scratch helpers remain compatibility-only. They
+are not part of the public `__all__` surface for new kernels.
+
+The current external-descriptor path stages A/B through the physical TMA
+layout, then uses a CUTLASS-owned physical-to-consumer adapter before the
+consumer copy. That adapter restores logical packed-FP4 byte order from the
+16U4_ALIGN16B physical slots and writes through the SM120 consumer tensor
+layout used by `as_position_independent_swizzle_tensor`. Global major offsets
+belong in the tensor-map coordinates; the adapter stages one local 128-major
+tile and rejects nonzero major offsets. The adapter `consumer_stage_idx`
+selects the destination consumer stage; pass a sliced physical-stage view when
+staging from a nonzero physical TMA stage.
+
+Consumer helpers take warp-local lane indices. In a multi-warp CTA, pass
+`threadIdx.x % 32` to A/B consumer-fragment helpers and to staging helpers.
+Call the physical-to-consumer staging helper from the intended staging
+warp/cohort, then synchronize before consumer warps load fragments. Use
+`make_mxf4nvf4_ab_consumer_microtile_views()` or the `m_atom`/`n_atom`
+arguments on the fragment/load helpers to select a local 16x8 output atom
+inside the staged 128x128 CTA tile.
+
+## Scale Bridge
+
+The rank-4 scale physical layout is adapted into fragment-compatible scratch by
+mapping logical payload order:
+
+```text
+payload_idx = scale_col * 128 + major
+scratch_idx = local_major * 8 + scale_col
+```
+
+Strict runtime coverage should keep the two-K64 scale canary where A/B are
+`0x22`, SFB is `1.0`, SFA columns `0..3` are `1.0`, SFA columns `4..7` are
+`2.0`, and the expected accumulator value is `192.0`.
+
+## Downstream Contract
+
+Downstream kernels own scheduling, descriptor lifetimes, producer/consumer warp
+partitioning, pipeline loops, and epilogues. They should not duplicate A/B byte
+rank maps, B register permutations, inline LDSM register extraction, or scale
+physical swizzle logic.

--- a/python/CuTeDSL/prep_editable_install.py
+++ b/python/CuTeDSL/prep_editable_install.py
@@ -23,7 +23,7 @@ import tempfile
 import zipfile
 import re
 from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple
 import logging
 
 # Configure logging
@@ -32,6 +32,20 @@ logger = logging.getLogger(__name__)
 
 # Constants
 PACKAGE_NAME = "nvidia-cutlass-dsl"
+RUNTIME_PACKAGE_PREFIX = "nvidia-cutlass-dsl-libs-"
+RUNTIME_PROVIDER_ENV = "CUTLASS_DSL_RUNTIME_PROVIDER"
+DEFAULT_RUNTIME_PROVIDER = "base"
+GENERATED_RUNTIME_DIRS = (
+    Path("cutlass") / "_mlir",
+    Path("lib"),
+)
+GENERATED_RUNTIME_FILE_GLOBS = (
+    str(Path("cutlass") / "**" / "py.typed"),
+)
+REQUIRED_RUNTIME_ARTIFACTS = (
+    Path("cutlass") / "_mlir",
+    Path("lib"),
+)
 
 
 class CutlassDSLSetupError(Exception):
@@ -61,6 +75,65 @@ def get_package_spec(requirements_path: Optional[Path] = None) -> str:
     return PACKAGE_NAME
 
 
+def download_requirement(requirement_spec: str, temp_dir: Path) -> Path:
+    """
+    Download one wheel to a temporary directory without dependencies.
+
+    Args:
+        requirement_spec: pip requirement spec to download
+        temp_dir: Temporary directory path for downloading
+
+    Returns:
+        Path to the downloaded wheel file
+
+    Raises:
+        CutlassDSLSetupError: If download fails or wheel not found
+    """
+    logger.info(f"Downloading {requirement_spec} wheel to {temp_dir}")
+    before = set(temp_dir.glob("*.whl"))
+
+    try:
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "download",
+                "--no-deps",
+                requirement_spec,
+                "--dest",
+                str(temp_dir),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as e:
+        error_msg = f"Failed to download {requirement_spec}: {e}"
+        if e.stdout:
+            error_msg += f"\nstdout: {e.stdout.decode()}"
+        if e.stderr:
+            error_msg += f"\nstderr: {e.stderr.decode()}"
+        raise CutlassDSLSetupError(error_msg)
+
+    # Find the newly downloaded wheel file.
+    wheel_pattern = "*.whl"
+    wheel_files = [path for path in temp_dir.glob(wheel_pattern) if path not in before]
+    if not wheel_files:
+        raise CutlassDSLSetupError(
+            f"No wheel file matching {wheel_pattern} found after downloading "
+            f"{requirement_spec}"
+        )
+    if len(wheel_files) != 1:
+        raise CutlassDSLSetupError(
+            f"Expected one wheel for {requirement_spec}, found "
+            f"{[path.name for path in wheel_files]}"
+        )
+
+    wheel_path = wheel_files[0]
+    logger.info(f"Successfully downloaded: {wheel_path.name}")
+    return wheel_path
+
+
 def download_wheel(temp_dir: Path) -> Path:
     """
     Download the nvidia-cutlass-dsl wheel to a temporary directory.
@@ -76,43 +149,7 @@ def download_wheel(temp_dir: Path) -> Path:
     """
     # Resolve package spec from requirements, or fall back to PACKAGE_NAME
     package_spec = get_package_spec()
-
-    logger.info(f"Downloading {package_spec} wheel to {temp_dir}")
-
-    try:
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "download",
-                "--no-deps",
-                package_spec,
-                "--dest",
-                str(temp_dir),
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except subprocess.CalledProcessError as e:
-        error_msg = f"Failed to download {PACKAGE_NAME}: {e}"
-        if e.stdout:
-            error_msg += f"\nstdout: {e.stdout.decode()}"
-        if e.stderr:
-            error_msg += f"\nstderr: {e.stderr.decode()}"
-        raise CutlassDSLSetupError(error_msg)
-
-    # Find the downloaded wheel file
-    wheel_pattern = f"*.whl"
-    wheel_files = list(temp_dir.glob(wheel_pattern))
-    if not wheel_files:
-        raise CutlassDSLSetupError(
-            f"No wheel file matching {wheel_pattern} found after download"
-        )
-
-    wheel_path = wheel_files[0]
-    logger.info(f"Successfully downloaded: {wheel_path.name}")
-    return wheel_path
+    return download_requirement(package_spec, temp_dir)
 
 
 def extract_version_from_wheel(wheel_path: Path) -> str:
@@ -159,6 +196,116 @@ def extract_version_from_wheel(wheel_path: Path) -> str:
         return "9.9.9.dev0"
 
 
+def read_wheel_metadata(wheel_path: Path) -> str:
+    """Read the METADATA payload from a wheel."""
+    try:
+        with zipfile.ZipFile(wheel_path, "r") as wheel_zip:
+            metadata_files = [
+                name
+                for name in wheel_zip.namelist()
+                if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_files) != 1:
+                raise CutlassDSLSetupError(
+                    f"Expected one METADATA file in {wheel_path.name}, found "
+                    f"{metadata_files}"
+                )
+            return wheel_zip.read(metadata_files[0]).decode("utf-8")
+    except zipfile.BadZipFile as e:
+        raise CutlassDSLSetupError(f"Invalid wheel file {wheel_path}: {e}")
+
+
+def _canonical_package_name(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def _extract_runtime_requires(metadata: str) -> dict[str, str]:
+    """Return exact runtime companion requirements keyed by provider name."""
+    runtime_requires: dict[str, str] = {}
+    for raw_line in metadata.splitlines():
+        if not raw_line.startswith("Requires-Dist:"):
+            continue
+        requirement = raw_line.split(":", 1)[1].strip()
+        requirement_name = re.split(r"[ ;(<>=!~]", requirement, maxsplit=1)[0]
+        requirement_name = _canonical_package_name(requirement_name)
+        if not requirement_name.startswith(RUNTIME_PACKAGE_PREFIX):
+            continue
+        provider = requirement_name.removeprefix(RUNTIME_PACKAGE_PREFIX)
+        version_match = re.search(r"==\s*([A-Za-z0-9_.!+\-]+)", requirement)
+        if version_match is None:
+            raise CutlassDSLSetupError(
+                "Runtime companion dependency must be exact-pinned, got "
+                f"{requirement!r}"
+            )
+        runtime_requires[provider] = (
+            f"{RUNTIME_PACKAGE_PREFIX}{provider}=={version_match.group(1)}"
+        )
+    return runtime_requires
+
+
+def _runtime_provider_from_package_spec(package_spec: str) -> str | None:
+    extras_match = re.search(r"\[([^\]]+)\]", package_spec)
+    if extras_match is None:
+        return None
+    extras = {
+        item.strip().lower().replace("_", "-")
+        for item in extras_match.group(1).split(",")
+        if item.strip()
+    }
+    providers = [extra for extra in extras if extra]
+    if len(providers) > 1:
+        raise CutlassDSLSetupError(
+            "Editable install runtime provider must be unique when selected "
+            f"through extras, got {providers}"
+        )
+    return providers[0] if providers else None
+
+
+def select_runtime_provider(runtime_requires: dict[str, str]) -> str:
+    """Select a runtime companion provider without consulting site-packages."""
+    requested_provider = None
+    try:
+        import os
+
+        requested_provider = os.environ.get(RUNTIME_PROVIDER_ENV)
+    except Exception:
+        requested_provider = None
+
+    if requested_provider:
+        provider = requested_provider.strip().lower().replace("_", "-")
+    else:
+        provider = _runtime_provider_from_package_spec(get_package_spec())
+        if provider is None:
+            provider = DEFAULT_RUNTIME_PROVIDER
+
+    if provider not in runtime_requires:
+        raise CutlassDSLSetupError(
+            f"Requested runtime provider {provider!r} is not available. "
+            f"Available providers: {sorted(runtime_requires)}. Set "
+            f"{RUNTIME_PROVIDER_ENV}=<provider> to select one explicitly."
+        )
+    logger.info(f"Selected runtime provider: {provider}")
+    return provider
+
+
+def download_runtime_payload_wheel(dsl_wheel_path: Path, temp_dir: Path) -> Path | None:
+    """
+    Download the exact runtime companion wheel required by nvidia-cutlass-dsl.
+
+    The generated Python payload and shared libraries must come from a companion
+    wheel whose version and provider match the downloaded DSL wheel metadata.
+    Copying from ambient site-packages is intentionally avoided because
+    nvidia-cutlass-dsl-libs-* wheels can install overlapping payload paths.
+    """
+    metadata = read_wheel_metadata(dsl_wheel_path)
+    runtime_requires = _extract_runtime_requires(metadata)
+    if not runtime_requires:
+        logger.info("No nvidia-cutlass-dsl runtime companion dependency found")
+        return None
+    provider = select_runtime_provider(runtime_requires)
+    return download_requirement(runtime_requires[provider], temp_dir)
+
+
 def extract_wheel_contents(wheel_path: Path, extract_dir: Path) -> None:
     """
     Extract wheel contents to specified directory.
@@ -182,6 +329,47 @@ def extract_wheel_contents(wheel_path: Path, extract_dir: Path) -> None:
         raise CutlassDSLSetupError(f"Failed to extract wheel: {e}")
 
 
+def clean_generated_runtime_payload(package_root: Path) -> None:
+    """
+    Remove generated runtime payload copied by previous editable setup runs.
+
+    The _mlir Python package, runtime shared library directory, and py.typed
+    markers come from the downloaded runtime wheel. They must be replaced as a
+    unit to avoid stale Python/.so skew across runtime package versions.
+    """
+    for rel_path in GENERATED_RUNTIME_DIRS:
+        path = package_root / rel_path
+        if path.exists():
+            logger.info(f"Removing generated runtime directory {path}")
+            shutil.rmtree(path)
+
+    for pattern in GENERATED_RUNTIME_FILE_GLOBS:
+        for path in package_root.glob(pattern):
+            if path.is_file():
+                logger.info(f"Removing generated runtime file {path}")
+                path.unlink()
+
+
+def validate_runtime_payload(package_root: Path) -> None:
+    """Validate that editable setup left the required runtime payload in place."""
+    missing = [
+        str(package_root / rel_path)
+        for rel_path in REQUIRED_RUNTIME_ARTIFACTS
+        if not (package_root / rel_path).exists()
+    ]
+    if missing:
+        raise CutlassDSLSetupError(
+            "Editable CuTe DSL runtime payload is incomplete; missing "
+            f"{missing}"
+        )
+
+    if not any((package_root / "lib").glob("*.so")):
+        raise CutlassDSLSetupError(
+            "Editable CuTe DSL runtime payload is incomplete; "
+            f"no shared libraries found in {package_root / 'lib'}"
+        )
+
+
 def copy_library_files(extract_dir: Path, package_root: Path) -> int:
     """
     Copy .so library files from extracted wheel to package lib directory.
@@ -193,7 +381,6 @@ def copy_library_files(extract_dir: Path, package_root: Path) -> int:
     Returns:
         Number of files copied
     """
-    lib_pattern = extract_dir / "**" / "lib" / "*.so"
     so_files = [f for f in extract_dir.rglob("lib/*.so")]
 
     if not so_files:
@@ -240,7 +427,7 @@ def copy_python_packages(extract_dir: Path, package_root: Path) -> Tuple[int, in
     cutlass_source_dir = cutlass_source_dirs[0]
     cutlass_dest_dir = package_root / "cutlass"
 
-    logger.info(f"Found python_packages/cutlass/ directory")
+    logger.info("Found python_packages/cutlass/ directory")
     logger.info(f"Copying from {cutlass_source_dir} to {cutlass_dest_dir}")
 
     copied_count = 0
@@ -256,7 +443,8 @@ def copy_python_packages(extract_dir: Path, package_root: Path) -> Tuple[int, in
             # Create parent directories
             dest_file.parent.mkdir(parents=True, exist_ok=True)
 
-            # Copy file if it doesn't exist
+            # Copy runtime files only when they do not overlap with source files.
+            # Generated payload state is cleaned before this pass.
             if dest_file.exists():
                 skipped_count += 1
                 logger.debug(f"  Skipping {rel_path} (already exists)")
@@ -310,11 +498,23 @@ def prep_editable_install() -> None:
         version = extract_version_from_wheel(wheel_path)
         extract_wheel_contents(wheel_path, extract_dir)
 
-        # Copy files
+        # Download and extract the exact companion runtime payload when the
+        # DSL wheel declares one. The payload provider can be selected with
+        # CUTLASS_DSL_RUNTIME_PROVIDER=base/cu13.
+        runtime_wheel_path = download_runtime_payload_wheel(wheel_path, temp_dir)
+        if runtime_wheel_path is not None:
+            extract_wheel_contents(runtime_wheel_path, extract_dir)
+
+        # Replace generated runtime files as a unit so stale _mlir/Python
+        # payloads cannot survive across runtime package version changes.
+        clean_generated_runtime_payload(package_root)
+
+        # Copy files from the downloaded wheels.
         lib_files_copied = copy_library_files(extract_dir, package_root)
         py_files_copied, py_files_skipped = copy_python_packages(
             extract_dir, package_root
         )
+        validate_runtime_payload(package_root)
 
         # Write version file
         write_version_file(version, package_root)

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_bf16_tma_store_partition.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_bf16_tma_store_partition.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import make_fake_compact_tensor
+from cutlass.utils import LayoutEnum
+import cutlass.utils.blackwell_helpers as blackwell_helpers
+
+
+_TILE_SHAPE_MN = (128, 128)
+_EPI_TILE = (32, 32)
+_COMPILE_OPTIONS = "--gpu-arch=sm_120a --enable-tvm-ffi"
+
+
+def _make_n_major_bf16_d():
+    return make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (128, 128, 1),
+        stride_order=(1, 0, 2),
+        assumed_align=16,
+    )
+
+
+@cute.jit
+def _compile_returned_tensor_partition(d: cute.Tensor):
+    _returned_tensor_partition_kernel(d).launch(
+        grid=(1, 1, 1),
+        block=(128, 1, 1),
+        smem=16384,
+    )
+
+
+@cute.kernel
+def _returned_tensor_partition_kernel(d: cute.Tensor):
+    smem = cutlass.utils.SmemAllocator()
+
+    d_layout = LayoutEnum.from_tensor(d)
+    smem_layout = blackwell_helpers.make_smem_layout_epi(
+        d.element_type,
+        d_layout,
+        _EPI_TILE,
+        1,
+    )
+    sD = smem.allocate_tensor(d.element_type, smem_layout, byte_alignment=1024)
+
+    epi_smem_layout = cute.slice_(smem_layout, (None, None, 0))
+    d_cta_v_layout = cute.composition(cute.make_identity_layout(d.shape), _EPI_TILE)
+    tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+        cpasync.CopyBulkTensorTileS2GOp(),
+        d,
+        epi_smem_layout,
+        d_cta_v_layout,
+    )
+
+    tD_mn = tma_tensor_d[None, None, 0]
+    tD_tile = cute.local_tile(tD_mn, _TILE_SHAPE_MN, (0, 0))
+    tD_epi = cute.flat_divide(tD_tile, _EPI_TILE)
+
+    cpasync.tma_partition(
+        tma_atom_d,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sD, 0, 2),
+        cute.group_modes(tD_epi, 0, 2),
+    )
+
+
+@cute.jit
+def _compile_helper_partition(d: cute.Tensor):
+    _helper_partition_kernel(d).launch(
+        grid=(1, 1, 1),
+        block=(128, 1, 1),
+        smem=16384,
+    )
+
+
+@cute.kernel
+def _helper_partition_kernel(d: cute.Tensor):
+    smem = cutlass.utils.SmemAllocator()
+
+    d_layout = LayoutEnum.from_tensor(d)
+    smem_layout = blackwell_helpers.make_smem_layout_epi(
+        d.element_type,
+        d_layout,
+        _EPI_TILE,
+        1,
+    )
+    sD = smem.allocate_tensor(d.element_type, smem_layout, byte_alignment=1024)
+
+    epi_smem_layout = cute.slice_(smem_layout, (None, None, 0))
+    d_cta_v_layout = cute.composition(cute.make_identity_layout(d.shape), _EPI_TILE)
+    tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+        cpasync.CopyBulkTensorTileS2GOp(),
+        d,
+        epi_smem_layout,
+        d_cta_v_layout,
+    )
+
+    cpasync.tma_partition_s2g_tile(
+        tma_atom_d,
+        tma_tensor_d,
+        sD,
+        _TILE_SHAPE_MN,
+        _EPI_TILE,
+        (0, 0, 0, 0),
+    )
+
+
+@cute.jit
+def _compile_reduce_helper_partition(d: cute.Tensor):
+    _reduce_helper_partition_kernel(d).launch(
+        grid=(1, 1, 1),
+        block=(128, 1, 1),
+        smem=16384,
+    )
+
+
+@cute.kernel
+def _reduce_helper_partition_kernel(d: cute.Tensor):
+    smem = cutlass.utils.SmemAllocator()
+
+    d_layout = LayoutEnum.from_tensor(d)
+    smem_layout = blackwell_helpers.make_smem_layout_epi(
+        d.element_type,
+        d_layout,
+        _EPI_TILE,
+        1,
+    )
+    sD = smem.allocate_tensor(d.element_type, smem_layout, byte_alignment=1024)
+
+    epi_smem_layout = cute.slice_(smem_layout, (None, None, 0))
+    d_cta_v_layout = cute.composition(cute.make_identity_layout(d.shape), _EPI_TILE)
+    tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+        cpasync.CopyReduceBulkTensorTileS2GOp(),
+        d,
+        epi_smem_layout,
+        d_cta_v_layout,
+    )
+
+    cpasync.tma_partition_s2g_tile(
+        tma_atom_d,
+        tma_tensor_d,
+        sD,
+        _TILE_SHAPE_MN,
+        _EPI_TILE,
+        (0, 0, 0, 0),
+    )
+
+
+@cute.jit
+def _compile_ordinary_gmem_partition(d: cute.Tensor):
+    _ordinary_gmem_partition_kernel(d).launch(
+        grid=(1, 1, 1),
+        block=(128, 1, 1),
+        smem=16384,
+    )
+
+
+@cute.kernel
+def _ordinary_gmem_partition_kernel(d: cute.Tensor):
+    smem = cutlass.utils.SmemAllocator()
+
+    d_layout = LayoutEnum.from_tensor(d)
+    smem_layout = blackwell_helpers.make_smem_layout_epi(
+        d.element_type,
+        d_layout,
+        _EPI_TILE,
+        1,
+    )
+    sD = smem.allocate_tensor(d.element_type, smem_layout, byte_alignment=1024)
+
+    epi_smem_layout = cute.slice_(smem_layout, (None, None, 0))
+    d_cta_v_layout = cute.composition(cute.make_identity_layout(d.shape), _EPI_TILE)
+    tma_atom_d, _ = cpasync.make_tiled_tma_atom(
+        cpasync.CopyBulkTensorTileS2GOp(),
+        d,
+        epi_smem_layout,
+        d_cta_v_layout,
+    )
+
+    gD_mn = d[None, None, 0]
+    gD_tile = cute.local_tile(gD_mn, _TILE_SHAPE_MN, (0, 0))
+    gD_epi = cute.flat_divide(gD_tile, _EPI_TILE)
+
+    cpasync.tma_partition(
+        tma_atom_d,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sD, 0, 2),
+        cute.group_modes(gD_epi, 0, 2),
+    )
+
+
+@pytest.mark.parametrize(
+    "compile_fn",
+    [
+        _compile_returned_tensor_partition,
+        _compile_helper_partition,
+        _compile_reduce_helper_partition,
+    ],
+)
+def test_sm120_bf16_s2g_tma_store_partition_uses_returned_tma_tensor(compile_fn):
+    compiled = cute.compile(
+        compile_fn,
+        _make_n_major_bf16_d(),
+        options=_COMPILE_OPTIONS,
+    )
+    assert compiled
+
+
+def test_sm120_bf16_s2g_tma_store_partition_rejects_ordinary_gmem_tile():
+    with pytest.raises(ValueError, match="returned by cpasync.make_tiled_tma_atom"):
+        cute.compile(
+            _compile_ordinary_gmem_partition,
+            _make_n_major_bf16_d(),
+            options=_COMPILE_OPTIONS,
+        )
+
+
+def test_sm120_bf16_s2g_tma_store_partition_helper_rejects_short_coord():
+    class FakeS2GAtom:
+        op = cpasync.CopyBulkTensorTileS2GOp()
+
+    with pytest.raises(
+        ValueError, match="tile_coord_mnkl must have at least four modes"
+    ):
+        cpasync.tma_partition_s2g_tile(
+            FakeS2GAtom(),
+            _make_n_major_bf16_d(),
+            _make_n_major_bf16_d(),
+            _TILE_SHAPE_MN,
+            _EPI_TILE,
+            (0, 0, 0),
+        )

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_canary.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_canary.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import pipeline
+from cutlass.base_dsl.common import CudaDriverDependencyError
+from cutlass.cute.runtime import from_dlpack
+
+
+pytestmark = [pytest.mark.arch(["120a"])]
+
+
+def _aligned_u8_tensor(num_bytes: int, alignment: int):
+    torch = pytest.importorskip("torch")
+    storage = torch.empty(num_bytes + alignment - 1, device="cuda", dtype=torch.uint8)
+    offset = (-storage.data_ptr()) % alignment
+    view = storage[offset : offset + num_bytes]
+    assert view.data_ptr() % alignment == 0
+    return storage, view
+
+
+def _device_desc_from_bytes(desc_bytes: bytes):
+    torch = pytest.importorskip("torch")
+    storage, view = _aligned_u8_tensor(128, 128)
+    view.copy_(torch.tensor(list(desc_bytes), device="cuda", dtype=torch.uint8))
+    return storage, view
+
+
+@cute.kernel
+def _sm120_tma_canary_kernel(
+    desc: cute.Tensor,
+    out: cute.Tensor,
+    num_bytes: cutlass.Constexpr[int],
+    rank: cutlass.Constexpr[int],
+    tx_count: cutlass.Constexpr[int],
+    coord0: cutlass.Constexpr[int],
+    coord1: cutlass.Constexpr[int],
+    coord2: cutlass.Constexpr[int],
+    coord3: cutlass.Constexpr[int],
+):
+    smem = cutlass.utils.SmemAllocator()
+    smem_tensor = smem.allocate_tensor(
+        cutlass.Uint8, cute.make_layout(num_bytes), byte_alignment=128
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+    tidx, _, _ = cute.arch.thread_idx()
+
+    for i in cutlass.range(tidx, num_bytes, 32):
+        smem_tensor[i] = cutlass.Uint8(0xCD)
+    cute.arch.sync_threads()
+
+    pipe = pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+        consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+        tx_count=tx_count,
+        barrier_storage=barriers,
+    )
+    producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+    consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+
+    if rank == 3:
+        pipeline.producer_acquire_issue_tma_load_3d(
+            pipe,
+            producer_state,
+            None,
+            smem_tensor.iterator,
+            desc.iterator,
+            coord0,
+            coord1,
+            coord2,
+            already_elected=False,
+        )
+    else:
+        pipeline.producer_acquire_issue_tma_load_4d(
+            pipe,
+            producer_state,
+            None,
+            smem_tensor.iterator,
+            desc.iterator,
+            coord0,
+            coord1,
+            coord2,
+            coord3,
+            already_elected=False,
+        )
+
+    pipe.consumer_wait(consumer_state)
+    cute.arch.sync_threads()
+    for i in cutlass.range(tidx, num_bytes, 32):
+        out[i] = smem_tensor[i]
+    pipe.consumer_release(consumer_state)
+
+
+@cute.jit
+def _launch_sm120_tma_canary(
+    desc: cute.Tensor,
+    out: cute.Tensor,
+    num_bytes: cutlass.Constexpr[int],
+    rank: cutlass.Constexpr[int],
+    tx_count: cutlass.Constexpr[int],
+    coord0: cutlass.Constexpr[int],
+    coord1: cutlass.Constexpr[int],
+    coord2: cutlass.Constexpr[int],
+    coord3: cutlass.Constexpr[int],
+):
+    _sm120_tma_canary_kernel(
+        desc, out, num_bytes, rank, tx_count, coord0, coord1, coord2, coord3
+    ).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def _run_canary(desc_bytes, expected, output_bytes, rank, tx_count, coords, touched_bytes):
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    desc_storage, desc = _device_desc_from_bytes(desc_bytes)
+    out = torch.empty(output_bytes, device="cuda", dtype=torch.uint8)
+    out.fill_(0xCD)
+    assert int((out != 0).sum().item()) == output_bytes
+    cute_desc = from_dlpack(desc, assumed_align=128, enable_tvm_ffi=True)
+    cute_out = from_dlpack(out, assumed_align=16, enable_tvm_ffi=True)
+    cute.compile(
+        _launch_sm120_tma_canary,
+        cute_desc,
+        cute_out,
+        output_bytes,
+        rank,
+        tx_count,
+        coords[0],
+        coords[1],
+        coords[2],
+        coords[3],
+        options="--enable-tvm-ffi",
+    )(cute_desc, cute_out)
+    torch.cuda.synchronize()
+    assert desc_storage is not None
+    assert torch.equal(out, expected)
+    assert torch.all(out[touched_bytes:] == 0xCD)
+
+
+def _patterned_u8(torch, count: int):
+    values = torch.arange(count, device="cuda", dtype=torch.int32)
+    return torch.bitwise_xor(values, 0x5A).to(torch.uint8)
+
+
+def _expected_rank3_fp4_tma_output(torch, src, output_bytes: int):
+    expected = torch.full((output_bytes,), 0xCD, device="cuda", dtype=torch.uint8)
+    payload_bytes = src.numel()
+    for dst_payload_chunk in range(payload_bytes // 8):
+        # 16U4_ALIGN16B copies each 8-byte packed-FP4 payload chunk into the
+        # first half of a 16-byte shared-memory slot. The 128B swizzle permutes
+        # the source payload chunk by xor'ing the chunk index with the 128B row
+        # bits; the high half of each destination slot remains the guard value.
+        dst_base = dst_payload_chunk * 16
+        src_swizzle_chunk = dst_payload_chunk ^ ((dst_payload_chunk >> 3) & 0x7)
+        src_base = src_swizzle_chunk * 8
+        expected[dst_base : dst_base + 8] = src[src_base : src_base + 8]
+    return expected
+
+
+def _expected_rank4_scale_tma_output(torch, src, output_bytes: int):
+    expected = torch.full((output_bytes,), 0xCD, device="cuda", dtype=torch.uint8)
+    payload_bytes = src.numel()
+    for dst_chunk in range(payload_bytes // 16):
+        # The UINT8 scale descriptor writes dense 16-byte chunks. Its 128B
+        # swizzle uses the same xor-by-row mapping, but without FP4 ALIGN16
+        # padding between destination payload chunks.
+        src_chunk = dst_chunk ^ (dst_chunk >> 3)
+        expected[dst_chunk * 16 : (dst_chunk + 1) * 16] = src[
+            src_chunk * 16 : (src_chunk + 1) * 16
+        ]
+    return expected
+
+
+def test_sm120_mxf4nvf4_rank3_external_descriptor_tma_canary():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(8192, 32)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(src.data_ptr())
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    output_bytes = 17408
+    expected = _expected_rank3_fp4_tma_output(torch, src, output_bytes)
+    _run_canary(desc, expected, output_bytes, 3, 8192, (0, 0, 0, 0), 16384)
+
+
+def test_sm120_mxf4nvf4_rank3_external_descriptor_nonzero_coordinate_canary():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(16384, 32)
+    src[:8192].copy_(_patterned_u8(torch, 8192))
+    src[8192:16384].copy_(torch.bitwise_xor(_patterned_u8(torch, 8192), 0xA5))
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(
+            src.data_ptr(), l_extent=2
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    output_bytes = 17408
+    expected = _expected_rank3_fp4_tma_output(torch, src[8192:16384], output_bytes)
+    _run_canary(desc, expected, output_bytes, 3, 8192, (0, 0, 1, 0), 16384)
+
+
+def test_sm120_mxf4nvf4_scale_rank4_external_descriptor_tma_canary():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(1024, 16)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(src.data_ptr())
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    expected = _expected_rank4_scale_tma_output(torch, src, 2048)
+    _run_canary(desc, expected, 2048, 4, 1024, (0, 0, 0, 0), 1024)
+
+
+def test_sm120_mxf4nvf4_scale_rank4_external_descriptor_nonzero_coordinate_canary():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(2048, 16)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    expected_src = src[128:1152].clone()
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            src.data_ptr(), tile_extent=2
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    expected = _expected_rank4_scale_tma_output(torch, expected_src, 2048)
+    _run_canary(desc, expected, 2048, 4, 1024, (0, 1, 0, 0), 1024)
+
+
+def test_sm120_mxf4nvf4_driver_descriptor_path_repro():
+    cutlass.utils.validate_sm120_mxf4nvf4_tma_desc(
+        base_ptr=0x1000,
+        global_dim=(128, 128, 1),
+        global_strides_bytes=(64, 8192),
+        box_dim=(128, 128, 1),
+        tx_count=8192,
+    )

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_canary.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_canary.py
@@ -161,6 +161,31 @@ def _expected_rank3_fp4_tma_output(torch, src, output_bytes: int):
     return expected
 
 
+def _expected_rank3_fp4_tma_output_from_logical_tile(
+    torch,
+    src,
+    output_bytes: int,
+    *,
+    k_extent: int,
+    major_extent: int,
+    coord_k: int,
+    coord_major: int,
+    coord_l: int = 0,
+):
+    major_stride = k_extent // 2
+    l_stride = major_stride * major_extent
+    payload = torch.empty((8192,), device="cuda", dtype=torch.uint8)
+    for major in range(128):
+        src_base = (
+            coord_l * l_stride
+            + (coord_major + major) * major_stride
+            + coord_k // 2
+        )
+        dst_base = major * 64
+        payload[dst_base : dst_base + 64] = src[src_base : src_base + 64]
+    return _expected_rank3_fp4_tma_output(torch, payload, output_bytes)
+
+
 def _expected_rank4_scale_tma_output(torch, src, output_bytes: int):
     expected = torch.full((output_bytes,), 0xCD, device="cuda", dtype=torch.uint8)
     payload_bytes = src.numel()
@@ -210,6 +235,58 @@ def test_sm120_mxf4nvf4_rank3_external_descriptor_nonzero_coordinate_canary():
     _run_canary(desc, expected, output_bytes, 3, 8192, (0, 0, 1, 0), 16384)
 
 
+def test_sm120_mxf4nvf4_rank3_external_descriptor_nonzero_k_tile_canary():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(16384, 32)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(
+            src.data_ptr(), k_extent=256
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    output_bytes = 17408
+    expected = _expected_rank3_fp4_tma_output_from_logical_tile(
+        torch,
+        src,
+        output_bytes,
+        k_extent=256,
+        major_extent=128,
+        coord_k=128,
+        coord_major=0,
+    )
+    _run_canary(desc, expected, output_bytes, 3, 8192, (128, 0, 0, 0), 16384)
+
+
+def test_sm120_mxf4nvf4_rank3_external_descriptor_nonzero_major_tile_canary():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(16384, 32)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(
+            src.data_ptr(), major_extent=256, box_major_extent=128
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    output_bytes = 17408
+    expected = _expected_rank3_fp4_tma_output_from_logical_tile(
+        torch,
+        src,
+        output_bytes,
+        k_extent=128,
+        major_extent=256,
+        coord_k=0,
+        coord_major=128,
+    )
+    _run_canary(desc, expected, output_bytes, 3, 8192, (0, 128, 0, 0), 16384)
+
+
 def test_sm120_mxf4nvf4_scale_rank4_external_descriptor_tma_canary():
     torch = pytest.importorskip("torch")
     if not torch.cuda.is_available():
@@ -241,6 +318,27 @@ def test_sm120_mxf4nvf4_scale_rank4_external_descriptor_nonzero_coordinate_canar
     assert src_storage is not None
     expected = _expected_rank4_scale_tma_output(torch, expected_src, 2048)
     _run_canary(desc, expected, 2048, 4, 1024, (0, 1, 0, 0), 1024)
+
+
+def test_sm120_mxf4nvf4_scale_rank4_external_descriptor_scale_k_substep_is_view_offset():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    src_storage, src = _aligned_u8_tensor(2048, 16)
+    src.copy_(_patterned_u8(torch, src.numel()))
+    # The external scale descriptor transfers the full logical scale-K box.
+    # K64 substep selection is handled by the SMEM scale-fragment view, not by
+    # issuing a second descriptor coordinate inside the scale-K box.
+    expected_src = src[:1024].clone()
+    try:
+        desc = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            src.data_ptr(), scale_k_extent=16, logical_scale_k_extent=8
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    assert src_storage is not None
+    expected = _expected_rank4_scale_tma_output(torch, expected_src, 2048)
+    _run_canary(desc, expected, 2048, 4, 1024, (0, 8, 0, 0), 1024)
 
 
 def test_sm120_mxf4nvf4_driver_descriptor_path_repro():

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_mainloop.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_mainloop.py
@@ -74,12 +74,980 @@ def test_sm120_mxf4nvf4_tma_mainloop_uses_atom_copy_path():
     assert "sm120_tma_load_4d" not in source
     assert "make_mxf4nvf4_tiled_tma_atom_a" in source
     assert "cpasync.tma_partition" in source
-    assert "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch" in source
-    assert "load_mxf4nvf4_ldsm_scratch_fragments" in source
+    assert "stage_mxf4nvf4_ab_tma_physical_to_consumer_smem" in source
+    assert "load_mxf4nvf4_ab_fragments_from_consumer_smem" in source
+    assert "load_mxf4nvf4_ldsm_scratch_fragments" not in source
+    assert "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch" not in source
+    assert "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch" not in source
+    assert "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch" not in source
+    assert "make_mxf4nvf4_ldsm_scratch_views" not in source
+    assert "allocate_mxf4nvf4_ldsm_scratch" not in source
     assert "stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch" in source
     assert "make_mxf4nvf4_scale_fragment_views_from_scratch" in source
     assert "cute.copy(" in source
     assert "tma_desc_ptr=" in source
+
+
+@cute.kernel
+def _consumer_smem_ldsm_copy_path_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA, sB = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA, sB, tidx
+    )
+    sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA, sB, a, b, tidx, 0
+    )
+    out[0] = cutlass.Float32(0.0)
+
+
+@cute.jit
+def _launch_consumer_smem_ldsm_copy_path(out: cute.Tensor):
+    _consumer_smem_ldsm_copy_path_kernel(out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=65536
+    )
+
+
+def test_sm120_mxf4nvf4_consumer_smem_ldsm_copy_path_compile():
+    out = make_fake_compact_tensor(cutlass.Float32, (1,))
+    compiled = cute.compile(
+        _launch_consumer_smem_ldsm_copy_path, out, options="--keep-ptx"
+    )
+
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    assert "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16" not in compiled.__ptx__
+
+
+@cute.kernel
+def _consumer_smem_logical_fill_mma_kernel(
+    out: cute.Tensor, case_id: cutlass.Constexpr[int]
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA, sB = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
+    sA_u8 = cute.recast_tensor(sA, cutlass.Uint8)
+    sB_u8 = cute.recast_tensor(sB, cutlass.Uint8)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_AB_TMA_BYTES, 32):
+        major = i // (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        k_byte = i % (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0)
+        sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0)
+        if cutlass.const_expr(case_id == 0):
+            sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+            sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+        elif cutlass.const_expr(case_id == 1):
+            sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+            def set_b() -> None:
+                sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+
+            cutlass.if_generate(major < 4, set_b)
+        elif cutlass.const_expr(case_id == 2):
+            sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+            def set_b() -> None:
+                sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+
+            cutlass.if_generate(major == 3, set_b)
+        elif cutlass.const_expr(case_id == 3):
+            def set_a() -> None:
+                sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+
+            cutlass.if_generate(major < 8, set_a)
+            sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0x22)
+        elif cutlass.const_expr(case_id == 4):
+            sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0x02)
+            sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0x02)
+        elif cutlass.const_expr(case_id == 5):
+            sA_u8[(major, k_byte, 0)] = cutlass.Uint8(0x02)
+            sB_u8[(major, k_byte, 0)] = cutlass.Uint8(0x20)
+    cute.arch.sync_threads()
+
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+        sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA, sB, tidx
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma, sA, sB, a, b, tidx, k_block_idx
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
+        cute.arch.sync_threads()
+
+    for i in cutlass.range(cute.size(acc), unroll_full=True):
+        out[tidx * cute.size(acc) + i] = acc[i]
+
+
+@cute.jit
+def _launch_consumer_smem_logical_fill_mma(
+    out: cute.Tensor, case_id: cutlass.Constexpr[int]
+):
+    _consumer_smem_logical_fill_mma_kernel(out, case_id).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=65536
+    )
+
+
+def _expected_raw_accumulator(torch, case_name: str):
+    expected = torch.zeros((32, 4), device="cuda", dtype=torch.float32)
+    if case_name == "all_ones":
+        expected.fill_(128.0)
+    elif case_name == "b_varies_by_logical_n":
+        expected[torch.arange(32, device="cuda") % 4 < 2, :] = 128.0
+    elif case_name == "sparse_b_logical_n_probe":
+        expected[torch.arange(32, device="cuda") % 4 == 1, 1] = 128.0
+        expected[torch.arange(32, device="cuda") % 4 == 1, 3] = 128.0
+    elif case_name == "a_varies_by_logical_m":
+        expected[:, 0:2] = 128.0
+    elif case_name == "low_nibble_only":
+        expected.fill_(64.0)
+    elif case_name == "cross_nibble_zero":
+        pass
+    else:
+        raise AssertionError(f"unknown case {case_name}")
+    return expected.reshape(-1)
+
+
+def _expected_multi_warp_m_atom_accumulator(torch):
+    expected = torch.zeros((8, 32, 4), device="cuda", dtype=torch.float32)
+    lane_mask = torch.arange(32, device="cuda") % 4 < 2
+    for m_atom in range(8):
+        if m_atom % 2 == 0:
+            expected[m_atom, lane_mask, 0:2] = 128.0
+        else:
+            expected[m_atom, lane_mask, 2:4] = 128.0
+    return expected.reshape(-1)
+
+
+def _expected_multi_warp_m_atom_one_hot_accumulator(torch):
+    expected = torch.zeros((8, 8, 32, 4), device="cuda", dtype=torch.float32)
+    tile = _expected_raw_accumulator(torch, "all_ones").reshape(32, 4)
+    for m_atom in range(8):
+        expected[m_atom, m_atom] = tile
+    return expected.reshape(-1)
+
+
+def _expected_multi_warp_n_atom_one_hot_accumulator(torch, n_base: int):
+    expected = torch.zeros((16, 8, 32, 4), device="cuda", dtype=torch.float32)
+    tile = _expected_raw_accumulator(torch, "all_ones").reshape(32, 4)
+    for n_atom in range(16):
+        if n_base <= n_atom < n_base + 8:
+            expected[n_atom, n_atom - n_base] = tile
+    return expected.reshape(-1)
+
+
+@pytest.mark.parametrize(
+    ("case_name", "case_id"),
+    [
+        ("all_ones", 0),
+        ("b_varies_by_logical_n", 1),
+        ("sparse_b_logical_n_probe", 2),
+        ("a_varies_by_logical_m", 3),
+        ("low_nibble_only", 4),
+        ("cross_nibble_zero", 5),
+    ],
+)
+def test_sm120_mxf4nvf4_consumer_smem_logical_fill_mma_runtime(
+    case_name, case_id
+):
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_consumer_smem_logical_fill_mma,
+        cute_out,
+        case_id,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    assert "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16" not in compiled.__ptx__
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    expected = _expected_raw_accumulator(torch, case_name)
+    assert torch.equal(out, expected), (case_name, out.reshape(32, 4).cpu())
+
+
+@cute.kernel
+def _stage1_lane_idx_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    lane_idx = tidx % 32
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem, num_stages=2)
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(
+        smem, num_stages=2
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+        stage1_i = sm120.MXF4NVF4_AB_SMEM_BYTES + i
+        sA_phys[stage1_i] = cutlass.Uint8(0)
+        sB_phys[stage1_i] = cutlass.Uint8(0)
+    cute.arch.sync_threads()
+    for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_TMA_BYTES, 32):
+        major = i // (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        payload_chunk = i // 8
+        payload_byte_in_chunk = i % 8
+        physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+        physical_idx = (
+            sm120.MXF4NVF4_AB_SMEM_BYTES
+            + physical_chunk * 16
+            + payload_byte_in_chunk
+        )
+        sA_phys[physical_idx] = cutlass.Uint8(0x22)
+
+        def set_b() -> None:
+            sB_phys[physical_idx] = cutlass.Uint8(0x22)
+
+        cutlass.if_generate(major < 4, set_b)
+    cute.arch.sync_threads()
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range(lane_idx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+        sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma[(None, None, 1)],
+        sB_tma[(None, None, 1)],
+        sA_consumer,
+        sB_consumer,
+        consumer_stage_idx=1,
+        lane_idx=lane_idx,
+    )
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, lane_idx=lane_idx
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a,
+            b,
+            lane_idx,
+            k_block_idx,
+            consumer_stage_idx=1,
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
+    if tidx < 32:
+        for i in cutlass.range(cute.size(acc), unroll_full=True):
+            out[lane_idx * cute.size(acc) + i] = acc[i]
+
+
+@cute.jit
+def _launch_stage1_lane_idx(out: cute.Tensor):
+    _stage1_lane_idx_kernel(out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=100352
+    )
+
+
+@cute.jit
+def _launch_multi_warp_lane_idx_compile(out: cute.Tensor):
+    _stage1_lane_idx_kernel(out).launch(
+        grid=[1, 1, 1], block=[288, 1, 1], smem=100352
+    )
+
+
+def test_sm120_mxf4nvf4_stage1_lane_idx_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.full((32 * 4,), -1.0, device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_stage1_lane_idx,
+        cute_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    expected = _expected_raw_accumulator(torch, "b_varies_by_logical_n")
+    assert torch.equal(out, expected), out.reshape(32, 4).cpu()
+
+
+@cute.kernel
+def _multi_warp_lane_idx_runtime_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    lane_idx = tidx % 32
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem, num_stages=2)
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(
+        smem, num_stages=2
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    if tidx < 32:
+        for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+            stage1_i = sm120.MXF4NVF4_AB_SMEM_BYTES + i
+            sA_phys[stage1_i] = cutlass.Uint8(0)
+            sB_phys[stage1_i] = cutlass.Uint8(0)
+        for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_TMA_BYTES, 32):
+            major = i // (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+            payload_chunk = i // 8
+            payload_byte_in_chunk = i % 8
+            physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+            physical_idx = (
+                sm120.MXF4NVF4_AB_SMEM_BYTES
+                + physical_chunk * 16
+                + payload_byte_in_chunk
+            )
+            local_m_major = major % sm120.MXF4NVF4_MMA_SHAPE_MNK[0]
+            local_m_atom = major // sm120.MXF4NVF4_MMA_SHAPE_MNK[0]
+
+            def set_a() -> None:
+                sA_phys[physical_idx] = cutlass.Uint8(0x22)
+
+            def set_a_even_atom() -> None:
+                cutlass.if_generate(local_m_major < 8, set_a)
+
+            def set_a_odd_atom() -> None:
+                cutlass.if_generate(local_m_major >= 8, set_a)
+
+            cutlass.if_generate(local_m_atom % 2 == 0, set_a_even_atom)
+            cutlass.if_generate(local_m_atom % 2 != 0, set_a_odd_atom)
+
+            local_n_major = major % sm120.MXF4NVF4_MMA_SHAPE_MNK[1]
+
+            def set_b() -> None:
+                sB_phys[physical_idx] = cutlass.Uint8(0x22)
+
+            cutlass.if_generate(local_n_major < 4, set_b)
+        sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+        sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+        for i in cutlass.range(lane_idx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+            sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+            sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+            sA_tma[(None, None, 1)],
+            sB_tma[(None, None, 1)],
+            sA_consumer,
+            sB_consumer,
+            consumer_stage_idx=1,
+            lane_idx=lane_idx,
+        )
+    cute.arch.sync_threads()
+
+    def run_consumer(
+        lane_idx_arg: cutlass.Int32,
+        sA_consumer_arg: cute.Tensor,
+        sB_consumer_arg: cute.Tensor,
+        sSFA_arg: cute.Tensor,
+        sSFB_arg: cute.Tensor,
+        out_arg: cute.Tensor,
+        m_atom: cutlass.Constexpr[int],
+        n_atom: cutlass.Constexpr[int],
+        out_warp: cutlass.Constexpr[int],
+    ) -> None:
+        tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+        a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer_arg,
+            sB_consumer_arg,
+            lane_idx=lane_idx_arg,
+            m_atom=m_atom,
+            n_atom=n_atom,
+        )
+        acc = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_C((16, 8)), cutlass.Float32
+        )
+        sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+        acc.fill(0.0)
+        for k_block_idx in cutlass.range_constexpr(2):
+            sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+                tiled_mma,
+                sA_consumer_arg,
+                sB_consumer_arg,
+                a,
+                b,
+                lane_idx_arg,
+                k_block_idx,
+                consumer_stage_idx=1,
+                m_atom=m_atom,
+                n_atom=n_atom,
+            )
+            sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+                sSFA_arg, sSFB_arg, k_block_idx
+            )
+            sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+            sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+            cute.gemm(
+                tiled_mma,
+                acc,
+                (a[(None, 0, k_block_idx)], sfa),
+                (b[(None, 0, k_block_idx)], sfb),
+                acc,
+            )
+        for i in cutlass.range(cute.size(acc), unroll_full=True):
+            out_arg[
+                out_warp * 32 * cute.size(acc) + lane_idx_arg * cute.size(acc) + i
+            ] = acc[i]
+
+    if tidx >= 32:
+        if tidx < 64:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 0, 0, 0)
+    if tidx >= 64:
+        if tidx < 96:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 1, 1, 1)
+    if tidx >= 96:
+        if tidx < 128:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 2, 2, 2)
+    if tidx >= 128:
+        if tidx < 160:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 3, 3, 3)
+    if tidx >= 160:
+        if tidx < 192:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 4, 4, 4)
+    if tidx >= 192:
+        if tidx < 224:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 5, 5, 5)
+    if tidx >= 224:
+        if tidx < 256:
+            run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 6, 6, 6)
+    if tidx >= 256:
+        run_consumer(lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, 7, 7, 7)
+
+
+@cute.kernel
+def _multi_warp_microtile_one_hot_kernel(
+    out: cute.Tensor,
+    probe_axis: cutlass.Constexpr[int],
+    n_base: cutlass.Constexpr[int],
+):
+    bidx, _, _ = cute.arch.block_idx()
+    tidx, _, _ = cute.arch.thread_idx()
+    lane_idx = tidx % 32
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem, num_stages=2)
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(
+        smem, num_stages=2
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    if tidx < 32:
+        for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+            stage1_i = sm120.MXF4NVF4_AB_SMEM_BYTES + i
+            sA_phys[stage1_i] = cutlass.Uint8(0)
+            sB_phys[stage1_i] = cutlass.Uint8(0)
+        for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_TMA_BYTES, 32):
+            major = i // (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+            payload_chunk = i // 8
+            payload_byte_in_chunk = i % 8
+            physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+            physical_idx = (
+                sm120.MXF4NVF4_AB_SMEM_BYTES
+                + physical_chunk * 16
+                + payload_byte_in_chunk
+            )
+            local_m_atom = major // sm120.MXF4NVF4_MMA_SHAPE_MNK[0]
+            local_n_atom = major // sm120.MXF4NVF4_MMA_SHAPE_MNK[1]
+
+            def set_a() -> None:
+                sA_phys[physical_idx] = cutlass.Uint8(0x22)
+
+            def set_b() -> None:
+                sB_phys[physical_idx] = cutlass.Uint8(0x22)
+
+            if cutlass.const_expr(probe_axis == 0):
+                cutlass.if_generate(local_m_atom == bidx, set_a)
+                set_b()
+            else:
+                set_a()
+                cutlass.if_generate(local_n_atom == bidx, set_b)
+        sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+        sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+        for i in cutlass.range(lane_idx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+            sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+            sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+            sA_tma[(None, None, 1)],
+            sB_tma[(None, None, 1)],
+            sA_consumer,
+            sB_consumer,
+            consumer_stage_idx=1,
+            lane_idx=lane_idx,
+        )
+    cute.arch.sync_threads()
+
+    def run_consumer(
+        lane_idx_arg: cutlass.Int32,
+        sA_consumer_arg: cute.Tensor,
+        sB_consumer_arg: cute.Tensor,
+        sSFA_arg: cute.Tensor,
+        sSFB_arg: cute.Tensor,
+        out_arg: cute.Tensor,
+        block_idx_arg: cutlass.Int32,
+        m_atom: cutlass.Constexpr[int],
+        n_atom: cutlass.Constexpr[int],
+        out_warp: cutlass.Constexpr[int],
+    ) -> None:
+        tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+        a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer_arg,
+            sB_consumer_arg,
+            lane_idx=lane_idx_arg,
+            m_atom=m_atom,
+            n_atom=n_atom,
+        )
+        acc = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_C((16, 8)), cutlass.Float32
+        )
+        sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+        acc.fill(0.0)
+        for k_block_idx in cutlass.range_constexpr(2):
+            sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+                tiled_mma,
+                sA_consumer_arg,
+                sB_consumer_arg,
+                a,
+                b,
+                lane_idx_arg,
+                k_block_idx,
+                consumer_stage_idx=1,
+                m_atom=m_atom,
+                n_atom=n_atom,
+            )
+            sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+                sSFA_arg, sSFB_arg, k_block_idx
+            )
+            sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+            sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+            cute.gemm(
+                tiled_mma,
+                acc,
+                (a[(None, 0, k_block_idx)], sfa),
+                (b[(None, 0, k_block_idx)], sfb),
+                acc,
+            )
+        for i in cutlass.range(cute.size(acc), unroll_full=True):
+            out_arg[
+                (block_idx_arg * 8 + out_warp) * 32 * cute.size(acc)
+                + lane_idx_arg * cute.size(acc)
+                + i
+            ] = acc[i]
+
+    if tidx >= 32:
+        if tidx < 64:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 0, 0, 0
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 0,
+                    0,
+                )
+    if tidx >= 64:
+        if tidx < 96:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 1, 0, 1
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 1,
+                    1,
+                )
+    if tidx >= 96:
+        if tidx < 128:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 2, 0, 2
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 2,
+                    2,
+                )
+    if tidx >= 128:
+        if tidx < 160:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 3, 0, 3
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 3,
+                    3,
+                )
+    if tidx >= 160:
+        if tidx < 192:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 4, 0, 4
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 4,
+                    4,
+                )
+    if tidx >= 192:
+        if tidx < 224:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 5, 0, 5
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 5,
+                    5,
+                )
+    if tidx >= 224:
+        if tidx < 256:
+            if cutlass.const_expr(probe_axis == 0):
+                run_consumer(
+                    lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 6, 0, 6
+                )
+            else:
+                run_consumer(
+                    lane_idx,
+                    sA_consumer,
+                    sB_consumer,
+                    sSFA,
+                    sSFB,
+                    out,
+                    bidx,
+                    0,
+                    n_base + 6,
+                    6,
+                )
+    if tidx >= 256:
+        if cutlass.const_expr(probe_axis == 0):
+            run_consumer(
+                lane_idx, sA_consumer, sB_consumer, sSFA, sSFB, out, bidx, 7, 0, 7
+            )
+        else:
+            run_consumer(
+                lane_idx,
+                sA_consumer,
+                sB_consumer,
+                sSFA,
+                sSFB,
+                out,
+                bidx,
+                0,
+                n_base + 7,
+                7,
+            )
+
+
+@cute.jit
+def _launch_multi_warp_lane_idx_runtime(out: cute.Tensor):
+    _multi_warp_lane_idx_runtime_kernel(out).launch(
+        grid=[1, 1, 1], block=[288, 1, 1], smem=100352
+    )
+
+
+@cute.jit
+def _launch_multi_warp_m_atom_one_hot_runtime(out: cute.Tensor):
+    _multi_warp_microtile_one_hot_kernel(out, 0, 0).launch(
+        grid=[8, 1, 1], block=[288, 1, 1], smem=100352
+    )
+
+
+@cute.jit
+def _launch_multi_warp_n_atom_one_hot_runtime(
+    out: cute.Tensor, n_base: cutlass.Constexpr[int]
+):
+    _multi_warp_microtile_one_hot_kernel(out, 1, n_base).launch(
+        grid=[16, 1, 1], block=[288, 1, 1], smem=100352
+    )
+
+
+def test_sm120_mxf4nvf4_multi_warp_lane_idx_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.full((8 * 32 * 4,), -1.0, device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_multi_warp_lane_idx_runtime,
+        cute_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    # Keep SFA/SFB fixed at 1.0 here. This canary is a cheap A/B-only stress
+    # test for ignored m_atom, wrong lane index, wrong consumer stage, and local
+    # M-half selection bugs. It is not injective over all m_atoms; the one-hot
+    # tests below cover aliasing such as m_atom + 2.
+    expected = _expected_multi_warp_m_atom_accumulator(torch)
+    assert torch.equal(out, expected), out.reshape(8, 32, 4).cpu()
+
+
+def test_sm120_mxf4nvf4_multi_warp_m_atom_one_hot_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.full((8 * 8 * 32 * 4,), -1.0, device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_multi_warp_m_atom_one_hot_runtime,
+        cute_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    # This keeps scales fixed and makes each block select one logical M band.
+    # Only the matching consumer warp may produce a nonzero MMA tile.
+    expected = _expected_multi_warp_m_atom_one_hot_accumulator(torch)
+    assert torch.equal(out, expected), out.reshape(8, 8, 32, 4).cpu()
+
+
+@pytest.mark.parametrize("n_base", [0, 8])
+def test_sm120_mxf4nvf4_multi_warp_n_atom_one_hot_runtime(n_base):
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.full((16 * 8 * 32 * 4,), -1.0, device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_multi_warp_n_atom_one_hot_runtime,
+        cute_out,
+        n_base,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    # This keeps scales fixed and makes each block select one logical N band.
+    # n_base splits the 16 local N atoms across the eight consumer warps.
+    expected = _expected_multi_warp_n_atom_one_hot_accumulator(torch, n_base)
+    assert torch.equal(out, expected), out.reshape(16, 8, 32, 4).cpu()
+
+
+def test_sm120_mxf4nvf4_stage1_lane_idx_compile():
+    out = make_fake_compact_tensor(cutlass.Float32, (32 * 4,))
+    compiled = cute.compile(
+        _launch_stage1_lane_idx,
+        out,
+        options="--keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+
+
+@cute.kernel
+def _stage1_adapter_bytes_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    lane_idx = tidx % 32
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem, num_stages=2)
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(
+        smem, num_stages=2
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(2 * sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+        sA_phys[sm120.MXF4NVF4_AB_SMEM_BYTES + i] = cutlass.Uint8(0)
+        sB_phys[sm120.MXF4NVF4_AB_SMEM_BYTES + i] = cutlass.Uint8(0)
+    cute.arch.sync_threads()
+    for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_TMA_BYTES, 32):
+        payload_chunk = i // 8
+        payload_byte_in_chunk = i % 8
+        physical_chunk = payload_chunk ^ ((payload_chunk >> 3) & 0x7)
+        physical_idx = (
+            sm120.MXF4NVF4_AB_SMEM_BYTES
+            + physical_chunk * 16
+            + payload_byte_in_chunk
+        )
+        sA_phys[physical_idx] = cutlass.Uint8(0x7B)
+        sB_phys[physical_idx] = cutlass.Uint8(0x3C)
+    cute.arch.sync_threads()
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma[(None, None, 1)],
+        sB_tma[(None, None, 1)],
+        sA_consumer,
+        sB_consumer,
+        consumer_stage_idx=1,
+        lane_idx=lane_idx,
+    )
+    cute.arch.sync_threads()
+    sA_u8 = cute.recast_tensor(sA_consumer, cutlass.Uint8)
+    sB_u8 = cute.recast_tensor(sB_consumer, cutlass.Uint8)
+    for i in cutlass.range(lane_idx, sm120.MXF4NVF4_AB_TMA_BYTES, 32):
+        major = i // (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        k_byte = i % (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        out[i] = sA_u8[(major, k_byte, 1)]
+        out[sm120.MXF4NVF4_AB_TMA_BYTES + i] = sB_u8[(major, k_byte, 1)]
+
+
+@cute.jit
+def _launch_stage1_adapter_bytes(out: cute.Tensor):
+    _stage1_adapter_bytes_kernel(out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=98304
+    )
+
+
+def test_sm120_mxf4nvf4_stage1_adapter_bytes_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.empty((2 * sm120.MXF4NVF4_AB_TMA_BYTES,), device="cuda", dtype=torch.uint8)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_stage1_adapter_bytes,
+        cute_out,
+        options="--enable-tvm-ffi",
+    )
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    assert torch.all(out[: sm120.MXF4NVF4_AB_TMA_BYTES] == 0x7B)
+    assert torch.all(out[sm120.MXF4NVF4_AB_TMA_BYTES :] == 0x3C)
+
+
+def test_sm120_mxf4nvf4_multi_warp_lane_idx_compile():
+    out = make_fake_compact_tensor(cutlass.Float32, (32 * 4,))
+    compiled = cute.compile(
+        _launch_multi_warp_lane_idx_compile,
+        out,
+        options="--keep-ptx",
+    )
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
 
 
 @cute.kernel
@@ -455,12 +1423,7 @@ def _smem_ldsm_ab_kernel(out: cute.Tensor):
     tidx, _, _ = cute.arch.thread_idx()
     smem = cutlass.utils.SmemAllocator()
     sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
-    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
-        smem
-    )
-    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
-        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
-    )
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
     sA_phys = cute.make_tensor(
         sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
     )
@@ -488,34 +1451,38 @@ def _smem_ldsm_ab_kernel(out: cute.Tensor):
     cute.arch.sync_threads()
 
     tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
-    a = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma, sB_tma, sA_consumer, sB_consumer, lane_idx=tidx
     )
-    b = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    cute.arch.sync_threads()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, tidx
     )
     acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
     sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
     acc.fill(0.0)
     for k_block_idx in cutlass.range_constexpr(2):
-        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
-            sA_tma,
-            sB_tma,
-            sA_ldsm_scratch,
-            sB_ldsm_scratch,
-            k_block_idx=k_block_idx,
-            lane_idx=tidx,
-        )
-        cute.arch.sync_threads()
-        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
-            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a,
+            b,
+            tidx,
+            k_block_idx,
         )
         sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
             sSFA, sSFB, k_block_idx
         )
         sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
         sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
-        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
         cute.arch.sync_threads()
 
     acc_size = cute.size(acc)
@@ -598,12 +1565,7 @@ def _mma_from_physical_smem_kernel(
     tidx, _, _ = cute.arch.thread_idx()
     smem = cutlass.utils.SmemAllocator()
     sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
-    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
-        smem
-    )
-    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
-        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
-    )
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
     sA_phys = cute.make_tensor(
         sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
     )
@@ -631,34 +1593,38 @@ def _mma_from_physical_smem_kernel(
     cute.arch.sync_threads()
 
     tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
-    a = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma, sB_tma, sA_consumer, sB_consumer, lane_idx=tidx
     )
-    b = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    cute.arch.sync_threads()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, tidx
     )
     acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
     sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
     acc.fill(0.0)
     for k_block_idx in cutlass.range_constexpr(2):
-        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
-            sA_tma,
-            sB_tma,
-            sA_ldsm_scratch,
-            sB_ldsm_scratch,
-            k_block_idx=k_block_idx,
-            lane_idx=tidx,
-        )
-        cute.arch.sync_threads()
-        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
-            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a,
+            b,
+            tidx,
+            k_block_idx,
         )
         sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
             sSFA, sSFB, k_block_idx
         )
         sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
         sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
-        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
         cute.arch.sync_threads()
 
     acc_size = cute.size(acc)
@@ -686,12 +1652,7 @@ def _external_tma_mma_kernel(
     tidx, _, _ = cute.arch.thread_idx()
     smem = cutlass.utils.SmemAllocator()
     sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
-    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
-        smem
-    )
-    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
-        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
-    )
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
     sA_phys = cute.make_tensor(
         sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
     )
@@ -763,34 +1724,38 @@ def _external_tma_mma_kernel(
     cute.arch.sync_threads()
 
     tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
-    a = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma, sB_tma, sA_consumer, sB_consumer, lane_idx=tidx
     )
-    b = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    cute.arch.sync_threads()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, tidx
     )
     acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
     sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
     acc.fill(0.0)
     for k_block_idx in cutlass.range_constexpr(2):
-        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
-            sA_tma,
-            sB_tma,
-            sA_ldsm_scratch,
-            sB_ldsm_scratch,
-            k_block_idx=k_block_idx,
-            lane_idx=tidx,
-        )
-        cute.arch.sync_threads()
-        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
-            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a,
+            b,
+            tidx,
+            k_block_idx,
         )
         sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
             sSFA, sSFB, k_block_idx
         )
         sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
         sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
-        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
         cute.arch.sync_threads()
 
     pipe.consumer_release(consumer_state)
@@ -825,12 +1790,7 @@ def _atom_external_tma_mma_kernel(
     tidx, _, _ = cute.arch.thread_idx()
     smem = cutlass.utils.SmemAllocator()
     sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
-    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
-        smem
-    )
-    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
-        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
-    )
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
     sA_phys = cute.make_tensor(
         sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
     )
@@ -910,34 +1870,38 @@ def _atom_external_tma_mma_kernel(
     cute.arch.sync_threads()
 
     tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
-    a = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma, sB_tma, sA_consumer, sB_consumer, lane_idx=tidx
     )
-    b = cute.make_rmem_tensor(
-        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    cute.arch.sync_threads()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, tidx
     )
     acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
     sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
     acc.fill(0.0)
     for k_block_idx in cutlass.range_constexpr(2):
-        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
-            sA_tma,
-            sB_tma,
-            sA_ldsm_scratch,
-            sB_ldsm_scratch,
-            k_block_idx=k_block_idx,
-            lane_idx=tidx,
-        )
-        cute.arch.sync_threads()
-        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
-            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a,
+            b,
+            tidx,
+            k_block_idx,
         )
         sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
             sSFA, sSFB, k_block_idx
         )
         sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
         sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
-        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
         cute.arch.sync_threads()
 
     pipe.consumer_release(consumer_state)
@@ -972,12 +1936,193 @@ def _launch_atom_external_tma_mma(
     ).launch(grid=[1, 1, 1], block=[32, 1, 1], smem=65536)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "legacy physical-byte reference no longer models the logical A/B "
-        "scratch bridge after payload/gap compaction"
+@cute.kernel
+def _atom_external_tma_mma_with_scale_bridge_kernel(
+    tma_atom_a: cute.CopyAtom,
+    tma_tensor_a: cute.Tensor,
+    tma_atom_b: cute.CopyAtom,
+    tma_tensor_b: cute.Tensor,
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    desc_sfa: cute.Tensor,
+    desc_sfb: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    sA_consumer, sB_consumer = sm120.make_mxf4nvf4_ab_consumer_smem_views(smem)
+    sSFA_tma = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
+        byte_alignment=128,
     )
-)
+    sSFB_tma = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFA_scratch_all, sSFB_scratch_all = sm120.allocate_mxf4nvf4_scale_fragment_scratch(
+        smem
+    )
+    sSFA_scratch, sSFB_scratch = sm120.make_mxf4nvf4_scale_fragment_scratch_views(
+        sSFA_scratch_all, sSFB_scratch_all, cutlass.Int32(0)
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+    tAsA, tAgA = cpasync.tma_partition(
+        tma_atom_a,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sA_tma, 0, 2),
+        cute.group_modes(tma_tensor_a, 0, 2),
+    )
+    tBsB, tBgB = cpasync.tma_partition(
+        tma_atom_b,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sB_tma, 0, 2),
+        cute.group_modes(tma_tensor_b, 0, 2),
+    )
+    pipe = cutlass.pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread),
+        consumer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        tx_count=2 * sm120.mxf4nvf4_ab_tma_tx_bytes()
+        + 2 * sm120.mxf4nvf4_scale_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Producer, 1
+    )
+    desc_a_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_a)
+    desc_b_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_b)
+    desc_sfa_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_sfa)
+    desc_sfb_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_sfb)
+    pipe.producer_acquire(producer_state, pipe.producer_try_acquire(producer_state))
+    bar = pipe.producer_get_barrier(producer_state)
+    cute.copy(
+        tma_atom_a,
+        tAgA[(None, 0)],
+        tAsA[(None, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_a_ptr,
+    )
+    cute.copy(
+        tma_atom_b,
+        tBgB[(None, 0)],
+        tBsB[(None, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_b_ptr,
+    )
+    with cute.arch.elect_one():
+        cutlass.pipeline.issue_tma_load_4d(
+            pipe,
+            producer_state,
+            sSFA_tma.iterator,
+            desc_sfa_ptr,
+            0,
+            0,
+            0,
+            0,
+            already_elected=True,
+        )
+        cutlass.pipeline.issue_tma_load_4d(
+            pipe,
+            producer_state,
+            sSFB_tma.iterator,
+            desc_sfb_ptr,
+            0,
+            0,
+            0,
+            0,
+            already_elected=True,
+        )
+    pipe.producer_commit(producer_state)
+    consumer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Consumer, 1
+    )
+    pipe.consumer_wait(consumer_state, pipe.consumer_try_wait(consumer_state))
+    cute.arch.sync_threads()
+
+    sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem(
+        sA_tma, sB_tma, sA_consumer, sB_consumer, lane_idx=tidx
+    )
+    sm120.stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch(
+        sSFA_tma,
+        sSFB_tma,
+        sSFA_scratch,
+        sSFB_scratch,
+        lane_idx=tidx,
+    )
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a, b = sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem(
+        tiled_mma, sA_consumer, sB_consumer, tidx
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem(
+            tiled_mma,
+            sA_consumer,
+            sB_consumer,
+            a,
+            b,
+            tidx,
+            k_block_idx,
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_fragment_views_from_scratch(
+            sSFA_scratch, sSFB_scratch, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(
+            tiled_mma,
+            acc,
+            (a[(None, 0, k_block_idx)], sfa),
+            (b[(None, 0, k_block_idx)], sfb),
+            acc,
+        )
+    pipe.consumer_release(consumer_state)
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_atom_external_tma_mma_with_scale_bridge(
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    desc_sfa: cute.Tensor,
+    desc_sfb: cute.Tensor,
+    gA: cute.Tensor,
+    gB: cute.Tensor,
+    out: cute.Tensor,
+):
+    ab_smem_layout = sm120.make_mxf4nvf4_ab_tma_physical_layout_staged()
+    tma_atom_a, tma_tensor_a = sm120.make_mxf4nvf4_tiled_tma_atom_a(
+        gA, ab_smem_layout
+    )
+    tma_atom_b, tma_tensor_b = sm120.make_mxf4nvf4_tiled_tma_atom_b(
+        gB, ab_smem_layout
+    )
+    _atom_external_tma_mma_with_scale_bridge_kernel(
+        tma_atom_a,
+        tma_tensor_a,
+        tma_atom_b,
+        tma_tensor_b,
+        desc_a,
+        desc_b,
+        desc_sfa,
+        desc_sfb,
+        out,
+    ).launch(grid=[1, 1, 1], block=[32, 1, 1], smem=100352)
+
+
 def test_sm120_mxf4nvf4_external_tma_ldsm_mma_runtime_nonuniform_ab():
     torch = pytest.importorskip("torch")
     if not torch.cuda.is_available():
@@ -1044,12 +2189,6 @@ def test_sm120_mxf4nvf4_external_tma_ldsm_mma_runtime_nonuniform_ab():
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "legacy physical-byte reference no longer models the logical A/B "
-        "scratch bridge after payload/gap compaction"
-    )
-)
 def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_nonuniform_ab():
     torch = pytest.importorskip("torch")
     if not torch.cuda.is_available():
@@ -1129,48 +2268,42 @@ def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_nonuniform_ab():
 
 
 @pytest.mark.parametrize(
-    ("case_name", "a_is_one", "b_is_one", "expected_128_count"),
+    ("case_name", "a_is_one", "b_is_one"),
     [
         (
             "all_ones",
             lambda major, k: True,
             lambda major, k: True,
-            128,
         ),
-        pytest.param(
+        (
             "b_varies_by_logical_n",
             lambda major, k: True,
             lambda major, k: major < 4,
-            64,
-            marks=pytest.mark.xfail(
-                reason="logical B major-to-output-N probe still needs the full SM120 LDSM map",
-                strict=True,
-            ),
         ),
-        pytest.param(
+        (
             "sparse_b_logical_n_probe",
             lambda major, k: True,
             lambda major, k: major == 3,
-            16,
-            marks=pytest.mark.xfail(
-                reason="logical B major-to-output-N probe still needs the full SM120 LDSM map",
-                strict=True,
-            ),
         ),
-        pytest.param(
+        (
             "a_varies_by_logical_m",
             lambda major, k: major < 8,
             lambda major, k: True,
-            64,
-            marks=pytest.mark.xfail(
-                reason="logical A major-to-output-M probe still needs the full SM120 LDSM map",
-                strict=True,
-            ),
+        ),
+        (
+            "low_nibble_only",
+            lambda major, k: k % 2 == 0,
+            lambda major, k: k % 2 == 0,
+        ),
+        (
+            "cross_nibble_zero",
+            lambda major, k: k % 2 == 0,
+            lambda major, k: k % 2 == 1,
         ),
     ],
 )
 def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_logical_ab(
-    case_name, a_is_one, b_is_one, expected_128_count
+    case_name, a_is_one, b_is_one
 ):
     torch = pytest.importorskip("torch")
     if not torch.cuda.is_available():
@@ -1217,13 +2350,8 @@ def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_logical_ab(
     compiled(cute_desc_a, cute_desc_b, cute_gA, cute_gB, cute_out)
     torch.cuda.synchronize()
 
-    expected_zero_count = out.numel() - expected_128_count
-    actual_128_count = int(torch.count_nonzero(out == 128.0).item())
-    actual_zero_count = int(torch.count_nonzero(out == 0.0).item())
-    unique_values, unique_counts = torch.unique(out, return_counts=True)
-    unique_summary = list(zip(unique_values.cpu().tolist(), unique_counts.cpu().tolist()))
-    assert actual_128_count == expected_128_count, (case_name, unique_summary)
-    assert actual_zero_count == expected_zero_count, (case_name, unique_summary)
+    expected = _expected_raw_accumulator(torch, case_name)
+    assert torch.equal(out, expected), (case_name, out.reshape(32, 4).cpu())
     assert all(
         x is not None
         for x in (
@@ -1231,5 +2359,103 @@ def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_logical_ab(
             b_storage,
             desc_a_storage,
             desc_b_storage,
+        )
+    )
+
+
+def test_sm120_mxf4nvf4_atom_tma_ab_scale_bridge_runtime_combined():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    rank3_tensor_bytes = 2 * sm120.MXF4NVF4_AB_SMEM_BYTES
+    a_storage, a_payload = _aligned_u8_tensor(torch, rank3_tensor_bytes, 32)
+    b_storage, b_payload = _aligned_u8_tensor(torch, rank3_tensor_bytes, 32)
+    sfa_storage, sfa_payload = _aligned_u8_tensor(
+        torch, sm120.MXF4NVF4_SCALE_TMA_BYTES, 16
+    )
+    sfb_storage, sfb_payload = _aligned_u8_tensor(
+        torch, sm120.MXF4NVF4_SCALE_TMA_BYTES, 16
+    )
+    a_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _logical_fp4_payload(torch, lambda major, k: major < 8)
+    )
+    b_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _logical_fp4_payload(torch, lambda major, k: major < 4)
+    )
+    a_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    b_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+
+    one = 0x38
+    two = 0x40
+    for scale_col in range(sm120.MXF4NVF4_SCALE_K):
+        value = one if scale_col < 4 else two
+        sfa_payload[scale_col * 128 : (scale_col + 1) * 128].fill_(value)
+        sfb_payload[scale_col * 128 : (scale_col + 1) * 128].fill_(one)
+    try:
+        desc_a = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(a_payload.data_ptr())
+        desc_b = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(b_payload.data_ptr())
+        desc_sfa = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            sfa_payload.data_ptr()
+        )
+        desc_sfb = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            sfb_payload.data_ptr()
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+
+    desc_a_storage, desc_a_dev = _device_desc_from_bytes(torch, desc_a)
+    desc_b_storage, desc_b_dev = _device_desc_from_bytes(torch, desc_b)
+    desc_sfa_storage, desc_sfa_dev = _device_desc_from_bytes(torch, desc_sfa)
+    desc_sfb_storage, desc_sfb_dev = _device_desc_from_bytes(torch, desc_sfb)
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_desc_a = from_dlpack(desc_a_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_b = from_dlpack(desc_b_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_sfa = from_dlpack(desc_sfa_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_sfb = from_dlpack(desc_sfb_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_gA = from_dlpack(
+        a_payload.reshape(128, 128, 2), assumed_align=32, enable_tvm_ffi=True
+    )
+    cute_gB = from_dlpack(
+        b_payload.reshape(128, 128, 2), assumed_align=32, enable_tvm_ffi=True
+    )
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_atom_external_tma_mma_with_scale_bridge,
+        cute_desc_a,
+        cute_desc_b,
+        cute_desc_sfa,
+        cute_desc_sfb,
+        cute_gA,
+        cute_gB,
+        cute_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert compiled.__ptx__.count("cp.async.bulk.tensor.3d.shared::cta.global.tile") == 2
+    assert compiled.__ptx__.count("cp.async.bulk.tensor.4d.shared::cta.global") == 2
+    compiled(
+        cute_desc_a,
+        cute_desc_b,
+        cute_desc_sfa,
+        cute_desc_sfb,
+        cute_gA,
+        cute_gB,
+        cute_out,
+    )
+    torch.cuda.synchronize()
+
+    expected = torch.zeros((32, 4), device="cuda", dtype=torch.float32)
+    expected[torch.arange(32, device="cuda") % 4 < 2, 0:2] = 192.0
+    assert torch.equal(out, expected.reshape(-1)), out.reshape(32, 4).cpu()
+    assert all(
+        x is not None
+        for x in (
+            a_storage,
+            b_storage,
+            sfa_storage,
+            sfb_storage,
+            desc_a_storage,
+            desc_b_storage,
+            desc_sfa_storage,
+            desc_sfb_storage,
         )
     )

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_mainloop.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_mainloop.py
@@ -1,0 +1,1235 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.base_dsl.common import CudaDriverDependencyError
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cute.runtime import make_fake_compact_tensor
+from cutlass.utils.gemm import sm120
+
+
+pytestmark = [pytest.mark.arch(["120a"])]
+
+
+def _load_example():
+    path = (
+        Path(__file__).parents[4]
+        / "examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py"
+    )
+    spec = importlib.util.spec_from_file_location("sm120_mxf4nvf4_tma_mainloop", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sm120_mxf4nvf4_tma_mainloop_ptx_inspect():
+    example = _load_example()
+    compiled = example.compile_mainloop(keep_ptx=True)
+    ptx = compiled.__ptx__
+
+    example.inspect_ptx(ptx)
+    assert "fence.proxy.tensormap::generic.acquire.gpu" in ptx
+    assert ptx.count("cp.async.bulk.tensor.3d.shared::cta.global.tile") == 2
+    assert ptx.count("cp.async.bulk.tensor.4d.shared::cta.global.tile") == 2
+    assert "shared::cluster" not in ptx
+    assert ".multicast" not in ptx
+    assert "tcgen05" not in ptx
+
+
+def test_sm120_mxf4nvf4_tma_mainloop_sass_inspect(tmp_path):
+    nvdisasm = Path("/usr/local/cuda/bin/nvdisasm")
+    if not nvdisasm.exists():
+        pytest.skip("nvdisasm unavailable")
+    example = _load_example()
+    compiled = example.compile_mainloop(keep_ptx=False, keep_cubin=True)
+    cubin = compiled.artifacts.CUBIN
+    if not isinstance(cubin, bytes):
+        pytest.skip("CuTe DSL CUBIN artifact unavailable")
+
+    cubin_path = tmp_path / "sm120_mxf4nvf4_tma_mainloop.cubin"
+    cubin_path.write_bytes(cubin)
+    sass = subprocess.check_output([str(nvdisasm), str(cubin_path)], text=True)
+
+    assert "LDSM.16.M88.4" in sass
+    assert "OMMA.SF.16864.F32.E2M1.E2M1.UE4M3.4X" in sass
+    assert "TCGEN05" not in sass
+
+
+def test_sm120_mxf4nvf4_tma_mainloop_uses_atom_copy_path():
+    source = (
+        Path(__file__).parents[4]
+        / "examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py"
+    ).read_text()
+
+    assert "sm120_tma_load_3d" not in source
+    assert "sm120_tma_load_4d" not in source
+    assert "make_mxf4nvf4_tiled_tma_atom_a" in source
+    assert "cpasync.tma_partition" in source
+    assert "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch" in source
+    assert "load_mxf4nvf4_ldsm_scratch_fragments" in source
+    assert "stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch" in source
+    assert "make_mxf4nvf4_scale_fragment_views_from_scratch" in source
+    assert "cute.copy(" in source
+    assert "tma_desc_ptr=" in source
+
+
+@cute.kernel
+def _no_external_desc_tma_kernel(
+    tma_atom_a: cute.CopyAtom,
+    tma_tensor_a: cute.Tensor,
+    out: cute.Tensor,
+):
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, _, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+    tAsA, tAgA = cpasync.tma_partition(
+        tma_atom_a,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sA_tma, 0, 2),
+        cute.group_modes(tma_tensor_a, 0, 2),
+    )
+    pipe = cutlass.pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread),
+        consumer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        tx_count=sm120.mxf4nvf4_ab_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Producer, 1
+    )
+    pipe.producer_acquire(producer_state, pipe.producer_try_acquire(producer_state))
+    cute.copy(
+        tma_atom_a,
+        tAgA[(None, 0)],
+        tAsA[(None, 0)],
+        tma_bar_ptr=pipe.producer_get_barrier(producer_state),
+    )
+    pipe.producer_commit(producer_state)
+    out[0] = cutlass.Uint8(0)
+
+
+@cute.jit
+def _launch_no_external_desc_tma(gA: cute.Tensor, out: cute.Tensor):
+    ab_smem_layout = sm120.make_mxf4nvf4_smem_layout_staged()
+    tma_atom_a, tma_tensor_a = sm120.make_mxf4nvf4_tiled_tma_atom_a(
+        gA, ab_smem_layout
+    )
+    _no_external_desc_tma_kernel(tma_atom_a, tma_tensor_a, out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=49152
+    )
+
+
+def test_sm120_mxf4nvf4_non_external_tma_does_not_emit_desc_fence():
+    g_ab = make_fake_compact_tensor(
+        cutlass.Uint8,
+        (128, 128, 2),
+        memspace=cute.AddressSpace.gmem,
+        assumed_align=32,
+    )
+    out = make_fake_compact_tensor(
+        cutlass.Uint8,
+        (1,),
+        memspace=cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    compiled = cute.compile(
+        _launch_no_external_desc_tma,
+        g_ab,
+        out,
+        options="--gpu-arch=sm_120a --enable-tvm-ffi --keep-ptx",
+    )
+    assert "cp.async.bulk.tensor.3d.shared::cta.global.tile" in compiled.__ptx__
+    assert "fence.proxy.tensormap::generic.acquire.gpu" not in compiled.__ptx__
+
+
+@cute.kernel
+def _two_kblock_scale_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    # The helper under test maps each K64 MMA substep to a different scale-K
+    # byte range in staged SMEM. K0 uses bytes 0..3 and K1 uses bytes 4..7.
+    for i in cutlass.range_constexpr(8):
+        sSFA_f8[(0, i, 0, 0)] = cutlass.Float8E4M3FN(1.0 if i < 4 else 2.0)
+        sSFB_f8[(0, i, 0, 0)] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+
+    cute.recast_tensor(a, cutlass.Int32).fill(0x22222222)
+    cute.recast_tensor(b, cutlass.Int32).fill(0x22222222)
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_two_kblock_scale(out: cute.Tensor):
+    _two_kblock_scale_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def test_sm120_mxf4nvf4_two_kblock_scale_offsets_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+
+    compiled = cute.compile(_launch_two_kblock_scale, cute_out, options="--keep-ptx")
+    assert (
+        compiled.__ptx__.count(
+            "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::4X"
+        )
+        == 2
+    )
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full_like(out, 192.0), rtol=0, atol=0)
+
+
+@cute.kernel
+def _scale_stage1_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(num_stages=2),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(num_stages=2),
+        byte_alignment=128,
+    )
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range_constexpr(4):
+        sSFA_f8[(0, i, 0, 1)] = cutlass.Float8E4M3FN(2.0)
+        sSFB_f8[(0, i, 0, 1)] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    cute.recast_tensor(a, cutlass.Int32).fill(0x22222222)
+    cute.recast_tensor(b, cutlass.Int32).fill(0x22222222)
+    acc.fill(0.0)
+    sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+        sSFA, sSFB, 0, stage_idx=1
+    )
+    sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+    sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+    cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_scale_stage1(out: cute.Tensor):
+    _scale_stage1_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def test_sm120_mxf4nvf4_scale_fragment_views_stage1_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+
+    cute.compile(_launch_scale_stage1, cute_out, options="--keep-ptx")(cute_out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full_like(out, 128.0), rtol=0, atol=0)
+
+
+@cute.kernel
+def _scale_tma_physical_bridge_kernel(
+    desc_sfa: cute.Tensor,
+    desc_sfb: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sSFA_tma = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB_tma = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_scale_tma_physical_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFA_scratch_all, sSFB_scratch_all = sm120.allocate_mxf4nvf4_scale_fragment_scratch(
+        smem
+    )
+    sSFA_scratch, sSFB_scratch = sm120.make_mxf4nvf4_scale_fragment_scratch_views(
+        sSFA_scratch_all, sSFB_scratch_all, cutlass.Int32(0)
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+
+    pipe = cutlass.pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread),
+        consumer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        tx_count=2 * sm120.mxf4nvf4_scale_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Producer, 1
+    )
+    pipe.producer_acquire(producer_state, pipe.producer_try_acquire(producer_state))
+    desc_sfa_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_sfa)
+    desc_sfb_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_sfb)
+    with cute.arch.elect_one():
+        cutlass.pipeline.issue_tma_load_4d(
+            pipe,
+            producer_state,
+            sSFA_tma.iterator,
+            desc_sfa_ptr,
+            0,
+            0,
+            0,
+            0,
+            already_elected=True,
+        )
+        cutlass.pipeline.issue_tma_load_4d(
+            pipe,
+            producer_state,
+            sSFB_tma.iterator,
+            desc_sfb_ptr,
+            0,
+            0,
+            0,
+            0,
+            already_elected=True,
+        )
+    pipe.producer_commit(producer_state)
+    consumer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Consumer, 1
+    )
+    pipe.consumer_wait(consumer_state, pipe.consumer_try_wait(consumer_state))
+    cute.arch.sync_threads()
+
+    sm120.stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch(
+        sSFA_tma,
+        sSFB_tma,
+        sSFA_scratch,
+        sSFB_scratch,
+        lane_idx=tidx,
+    )
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+
+    cute.recast_tensor(a, cutlass.Int32).fill(0x22222222)
+    cute.recast_tensor(b, cutlass.Int32).fill(0x22222222)
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_fragment_views_from_scratch(
+            sSFA_scratch, sSFB_scratch, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    pipe.consumer_release(consumer_state)
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_scale_tma_physical_bridge(
+    desc_sfa: cute.Tensor,
+    desc_sfb: cute.Tensor,
+    out: cute.Tensor,
+):
+    _scale_tma_physical_bridge_kernel(desc_sfa, desc_sfb, out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=49152
+    )
+
+
+def test_sm120_mxf4nvf4_scale_tma_physical_to_fragment_scratch_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    sfa_storage, sfa = _aligned_u8_tensor(torch, sm120.MXF4NVF4_SCALE_TMA_BYTES, 16)
+    sfb_storage, sfb = _aligned_u8_tensor(torch, sm120.MXF4NVF4_SCALE_TMA_BYTES, 16)
+    one = 0x38
+    two = 0x40
+    for scale_col in range(sm120.MXF4NVF4_SCALE_K):
+        value = one if scale_col < 4 else two
+        sfa[scale_col * 128 : (scale_col + 1) * 128].fill_(value)
+        sfb[scale_col * 128 : (scale_col + 1) * 128].fill_(one)
+    try:
+        desc_sfa = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            sfa.data_ptr()
+        )
+        desc_sfb = cutlass.utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            sfb.data_ptr()
+        )
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+
+    _, desc_sfa_dev = _device_desc_from_bytes(torch, desc_sfa)
+    _, desc_sfb_dev = _device_desc_from_bytes(torch, desc_sfb)
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_desc_sfa = from_dlpack(desc_sfa_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_sfb = from_dlpack(desc_sfb_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_scale_tma_physical_bridge,
+        cute_desc_sfa,
+        cute_desc_sfb,
+        cute_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "cp.async.bulk.tensor.4d.shared::cta.global" in compiled.__ptx__
+    compiled(cute_desc_sfa, cute_desc_sfb, cute_out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full_like(out, 192.0), rtol=0, atol=0)
+    assert sfa_storage is not None and sfb_storage is not None
+
+
+@cute.kernel
+def _smem_ldsm_ab_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
+        smem
+    )
+    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
+        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+        sA_phys[i] = cutlass.Uint8(0x22)
+        sB_phys[i] = cutlass.Uint8(0x22)
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+        sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
+            sA_tma,
+            sB_tma,
+            sA_ldsm_scratch,
+            sB_ldsm_scratch,
+            k_block_idx=k_block_idx,
+            lane_idx=tidx,
+        )
+        cute.arch.sync_threads()
+        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
+            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.arch.sync_threads()
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_smem_ldsm_ab(out: cute.Tensor):
+    _smem_ldsm_ab_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1], smem=65536)
+
+
+def test_sm120_mxf4nvf4_smem_ldsm_ab_runtime():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+
+    compiled = cute.compile(_launch_smem_ldsm_ab, cute_out, options="--keep-ptx")
+    assert "ldmatrix.sync.aligned.m8n8.x4.shared.b16" in compiled.__ptx__
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full_like(out, 128.0), rtol=0, atol=0)
+
+
+def _aligned_u8_tensor(torch, num_bytes: int, alignment: int):
+    storage = torch.empty(num_bytes + alignment - 1, device="cuda", dtype=torch.uint8)
+    offset = (-storage.data_ptr()) % alignment
+    view = storage[offset : offset + num_bytes]
+    assert view.data_ptr() % alignment == 0
+    return storage, view
+
+
+def _device_desc_from_bytes(torch, desc_bytes: bytes):
+    storage, desc = _aligned_u8_tensor(torch, sm120.MXF4NVF4_TMA_DESC_BYTES, 128)
+    desc.copy_(torch.tensor(list(desc_bytes), device="cuda", dtype=torch.uint8))
+    return storage, desc
+
+
+def _patterned_u8(torch, count: int, xor_value: int):
+    values = torch.arange(count, device="cuda", dtype=torch.int32)
+    return torch.bitwise_xor(values, xor_value).to(torch.uint8)
+
+
+def _logical_fp4_payload(torch, is_one):
+    # The descriptor logical layout is (K, major, L). Each byte packs two
+    # adjacent K values; nibble 0x2 is FP4 E2M1 one and 0x0 is zero.
+    host = bytearray(sm120.MXF4NVF4_AB_TMA_BYTES)
+    for major in range(sm120.MXF4NVF4_CTA_SHAPE_MNK[0]):
+        major_base = major * (sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2)
+        for k_pair in range(sm120.MXF4NVF4_CTA_SHAPE_MNK[2] // 2):
+            k0 = 2 * k_pair
+            lo = 0x2 if is_one(major, k0) else 0x0
+            hi = 0x2 if is_one(major, k0 + 1) else 0x0
+            host[major_base + k_pair] = lo | (hi << 4)
+    return torch.tensor(list(host), device="cuda", dtype=torch.uint8)
+
+
+def _expected_rank3_fp4_tma_physical(torch, src):
+    # The end-to-end canary compares descriptor TMA against a physical-SMEM
+    # reference so that lane offsets and K64 LDSM substep addresses are tested.
+    expected = torch.full(
+        (sm120.MXF4NVF4_AB_SMEM_BYTES,), 0xCD, device="cuda", dtype=torch.uint8
+    )
+    for dst_payload_chunk in range(src.numel() // 8):
+        dst_base = dst_payload_chunk * 16
+        src_swizzle_chunk = dst_payload_chunk ^ ((dst_payload_chunk >> 3) & 0x7)
+        src_base = src_swizzle_chunk * 8
+        expected[dst_base : dst_base + 8] = src[src_base : src_base + 8]
+    return expected
+
+
+@cute.kernel
+def _mma_from_physical_smem_kernel(
+    phys_a: cute.Tensor,
+    phys_b: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
+        smem
+    )
+    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
+        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+        sA_phys[i] = phys_a[i]
+        sB_phys[i] = phys_b[i]
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+        sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
+            sA_tma,
+            sB_tma,
+            sA_ldsm_scratch,
+            sB_ldsm_scratch,
+            k_block_idx=k_block_idx,
+            lane_idx=tidx,
+        )
+        cute.arch.sync_threads()
+        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
+            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.arch.sync_threads()
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_mma_from_physical_smem(
+    phys_a: cute.Tensor,
+    phys_b: cute.Tensor,
+    out: cute.Tensor,
+):
+    _mma_from_physical_smem_kernel(phys_a, phys_b, out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1], smem=65536
+    )
+
+
+@cute.kernel
+def _external_tma_mma_kernel(
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
+        smem
+    )
+    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
+        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+        sA_phys[i] = cutlass.Uint8(0xCD)
+        sB_phys[i] = cutlass.Uint8(0xCD)
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+        sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    pipe = cutlass.pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread),
+        consumer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        tx_count=2 * sm120.mxf4nvf4_ab_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Producer, 1
+    )
+    pipe.producer_acquire(producer_state, pipe.producer_try_acquire(producer_state))
+    desc_a_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_a)
+    desc_b_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_b)
+    with cute.arch.elect_one():
+        cutlass.pipeline.issue_tma_load_3d(
+            pipe,
+            producer_state,
+            sA_tma.iterator,
+            desc_a_ptr,
+            0,
+            0,
+            0,
+            already_elected=True,
+        )
+        cutlass.pipeline.issue_tma_load_3d(
+            pipe,
+            producer_state,
+            sB_tma.iterator,
+            desc_b_ptr,
+            0,
+            0,
+            0,
+            already_elected=True,
+        )
+    pipe.producer_commit(producer_state)
+    consumer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Consumer, 1
+    )
+    pipe.consumer_wait(consumer_state, pipe.consumer_try_wait(consumer_state))
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
+            sA_tma,
+            sB_tma,
+            sA_ldsm_scratch,
+            sB_ldsm_scratch,
+            k_block_idx=k_block_idx,
+            lane_idx=tidx,
+        )
+        cute.arch.sync_threads()
+        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
+            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.arch.sync_threads()
+
+    pipe.consumer_release(consumer_state)
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_external_tma_mma(
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    out: cute.Tensor,
+):
+    _external_tma_mma_kernel(
+        desc_a,
+        desc_b,
+        out,
+    ).launch(grid=[1, 1, 1], block=[32, 1, 1], smem=65536)
+
+
+@cute.kernel
+def _atom_external_tma_mma_kernel(
+    tma_atom_a: cute.CopyAtom,
+    tma_tensor_a: cute.Tensor,
+    tma_atom_b: cute.CopyAtom,
+    tma_tensor_b: cute.Tensor,
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    smem = cutlass.utils.SmemAllocator()
+    sA_tma, _, sB_tma, _ = sm120.make_mxf4nvf4_ab_smem_views(smem)
+    sA_ldsm_scratch_all, sB_ldsm_scratch_all = sm120.allocate_mxf4nvf4_ldsm_scratch(
+        smem
+    )
+    sA_ldsm_scratch, sB_ldsm_scratch = sm120.make_mxf4nvf4_ldsm_scratch_views(
+        sA_ldsm_scratch_all, sB_ldsm_scratch_all, cutlass.Int32(0)
+    )
+    sA_phys = cute.make_tensor(
+        sA_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sB_phys = cute.make_tensor(
+        sB_tma.iterator, cute.make_layout(sm120.MXF4NVF4_AB_SMEM_BYTES)
+    )
+    sSFA = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    sSFB = smem.allocate_tensor(
+        cutlass.Uint8,
+        sm120.make_mxf4nvf4_tma_scale_layout_staged(),
+        byte_alignment=128,
+    )
+    barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+    tAsA, tAgA = cpasync.tma_partition(
+        tma_atom_a,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sA_tma, 0, 2),
+        cute.group_modes(tma_tensor_a, 0, 2),
+    )
+    tBsB, tBgB = cpasync.tma_partition(
+        tma_atom_b,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sB_tma, 0, 2),
+        cute.group_modes(tma_tensor_b, 0, 2),
+    )
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_AB_SMEM_BYTES, 32):
+        sA_phys[i] = cutlass.Uint8(0xCD)
+        sB_phys[i] = cutlass.Uint8(0xCD)
+    sSFA_f8 = cute.recast_tensor(sSFA, cutlass.Float8E4M3FN)
+    sSFB_f8 = cute.recast_tensor(sSFB, cutlass.Float8E4M3FN)
+    for i in cutlass.range(tidx, sm120.MXF4NVF4_SCALE_TMA_BYTES, 32):
+        sSFA_f8[i] = cutlass.Float8E4M3FN(1.0)
+        sSFB_f8[i] = cutlass.Float8E4M3FN(1.0)
+    cute.arch.sync_threads()
+
+    pipe = cutlass.pipeline.PipelineTmaWarpMma.create(
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread),
+        consumer_group=cutlass.pipeline.CooperativeGroup(
+            cutlass.pipeline.Agent.Thread, 1
+        ),
+        tx_count=2 * sm120.mxf4nvf4_ab_tma_tx_bytes(),
+        barrier_storage=barriers,
+    )
+    producer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Producer, 1
+    )
+    desc_a_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_a)
+    desc_b_ptr = sm120.make_mxf4nvf4_external_tma_desc_ptr(desc_b)
+    pipe.producer_acquire(producer_state, pipe.producer_try_acquire(producer_state))
+    bar = pipe.producer_get_barrier(producer_state)
+    cute.copy(
+        tma_atom_a,
+        tAgA[(None, 0)],
+        tAsA[(None, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_a_ptr,
+    )
+    cute.copy(
+        tma_atom_b,
+        tBgB[(None, 0)],
+        tBsB[(None, 0)],
+        tma_bar_ptr=bar,
+        tma_desc_ptr=desc_b_ptr,
+    )
+    pipe.producer_commit(producer_state)
+    consumer_state = cutlass.pipeline.make_pipeline_state(
+        cutlass.pipeline.PipelineUserType.Consumer, 1
+    )
+    pipe.consumer_wait(consumer_state, pipe.consumer_try_wait(consumer_state))
+    cute.arch.sync_threads()
+
+    tiled_mma = sm120.make_mxf4nvf4_tiled_mma()
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa, sfb = sm120.make_mxf4nvf4_scale_fragments()
+    acc.fill(0.0)
+    for k_block_idx in cutlass.range_constexpr(2):
+        sm120.stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch(
+            sA_tma,
+            sB_tma,
+            sA_ldsm_scratch,
+            sB_ldsm_scratch,
+            k_block_idx=k_block_idx,
+            lane_idx=tidx,
+        )
+        cute.arch.sync_threads()
+        sm120.load_mxf4nvf4_ldsm_scratch_fragments(
+            tiled_mma, sA_ldsm_scratch, sB_ldsm_scratch, a, b, tidx
+        )
+        sfa_src, sfb_src = sm120.make_mxf4nvf4_scale_smem_fragment_views(
+            sSFA, sSFB, k_block_idx
+        )
+        sm120.load_mxf4nvf4_sfa_fragment(sfa_src, sfa)
+        sm120.load_mxf4nvf4_sfb_fragment(sfb_src, sfb)
+        cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+        cute.arch.sync_threads()
+
+    pipe.consumer_release(consumer_state)
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.jit
+def _launch_atom_external_tma_mma(
+    desc_a: cute.Tensor,
+    desc_b: cute.Tensor,
+    gA: cute.Tensor,
+    gB: cute.Tensor,
+    out: cute.Tensor,
+):
+    ab_smem_layout = sm120.make_mxf4nvf4_ab_tma_physical_layout_staged()
+    tma_atom_a, tma_tensor_a = sm120.make_mxf4nvf4_tiled_tma_atom_a(
+        gA, ab_smem_layout
+    )
+    tma_atom_b, tma_tensor_b = sm120.make_mxf4nvf4_tiled_tma_atom_b(
+        gB, ab_smem_layout
+    )
+    _atom_external_tma_mma_kernel(
+        tma_atom_a,
+        tma_tensor_a,
+        tma_atom_b,
+        tma_tensor_b,
+        desc_a,
+        desc_b,
+        out,
+    ).launch(grid=[1, 1, 1], block=[32, 1, 1], smem=65536)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "legacy physical-byte reference no longer models the logical A/B "
+        "scratch bridge after payload/gap compaction"
+    )
+)
+def test_sm120_mxf4nvf4_external_tma_ldsm_mma_runtime_nonuniform_ab():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    a_storage, a_payload = _aligned_u8_tensor(torch, sm120.MXF4NVF4_AB_SMEM_BYTES, 32)
+    b_storage, b_payload = _aligned_u8_tensor(torch, sm120.MXF4NVF4_AB_SMEM_BYTES, 32)
+    a_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _patterned_u8(torch, sm120.MXF4NVF4_AB_TMA_BYTES, 0x5A)
+    )
+    b_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _patterned_u8(torch, sm120.MXF4NVF4_AB_TMA_BYTES, 0xA5)
+    )
+    a_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    b_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    phys_a = _expected_rank3_fp4_tma_physical(
+        torch, a_payload[: sm120.MXF4NVF4_AB_TMA_BYTES]
+    )
+    phys_b = _expected_rank3_fp4_tma_physical(
+        torch, b_payload[: sm120.MXF4NVF4_AB_TMA_BYTES]
+    )
+    try:
+        desc_a = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(a_payload.data_ptr())
+        desc_b = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(b_payload.data_ptr())
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+
+    desc_a_storage, desc_a_dev = _device_desc_from_bytes(torch, desc_a)
+    desc_b_storage, desc_b_dev = _device_desc_from_bytes(torch, desc_b)
+    ref_out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    tma_out = torch.empty_like(ref_out)
+    cute_phys_a = from_dlpack(phys_a, assumed_align=16, enable_tvm_ffi=True)
+    cute_phys_b = from_dlpack(phys_b, assumed_align=16, enable_tvm_ffi=True)
+    cute_ref_out = from_dlpack(ref_out, enable_tvm_ffi=True)
+    cute.compile(
+        _launch_mma_from_physical_smem,
+        cute_phys_a,
+        cute_phys_b,
+        cute_ref_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )(cute_phys_a, cute_phys_b, cute_ref_out)
+    cute_desc_a = from_dlpack(desc_a_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_b = from_dlpack(desc_b_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_tma_out = from_dlpack(tma_out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_external_tma_mma,
+        cute_desc_a,
+        cute_desc_b,
+        cute_tma_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert "fence.proxy.tensormap::generic.acquire.gpu" in compiled.__ptx__
+    compiled(cute_desc_a, cute_desc_b, cute_tma_out)
+    torch.cuda.synchronize()
+    assert int(torch.unique(ref_out).numel()) > 1
+    torch.testing.assert_close(tma_out, ref_out, rtol=0, atol=0)
+    assert all(
+        x is not None
+        for x in (
+            a_storage,
+            b_storage,
+            desc_a_storage,
+            desc_b_storage,
+        )
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "legacy physical-byte reference no longer models the logical A/B "
+        "scratch bridge after payload/gap compaction"
+    )
+)
+def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_nonuniform_ab():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    # Keep the atom input rank-3 at compile time; the external descriptor still
+    # provides the actual A/B base pointer, datatype, swizzle, and box shape.
+    rank3_tensor_bytes = 2 * sm120.MXF4NVF4_AB_SMEM_BYTES
+    a_storage, a_payload = _aligned_u8_tensor(torch, rank3_tensor_bytes, 32)
+    b_storage, b_payload = _aligned_u8_tensor(torch, rank3_tensor_bytes, 32)
+    a_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _patterned_u8(torch, sm120.MXF4NVF4_AB_TMA_BYTES, 0x3C)
+    )
+    b_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _patterned_u8(torch, sm120.MXF4NVF4_AB_TMA_BYTES, 0xC3)
+    )
+    a_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    b_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    phys_a = _expected_rank3_fp4_tma_physical(
+        torch, a_payload[: sm120.MXF4NVF4_AB_TMA_BYTES]
+    )
+    phys_b = _expected_rank3_fp4_tma_physical(
+        torch, b_payload[: sm120.MXF4NVF4_AB_TMA_BYTES]
+    )
+    try:
+        desc_a = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(a_payload.data_ptr())
+        desc_b = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(b_payload.data_ptr())
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+
+    desc_a_storage, desc_a_dev = _device_desc_from_bytes(torch, desc_a)
+    desc_b_storage, desc_b_dev = _device_desc_from_bytes(torch, desc_b)
+    ref_out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    atom_out = torch.empty_like(ref_out)
+    cute_phys_a = from_dlpack(phys_a, assumed_align=16, enable_tvm_ffi=True)
+    cute_phys_b = from_dlpack(phys_b, assumed_align=16, enable_tvm_ffi=True)
+    cute_ref_out = from_dlpack(ref_out, enable_tvm_ffi=True)
+    cute.compile(
+        _launch_mma_from_physical_smem,
+        cute_phys_a,
+        cute_phys_b,
+        cute_ref_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )(cute_phys_a, cute_phys_b, cute_ref_out)
+    cute_desc_a = from_dlpack(desc_a_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_b = from_dlpack(desc_b_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_gA = from_dlpack(
+        a_payload.reshape(128, 128, 2), assumed_align=32, enable_tvm_ffi=True
+    )
+    cute_gB = from_dlpack(
+        b_payload.reshape(128, 128, 2), assumed_align=32, enable_tvm_ffi=True
+    )
+    cute_atom_out = from_dlpack(atom_out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_atom_external_tma_mma,
+        cute_desc_a,
+        cute_desc_b,
+        cute_gA,
+        cute_gB,
+        cute_atom_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert compiled.__ptx__.count("cp.async.bulk.tensor.3d.shared::cta.global.tile") == 2
+    assert "fence.proxy.tensormap::generic.acquire.gpu" in compiled.__ptx__
+    compiled(cute_desc_a, cute_desc_b, cute_gA, cute_gB, cute_atom_out)
+    torch.cuda.synchronize()
+    assert int(torch.unique(ref_out).numel()) > 1
+    torch.testing.assert_close(atom_out, ref_out, rtol=0, atol=0)
+    assert all(
+        x is not None
+        for x in (
+            a_storage,
+            b_storage,
+            desc_a_storage,
+            desc_b_storage,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("case_name", "a_is_one", "b_is_one", "expected_128_count"),
+    [
+        (
+            "all_ones",
+            lambda major, k: True,
+            lambda major, k: True,
+            128,
+        ),
+        pytest.param(
+            "b_varies_by_logical_n",
+            lambda major, k: True,
+            lambda major, k: major < 4,
+            64,
+            marks=pytest.mark.xfail(
+                reason="logical B major-to-output-N probe still needs the full SM120 LDSM map",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "sparse_b_logical_n_probe",
+            lambda major, k: True,
+            lambda major, k: major == 3,
+            16,
+            marks=pytest.mark.xfail(
+                reason="logical B major-to-output-N probe still needs the full SM120 LDSM map",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "a_varies_by_logical_m",
+            lambda major, k: major < 8,
+            lambda major, k: True,
+            64,
+            marks=pytest.mark.xfail(
+                reason="logical A major-to-output-M probe still needs the full SM120 LDSM map",
+                strict=True,
+            ),
+        ),
+    ],
+)
+def test_sm120_mxf4nvf4_atom_copy_external_tma_ldsm_mma_runtime_logical_ab(
+    case_name, a_is_one, b_is_one, expected_128_count
+):
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    rank3_tensor_bytes = 2 * sm120.MXF4NVF4_AB_SMEM_BYTES
+    a_storage, a_payload = _aligned_u8_tensor(torch, rank3_tensor_bytes, 32)
+    b_storage, b_payload = _aligned_u8_tensor(torch, rank3_tensor_bytes, 32)
+    a_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _logical_fp4_payload(torch, a_is_one)
+    )
+    b_payload[: sm120.MXF4NVF4_AB_TMA_BYTES].copy_(
+        _logical_fp4_payload(torch, b_is_one)
+    )
+    a_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    b_payload[sm120.MXF4NVF4_AB_TMA_BYTES :].fill_(0)
+    try:
+        desc_a = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(a_payload.data_ptr())
+        desc_b = cutlass.utils.make_sm120_mxf4nvf4_tma_desc_bytes(b_payload.data_ptr())
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+
+    desc_a_storage, desc_a_dev = _device_desc_from_bytes(torch, desc_a)
+    desc_b_storage, desc_b_dev = _device_desc_from_bytes(torch, desc_b)
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    cute_desc_a = from_dlpack(desc_a_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_desc_b = from_dlpack(desc_b_dev, assumed_align=128, enable_tvm_ffi=True)
+    cute_gA = from_dlpack(
+        a_payload.reshape(128, 128, 2), assumed_align=32, enable_tvm_ffi=True
+    )
+    cute_gB = from_dlpack(
+        b_payload.reshape(128, 128, 2), assumed_align=32, enable_tvm_ffi=True
+    )
+    cute_out = from_dlpack(out, enable_tvm_ffi=True)
+    compiled = cute.compile(
+        _launch_atom_external_tma_mma,
+        cute_desc_a,
+        cute_desc_b,
+        cute_gA,
+        cute_gB,
+        cute_out,
+        options="--enable-tvm-ffi --keep-ptx",
+    )
+    assert compiled.__ptx__.count("cp.async.bulk.tensor.3d.shared::cta.global.tile") == 2
+    compiled(cute_desc_a, cute_desc_b, cute_gA, cute_gB, cute_out)
+    torch.cuda.synchronize()
+
+    expected_zero_count = out.numel() - expected_128_count
+    actual_128_count = int(torch.count_nonzero(out == 128.0).item())
+    actual_zero_count = int(torch.count_nonzero(out == 0.0).item())
+    unique_values, unique_counts = torch.unique(out, return_counts=True)
+    unique_summary = list(zip(unique_values.cpu().tolist(), unique_counts.cpu().tolist()))
+    assert actual_128_count == expected_128_count, (case_name, unique_summary)
+    assert actual_zero_count == expected_zero_count, (case_name, unique_summary)
+    assert all(
+        x is not None
+        for x in (
+            a_storage,
+            b_storage,
+            desc_a_storage,
+            desc_b_storage,
+        )
+    )

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_warp_mma.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_warp_mma.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import warp
+from cutlass.cute.runtime import from_dlpack
+
+
+pytestmark = [pytest.mark.arch(["120a"])]
+
+_MXF4NVF4_UE4M3_MMA_PTX = (
+    "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale."
+    "scale_vec::4X.f32.e2m1.e2m1.f32.ue4m3"
+)
+
+
+@cute.kernel
+def _mma_unpack_kernel(out: cute.Tensor, scale_a2: cutlass.Constexpr[bool]):
+    tidx, _, _ = cute.arch.thread_idx()
+    mma_op = warp.MmaMXF4NVF4Op(
+        cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+    )
+    tiled_mma = cute.make_tiled_mma(mma_op)
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa = warp.make_mxf4nvf4_sfa_fragment()
+    sfb = warp.make_mxf4nvf4_sfb_fragment()
+
+    cute.recast_tensor(a, cutlass.Int32).fill(0x22222222)
+    cute.recast_tensor(b, cutlass.Int32).fill(0x22222222)
+    acc.fill(0.0)
+    sfa.fill(2.0 if scale_a2 else 1.0)
+    sfb.fill(1.0)
+
+    warp.mma_unpack(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.kernel
+def _gemm_bundle_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    mma_op = warp.MmaMXF4NVF4Op(
+        cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+    )
+    tiled_mma = cute.make_tiled_mma(mma_op)
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa = warp.make_mxf4nvf4_sfa_fragment()
+    sfb = warp.make_mxf4nvf4_sfb_fragment()
+
+    cute.recast_tensor(a, cutlass.Int32).fill(0x22222222)
+    cute.recast_tensor(b, cutlass.Int32).fill(0x22222222)
+    acc.fill(0.0)
+    sfa.fill(1.0)
+    sfb.fill(1.0)
+
+    cute.gemm(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.kernel
+def _mma_unpack_nonuniform_kernel(out: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    mma_op = warp.MmaMXF4NVF4Op(
+        cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+    )
+    tiled_mma = cute.make_tiled_mma(mma_op)
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa = warp.make_mxf4nvf4_sfa_fragment()
+    sfb = warp.make_mxf4nvf4_sfb_fragment()
+    a_i32 = cute.recast_tensor(a, cutlass.Int32)
+    b_i32 = cute.recast_tensor(b, cutlass.Int32)
+
+    for i in cutlass.range(cute.size(a_i32), unroll_full=True):
+        a_i32[i] = 0x11111111 + tidx + i
+    for i in cutlass.range(cute.size(b_i32), unroll_full=True):
+        b_i32[i] = 0x22222222 + tidx + i
+    sfa.fill(1.0)
+    sfb.fill(1.0)
+    acc.fill(0.0)
+
+    warp.mma_unpack(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+
+    acc_size = cute.size(acc)
+    for i in cutlass.range(acc_size, unroll_full=True):
+        out[tidx * acc_size + i] = acc[i]
+
+
+@cute.kernel
+def _bad_scale_dtype_kernel(out: cute.Tensor):
+    mma_op = warp.MmaMXF4NVF4Op(
+        cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+    )
+    tiled_mma = cute.make_tiled_mma(mma_op)
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa = cute.make_rmem_tensor(warp.make_mxf4nvf4_sfa_layout(), cutlass.Float32)
+    sfb = warp.make_mxf4nvf4_sfb_fragment()
+    warp.mma_unpack(tiled_mma, acc, (a, sfa), (b, sfb), acc)
+    out[0] = 0.0
+
+
+@cute.kernel
+def _bad_bundle_kernel(out: cute.Tensor):
+    mma_op = warp.MmaMXF4NVF4Op(
+        cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+    )
+    tiled_mma = cute.make_tiled_mma(mma_op)
+    a = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+    )
+    b = cute.make_rmem_tensor(
+        tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+    )
+    acc = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, 8)), cutlass.Float32)
+    sfa = warp.make_mxf4nvf4_sfa_fragment()
+    cute.gemm(tiled_mma, acc, (a, sfa), b, acc)
+    out[0] = 0.0
+
+
+@cute.jit
+def _launch_mma_unpack(out: cute.Tensor):
+    _mma_unpack_kernel(out, False).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+@cute.jit
+def _launch_mma_unpack_scale_a2(out: cute.Tensor):
+    _mma_unpack_kernel(out, True).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+@cute.jit
+def _launch_gemm_bundle(out: cute.Tensor):
+    _gemm_bundle_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+@cute.jit
+def _launch_mma_unpack_nonuniform(out: cute.Tensor):
+    _mma_unpack_nonuniform_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+@cute.jit
+def _launch_bad_scale_dtype(out: cute.Tensor):
+    _bad_scale_dtype_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+@cute.jit
+def _launch_bad_bundle(out: cute.Tensor):
+    _bad_bundle_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def _cuda_out():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+    out = torch.empty((32 * 4,), device="cuda", dtype=torch.float32)
+    return torch, out, from_dlpack(out, enable_tvm_ffi=True)
+
+
+def _compile_mma_runtime(fn, *args):
+    # Keep executable canaries coupled to the exact SM120 MMA mnemonic and a
+    # materialized CUBIN while leaving constexpr choices at compile time.
+    compiled = cute.compile(fn, *args, options="--keep-ptx --keep-cubin")
+    ptx = compiled.__ptx__
+    assert _MXF4NVF4_UE4M3_MMA_PTX in ptx
+    assert "_mma.block_scale" not in ptx
+
+    cubin = compiled.artifacts.CUBIN
+    if not isinstance(cubin, bytes):
+        pytest.skip("CuTe DSL CUBIN artifact unavailable for SM120 MMA backend check")
+    return compiled
+
+
+def test_sm120_mxf4nvf4_mma_unpack_all_ones():
+    torch, out, cute_out = _cuda_out()
+    compiled = _compile_mma_runtime(_launch_mma_unpack, cute_out)
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full_like(out, 64.0), rtol=0, atol=0)
+
+
+def test_sm120_mxf4nvf4_gemm_bundle_matches_mma_unpack():
+    torch, out_unpack, cute_unpack = _cuda_out()
+    _, out_gemm, cute_gemm = _cuda_out()
+    _compile_mma_runtime(_launch_mma_unpack, cute_unpack)(cute_unpack)
+    _compile_mma_runtime(_launch_gemm_bundle, cute_gemm)(cute_gemm)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out_gemm, out_unpack, rtol=0, atol=0)
+
+
+def test_sm120_mxf4nvf4_mma_unpack_scale_a2():
+    torch, out, cute_out = _cuda_out()
+    compiled = _compile_mma_runtime(_launch_mma_unpack_scale_a2, cute_out)
+    compiled(cute_out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full_like(out, 128.0), rtol=0, atol=0)
+
+
+def test_sm120_mxf4nvf4_mma_unpack_nonuniform_operands_compile():
+    _, out, cute_out = _cuda_out()
+    cute.compile(_launch_mma_unpack_nonuniform, cute_out, options="--keep-ptx")
+
+
+def test_sm120_mxf4nvf4_bad_scale_dtype_raises():
+    _, out, cute_out = _cuda_out()
+    with pytest.raises(TypeError):
+        cute.compile(_launch_bad_scale_dtype, cute_out)
+
+
+def test_sm120_mxf4nvf4_one_sided_bundle_raises():
+    _, out, cute_out = _cuda_out()
+    with pytest.raises((TypeError, ValueError)):
+        cute.compile(_launch_bad_bundle, cute_out)
+
+
+def test_sm120_mxf4nvf4_mma_unpack_rejects_non_2_sequence():
+    _, out, cute_out = _cuda_out()
+
+    @cute.kernel
+    def _bad(out_: cute.Tensor):
+        mma_op = warp.MmaMXF4NVF4Op(
+            cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+        )
+        tiled_mma = cute.make_tiled_mma(mma_op)
+        a = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+        )
+        b = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+        )
+        acc = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_C((16, 8)), cutlass.Float32
+        )
+        sfa = warp.make_mxf4nvf4_sfa_fragment()
+        sfb = warp.make_mxf4nvf4_sfb_fragment()
+        warp.mma_unpack(tiled_mma, acc, (a, sfa, sfa), (b, sfb), acc)
+        out_[0] = 0.0
+
+    @cute.jit
+    def _launch(out_: cute.Tensor):
+        _bad(out_).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+    with pytest.raises(TypeError):
+        cute.compile(_launch, cute_out)
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        ("a", "a fragment"),
+        ("b", "b fragment"),
+        ("c", "c"),
+        ("d", "d"),
+    ],
+)
+def test_sm120_mxf4nvf4_mma_unpack_rejects_malformed_fragment_layout(kind, expected):
+    _, out, cute_out = _cuda_out()
+
+    @cute.kernel
+    def _bad(out_: cute.Tensor):
+        mma_op = warp.MmaMXF4NVF4Op(
+            cutlass.Float4E2M1FN, cutlass.Float32, cutlass.Float8E4M3FN
+        )
+        tiled_mma = cute.make_tiled_mma(mma_op)
+        good_a = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_A((16, 64)), cutlass.Float4E2M1FN
+        )
+        good_b = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_B((8, 64)), cutlass.Float4E2M1FN
+        )
+        good_acc = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_C((16, 8)), cutlass.Float32
+        )
+        bad_a = cute.make_rmem_tensor(cute.make_layout(16), cutlass.Float4E2M1FN)
+        bad_b = cute.make_rmem_tensor(cute.make_layout(8), cutlass.Float4E2M1FN)
+        bad_acc = cute.make_rmem_tensor(cute.make_layout(8), cutlass.Float32)
+        sfa = warp.make_mxf4nvf4_sfa_fragment()
+        sfb = warp.make_mxf4nvf4_sfb_fragment()
+        a = bad_a if kind == "a" else good_a
+        b = bad_b if kind == "b" else good_b
+        d = bad_acc if kind == "d" else good_acc
+        c = bad_acc if kind == "c" else good_acc
+        warp.mma_unpack(tiled_mma, d, (a, sfa), (b, sfb), c)
+        out_[0] = 0.0
+
+    @cute.jit
+    def _launch(out_: cute.Tensor):
+        _bad(out_).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+    with pytest.raises(ValueError, match=expected):
+        cute.compile(_launch, cute_out)

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_pipeline_tma_issue_helpers.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_pipeline_tma_issue_helpers.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import pipeline
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+
+pytestmark = [pytest.mark.arch(["120a"])]
+
+
+def _make_pipeline_kernel(rank, acquire_and_commit):
+    @cute.kernel
+    def _kernel(out: cute.Tensor):
+        smem = cutlass.utils.SmemAllocator()
+        smem_tensor = smem.allocate_tensor(
+            cutlass.Uint8, cute.make_layout(2048), byte_alignment=128
+        )
+        barriers = smem.allocate_array(cutlass.Int64, 2, byte_alignment=8)
+        desc = cute.make_ptr(cutlass.Int64, 0, cute.AddressSpace.gmem, assumed_align=64)
+        pipe = pipeline.PipelineTmaWarpMma.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=1024,
+            barrier_storage=barriers,
+        )
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, 1
+        )
+
+        if rank == 3 and acquire_and_commit:
+            pipeline.producer_acquire_issue_tma_load_3d(
+                pipe,
+                producer_state,
+                None,
+                smem_tensor.iterator,
+                desc,
+                0,
+                0,
+                0,
+                already_elected=True,
+            )
+        elif rank == 3:
+            pipeline.issue_tma_load_3d(
+                pipe,
+                producer_state,
+                smem_tensor.iterator,
+                desc,
+                0,
+                0,
+                0,
+                already_elected=True,
+            )
+        elif acquire_and_commit:
+            pipeline.producer_acquire_issue_tma_load_4d(
+                pipe,
+                producer_state,
+                None,
+                smem_tensor.iterator,
+                desc,
+                0,
+                0,
+                0,
+                0,
+                already_elected=True,
+            )
+        else:
+            pipeline.issue_tma_load_4d(
+                pipe,
+                producer_state,
+                smem_tensor.iterator,
+                desc,
+                0,
+                0,
+                0,
+                0,
+                already_elected=True,
+            )
+        out[0] = 0
+
+    @cute.jit
+    def _launch(out: cute.Tensor):
+        _kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+    return _launch
+
+
+@pytest.mark.parametrize("rank", [3, 4])
+@pytest.mark.parametrize("acquire_and_commit", [False, True])
+def test_sm120_pipeline_tma_wrappers_compile(rank, acquire_and_commit):
+    cute_out = make_fake_compact_tensor(cutlass.Int32, (1,), assumed_align=16)
+    ptx = cute.compile(
+        _make_pipeline_kernel(rank, acquire_and_commit),
+        cute_out,
+        options="--keep-ptx",
+    ).__ptx__
+
+    assert f"cp.async.bulk.tensor.{rank}d.shared::cta.global" in ptx
+    assert "fence.proxy.tensormap::generic.acquire.gpu" in ptx

--- a/test/examples/CuTeDSL/sm_120a/test_sm120_tma_issue_helpers.py
+++ b/test/examples/CuTeDSL/sm_120a/test_sm120_tma_issue_helpers.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.runtime import make_fake_compact_tensor
+
+
+pytestmark = [pytest.mark.arch(["120a"])]
+
+
+def _make_kernel(
+    rank,
+    tile_mode,
+    cache_hint,
+    already_elected=True,
+    desc_space=cute.AddressSpace.gmem,
+):
+    @cute.kernel
+    def _kernel(out: cute.Tensor):
+        dst = cute.make_ptr(cutlass.Int32, 0, cute.AddressSpace.smem, assumed_align=16)
+        desc = cute.make_ptr(cutlass.Int64, 0, desc_space, assumed_align=64)
+        bar = cute.make_ptr(cutlass.Int64, 0, cute.AddressSpace.smem, assumed_align=8)
+        if rank == 2:
+            cpasync.sm120_tma_load_2d(
+                dst,
+                desc,
+                bar,
+                0,
+                0,
+                cache_policy=0 if cache_hint else None,
+                already_elected=already_elected,
+                tile_mode=tile_mode,
+            )
+        elif rank == 3:
+            cpasync.sm120_tma_load_3d(
+                dst,
+                desc,
+                bar,
+                0,
+                0,
+                0,
+                cache_policy=0 if cache_hint else None,
+                already_elected=already_elected,
+                tile_mode=tile_mode,
+            )
+        else:
+            cpasync.sm120_tma_load_4d(
+                dst,
+                desc,
+                bar,
+                0,
+                0,
+                0,
+                0,
+                cache_policy=0 if cache_hint else None,
+                already_elected=already_elected,
+                tile_mode=tile_mode,
+            )
+        out[0] = 0
+
+    @cute.jit
+    def _launch(out: cute.Tensor):
+        _kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+    return _launch
+
+
+def _compile_ptx(host_fn) -> str:
+    cute_out = make_fake_compact_tensor(cutlass.Int32, (1,), assumed_align=16)
+    compiled = cute.compile(host_fn, cute_out, options="--keep-ptx")
+    return compiled.__ptx__
+
+
+@pytest.mark.parametrize(
+    ("rank", "tile_mode", "cache_hint", "expected"),
+    [
+        (
+            2,
+            False,
+            False,
+            "cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes",
+        ),
+        (
+            2,
+            True,
+            True,
+            "cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint",
+        ),
+        (
+            3,
+            False,
+            False,
+            "cp.async.bulk.tensor.3d.shared::cta.global.mbarrier::complete_tx::bytes",
+        ),
+        (
+            3,
+            True,
+            True,
+            "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint",
+        ),
+        (
+            4,
+            False,
+            False,
+            "cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes",
+        ),
+        (
+            4,
+            True,
+            True,
+            "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint",
+        ),
+    ],
+)
+def test_sm120_tma_issue_helper_ptx(rank, tile_mode, cache_hint, expected):
+    ptx = _compile_ptx(_make_kernel(rank, tile_mode, cache_hint))
+    tma_lines = [line.strip() for line in ptx.splitlines() if "cp.async.bulk.tensor" in line]
+
+    assert len(tma_lines) == 1
+    assert expected in tma_lines[0]
+    assert "shared::cluster" not in tma_lines[0]
+    assert ".cta_group" not in tma_lines[0]
+    assert "multicast" not in tma_lines[0]
+
+
+def test_sm120_tma_issue_helper_election_control():
+    elected_ptx = _compile_ptx(_make_kernel(3, False, False, already_elected=True))
+    non_elected_ptx = _compile_ptx(
+        _make_kernel(3, False, False, already_elected=False)
+    )
+
+    assert "elect.sync" not in elected_ptx
+    assert "elect.sync" in non_elected_ptx
+
+
+def test_sm120_tma_issue_helper_accepts_generic_descriptor_pointer():
+    ptx = _compile_ptx(
+        _make_kernel(3, False, False, desc_space=cute.AddressSpace.generic)
+    )
+
+    assert "cp.async.bulk.tensor.3d.shared::cta.global" in ptx
+
+
+def _make_bad_address_space_kernel(kind):
+    @cute.kernel
+    def _kernel(out: cute.Tensor):
+        dst_space = cute.AddressSpace.gmem if kind == "dst" else cute.AddressSpace.smem
+        desc_space = (
+            cute.AddressSpace.smem if kind == "desc" else cute.AddressSpace.gmem
+        )
+        bar_space = cute.AddressSpace.gmem if kind == "bar" else cute.AddressSpace.smem
+        dst = cute.make_ptr(cutlass.Int32, 0, dst_space, assumed_align=16)
+        desc = cute.make_ptr(cutlass.Int64, 0, desc_space, assumed_align=64)
+        bar = cute.make_ptr(cutlass.Int64, 0, bar_space, assumed_align=8)
+        cpasync.sm120_tma_load_3d(dst, desc, bar, 0, 0, 0, already_elected=True)
+        out[0] = 0
+
+    @cute.jit
+    def _launch(out: cute.Tensor):
+        _kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+    return _launch
+
+
+@pytest.mark.parametrize("kind", ["dst", "desc", "bar"])
+def test_sm120_tma_issue_helper_rejects_wrong_address_space(kind):
+    cute_out = make_fake_compact_tensor(cutlass.Int32, (1,), assumed_align=16)
+    with pytest.raises(ValueError):
+        cute.compile(_make_bad_address_space_kernel(kind), cute_out)
+
+
+def test_sm120_tma_issue_helper_rejects_wrong_coordinate_count():
+    @cute.kernel
+    def _kernel(out: cute.Tensor):
+        dst = cute.make_ptr(cutlass.Int32, 0, cute.AddressSpace.smem, assumed_align=16)
+        desc = cute.make_ptr(cutlass.Int64, 0, cute.AddressSpace.gmem, assumed_align=64)
+        bar = cute.make_ptr(cutlass.Int64, 0, cute.AddressSpace.smem, assumed_align=8)
+        cpasync.sm120_tma_load_3d(dst, desc, bar, 0, 0, already_elected=True)
+        out[0] = 0
+
+    @cute.jit
+    def _launch(out: cute.Tensor):
+        _kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+    cute_out = make_fake_compact_tensor(cutlass.Int32, (1,), assumed_align=16)
+    with pytest.raises(TypeError):
+        cute.compile(_launch, cute_out)

--- a/test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py
+++ b/test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import cutlass
+from cutlass.utils.gemm import sm120
+
+
+def test_sm120_blackwell_geforce_helpers_are_exported():
+    assert cutlass.utils.gemm.sm120 is sm120
+    assert cutlass.utils.sm120.make_mxf4nvf4_tiled_mma is sm120.make_mxf4nvf4_tiled_mma
+    assert (
+        cutlass.utils.sm120.make_mxf4nvf4_scale_smem_fragment_views
+        is sm120.make_mxf4nvf4_scale_smem_fragment_views
+    )
+    assert cutlass.utils.blackwell_geforce_helpers.MXF4NVF4_FULL_TMA_BYTES == 18432
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "make_mxf4nvf4_ab_tma_physical_layout_staged",
+        "make_mxf4nvf4_scale_tma_physical_layout_staged",
+        "make_mxf4nvf4_ab_ldsm_scratch_layout",
+        "make_mxf4nvf4_scale_fragment_scratch_layout",
+        "allocate_mxf4nvf4_ldsm_scratch",
+        "make_mxf4nvf4_ldsm_scratch_views",
+        "make_mxf4nvf4_ab_ldsm_copy_views_from_scratch",
+        "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch",
+        "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch",
+        "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch",
+        "load_mxf4nvf4_ldsm_scratch_fragments",
+        "allocate_mxf4nvf4_scale_fragment_scratch",
+        "make_mxf4nvf4_scale_fragment_scratch_views",
+        "stage_mxf4nvf4_sfa_tma_physical_to_fragment_scratch",
+        "stage_mxf4nvf4_scale_tma_physical_to_fragment_scratch",
+        "stage_mxf4nvf4_sfb_tma_physical_to_fragment_scratch",
+        "make_mxf4nvf4_scale_fragment_views_from_compact_smem",
+        "make_mxf4nvf4_scale_fragment_views_from_scratch",
+        "make_mxf4nvf4_scale_fragment_views_from_tma_physical",
+        "mxf4nvf4_scale_tma_physical_offset",
+    ],
+)
+def test_sm120_mxf4nvf4_layout_adapter_helpers_are_exported(name):
+    assert hasattr(sm120, name)
+    assert name in sm120.__all__
+
+
+def test_sm120_mxf4nvf4_transaction_bytes():
+    assert sm120.MXF4NVF4_AB_SMEM_BYTES == 16384
+    assert sm120.mxf4nvf4_ab_tma_tx_bytes() == 8192
+    assert sm120.mxf4nvf4_scale_tma_tx_bytes() == 1024
+    assert sm120.mxf4nvf4_full_tma_tx_bytes() == 18432
+
+
+@pytest.mark.parametrize(
+    ("fn", "args"),
+    [
+        (sm120.mxf4nvf4_ab_tma_tx_bytes, (128, 64)),
+        (sm120.mxf4nvf4_scale_tma_tx_bytes, (128, 128, 32)),
+        (sm120.mxf4nvf4_full_tma_tx_bytes, (128, 128, 64, 16)),
+    ],
+)
+def test_sm120_mxf4nvf4_transaction_bytes_reject_unsupported_shapes(fn, args):
+    with pytest.raises(ValueError):
+        fn(*args)
+
+
+@pytest.mark.parametrize("name", ["sfa_major_offset", "sfb_major_offset"])
+def test_sm120_mxf4nvf4_scale_major_offsets_are_not_silently_ignored(name):
+    # The public staging wrappers are DSL ops that require tensor operands, so
+    # the Python-level regression covers the shared validation guard directly.
+    with pytest.raises(ValueError, match="encode the global major tile"):
+        sm120._require_zero_scale_major_offset(name, 128)
+
+
+def test_sm120_mxf4nvf4_descriptor_contracts_accept_defaults():
+    sm120.validate_mxf4nvf4_ab_tma_contract(base_ptr=0x1000, desc_ptr=0x2000)
+    sm120.validate_mxf4nvf4_scale_tma_contract(base_ptr=0x1000, desc_ptr=0x2000)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"global_dim": (128, 128)},
+        {"global_dim": (64, 128, 1)},
+        {"box_dim": (64, 128, 1)},
+        {"box_dim": (128, 129, 1)},
+        {"desc_ptr": 0x2001},
+        {"global_strides_bytes": (16, 8192)},
+        {"element_strides": (2, 1, 1)},
+        {"tx_count": 8191},
+        {"dtype": cutlass.Uint8},
+        {"align16": False},
+    ],
+)
+def test_sm120_mxf4nvf4_ab_descriptor_contract_rejects_invalid(kwargs):
+    params = {"base_ptr": 0x1000, "desc_ptr": 0x2000}
+    params.update(kwargs)
+    with pytest.raises(ValueError):
+        sm120.validate_mxf4nvf4_ab_tma_contract(**params)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"global_dim": (128, 16, 1)},
+        {"global_dim": (128, 8, 1, 1)},
+        {"box_dim": (128, 17, 1, 1)},
+        {"box_dim": (129, 8, 1, 1)},
+        {"desc_ptr": 0x2001},
+        {"global_strides_bytes": (64, 2048, 2048)},
+        {"element_strides": (2, 1, 1, 1)},
+        {"tx_count": 1023},
+        {"dtype": cutlass.Float8E4M3FN},
+    ],
+)
+def test_sm120_mxf4nvf4_scale_descriptor_contract_rejects_invalid(kwargs):
+    params = {"base_ptr": 0x1000, "desc_ptr": 0x2000}
+    params.update(kwargs)
+    with pytest.raises(ValueError):
+        sm120.validate_mxf4nvf4_scale_tma_contract(**params)

--- a/test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py
+++ b/test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py
@@ -9,6 +9,8 @@ from cutlass.utils.gemm import sm120
 
 def test_sm120_blackwell_geforce_helpers_are_exported():
     assert cutlass.utils.gemm.sm120 is sm120
+    assert cutlass.cute.as_position_independent_swizzle_tensor is not None
+    assert "as_position_independent_swizzle_tensor" in cutlass.cute.__all__
     assert cutlass.utils.sm120.make_mxf4nvf4_tiled_mma is sm120.make_mxf4nvf4_tiled_mma
     assert (
         cutlass.utils.sm120.make_mxf4nvf4_scale_smem_fragment_views
@@ -22,15 +24,22 @@ def test_sm120_blackwell_geforce_helpers_are_exported():
     [
         "make_mxf4nvf4_ab_tma_physical_layout_staged",
         "make_mxf4nvf4_scale_tma_physical_layout_staged",
-        "make_mxf4nvf4_ab_ldsm_scratch_layout",
+        "make_mxf4nvf4_consumer_smem_layout_atom_ab",
+        "make_mxf4nvf4_a_consumer_smem_layout_staged",
+        "make_mxf4nvf4_b_consumer_smem_layout_staged",
+        "make_mxf4nvf4_ab_consumer_smem_views",
+        "make_mxf4nvf4_ab_consumer_microtile_views",
+        "make_mxf4nvf4_ab_fragments_from_consumer_smem",
         "make_mxf4nvf4_scale_fragment_scratch_layout",
-        "allocate_mxf4nvf4_ldsm_scratch",
-        "make_mxf4nvf4_ldsm_scratch_views",
-        "make_mxf4nvf4_ab_ldsm_copy_views_from_scratch",
-        "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch",
-        "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch",
-        "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch",
-        "load_mxf4nvf4_ldsm_scratch_fragments",
+        "make_mxf4nvf4_ab_smem_copy_atoms",
+        "make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem",
+        "load_mxf4nvf4_ab_fragments_from_consumer_smem",
+        "shift_mxf4nvf4_post_ldsm_fp4_fragment",
+        "fp4_shift_mxf4nvf4_a",
+        "fp4_shift_mxf4nvf4_b",
+        "stage_mxf4nvf4_a_tma_physical_to_consumer_smem",
+        "stage_mxf4nvf4_ab_tma_physical_to_consumer_smem",
+        "stage_mxf4nvf4_b_tma_physical_to_consumer_smem",
         "allocate_mxf4nvf4_scale_fragment_scratch",
         "make_mxf4nvf4_scale_fragment_scratch_views",
         "stage_mxf4nvf4_sfa_tma_physical_to_fragment_scratch",
@@ -45,6 +54,80 @@ def test_sm120_blackwell_geforce_helpers_are_exported():
 def test_sm120_mxf4nvf4_layout_adapter_helpers_are_exported(name):
     assert hasattr(sm120, name)
     assert name in sm120.__all__
+
+
+def test_sm120_mxf4nvf4_manual_ldsm_compat_helpers_are_not_public_exports():
+    assert hasattr(sm120, "make_mxf4nvf4_ab_ldsm_scratch_layout")
+    assert hasattr(sm120, "allocate_mxf4nvf4_ldsm_scratch")
+    assert hasattr(sm120, "make_mxf4nvf4_ldsm_scratch_views")
+    assert hasattr(sm120, "make_mxf4nvf4_ab_ldsm_copy_views")
+    assert hasattr(sm120, "make_mxf4nvf4_ab_ldsm_copy_views_from_scratch")
+    assert hasattr(sm120, "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch")
+    assert hasattr(sm120, "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch")
+    assert hasattr(sm120, "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch")
+    assert hasattr(sm120, "load_mxf4nvf4_ldsm_scratch_fragments")
+    assert hasattr(sm120, "load_mxf4nvf4_packed_ldsm_kblock_fragments")
+    assert "make_mxf4nvf4_ab_ldsm_scratch_layout" not in sm120.__all__
+    assert "allocate_mxf4nvf4_ldsm_scratch" not in sm120.__all__
+    assert "make_mxf4nvf4_ldsm_scratch_views" not in sm120.__all__
+    assert "make_mxf4nvf4_ab_ldsm_copy_views" not in sm120.__all__
+    assert "make_mxf4nvf4_ab_ldsm_copy_views_from_scratch" not in sm120.__all__
+    assert "stage_mxf4nvf4_a_tma_physical_to_ldsm_scratch" not in sm120.__all__
+    assert "stage_mxf4nvf4_ab_tma_physical_to_ldsm_scratch" not in sm120.__all__
+    assert "stage_mxf4nvf4_b_tma_physical_to_ldsm_scratch" not in sm120.__all__
+    assert "load_mxf4nvf4_ldsm_scratch_fragments" not in sm120.__all__
+    assert "load_mxf4nvf4_packed_ldsm_kblock_fragments" not in sm120.__all__
+
+
+def test_sm120_mxf4nvf4_consumer_loader_uses_cute_tiled_copy_path():
+    source = sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem.__wrapped__.__code__
+    helper_names = set(source.co_names)
+
+    assert "make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem" in helper_names
+    assert "copy" in helper_names
+    assert "fp4_shift_mxf4nvf4_a" in helper_names
+    assert "fp4_shift_mxf4nvf4_b" in helper_names
+    assert "_ldmatrix_x4_shared_b16" not in helper_names
+
+    view_source = sm120.make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem.__wrapped__.__code__
+    view_names = set(view_source.co_names)
+    assert "make_tiled_copy_A" in view_names
+    assert "make_tiled_copy_B" in view_names
+    assert "as_position_independent_swizzle_tensor" in view_names
+    assert "retile_D" in view_names
+
+
+@pytest.mark.parametrize(
+    "helper",
+    [
+        sm120.make_mxf4nvf4_ab_ldsm_copy_views_from_consumer_smem,
+        sm120.make_mxf4nvf4_ab_fragments_from_consumer_smem,
+        sm120.load_mxf4nvf4_ab_fragments_from_consumer_smem,
+    ],
+)
+def test_sm120_mxf4nvf4_consumer_helpers_name_lane_idx_contract(helper):
+    varnames = helper.__wrapped__.__code__.co_varnames
+    assert "lane_idx" in varnames
+    assert "tidx" not in varnames
+
+
+def test_sm120_mxf4nvf4_physical_to_consumer_bridge_uses_consumer_layout():
+    for helper_name, offset_name in [
+        ("stage_mxf4nvf4_a_tma_physical_to_consumer_smem", "a_major_tile"),
+        ("stage_mxf4nvf4_b_tma_physical_to_consumer_smem", "b_major_tile"),
+    ]:
+        source = getattr(sm120, helper_name).__code__
+        names = set(source.co_names)
+        assert "recast_tensor" in names
+        assert "recast_ptr" not in names
+        assert "make_tensor" in names
+        assert "MXF4NVF4_AB_SMEM_BYTES" in names
+        assert "consumer_stage_idx" in source.co_varnames
+        assert "stage_idx" not in source.co_varnames
+        assert offset_name in source.co_varnames
+    combined = sm120.stage_mxf4nvf4_ab_tma_physical_to_consumer_smem.__code__
+    assert "consumer_stage_idx" in combined.co_varnames
+    assert "stage_idx" not in combined.co_varnames
 
 
 def test_sm120_mxf4nvf4_transaction_bytes():
@@ -73,6 +156,12 @@ def test_sm120_mxf4nvf4_scale_major_offsets_are_not_silently_ignored(name):
     # the Python-level regression covers the shared validation guard directly.
     with pytest.raises(ValueError, match="encode the global major tile"):
         sm120._require_zero_scale_major_offset(name, 128)
+
+
+@pytest.mark.parametrize("name", ["a_major_tile", "b_major_tile"])
+def test_sm120_mxf4nvf4_ab_major_offsets_are_not_silently_ignored(name):
+    with pytest.raises(ValueError, match="encode the global major tile"):
+        sm120._require_zero_major_offset(name, 1)
 
 
 def test_sm120_mxf4nvf4_descriptor_contracts_accept_defaults():

--- a/test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py
+++ b/test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py
@@ -4,6 +4,9 @@
 import pytest
 
 import cutlass
+import cutlass.cute as cute
+import cutlass.utils.blackwell_geforce_helpers as sm120_utils
+from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.utils.gemm import sm120
 
 
@@ -11,12 +14,10 @@ def test_sm120_blackwell_geforce_helpers_are_exported():
     assert cutlass.utils.gemm.sm120 is sm120
     assert cutlass.cute.as_position_independent_swizzle_tensor is not None
     assert "as_position_independent_swizzle_tensor" in cutlass.cute.__all__
-    assert cutlass.utils.sm120.make_mxf4nvf4_tiled_mma is sm120.make_mxf4nvf4_tiled_mma
-    assert (
-        cutlass.utils.sm120.make_mxf4nvf4_scale_smem_fragment_views
-        is sm120.make_mxf4nvf4_scale_smem_fragment_views
+    assert cutlass.utils.sm120.make_blockscaled_trivial_tiled_mma is (
+        sm120_utils.make_blockscaled_trivial_tiled_mma
     )
-    assert cutlass.utils.blackwell_geforce_helpers.MXF4NVF4_FULL_TMA_BYTES == 18432
+    assert sm120_utils.get_full_tma_tx_bytes() == 18432
 
 
 @pytest.mark.parametrize(
@@ -54,6 +55,161 @@ def test_sm120_blackwell_geforce_helpers_are_exported():
 def test_sm120_mxf4nvf4_layout_adapter_helpers_are_exported(name):
     assert hasattr(sm120, name)
     assert name in sm120.__all__
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "make_blockscaled_trivial_tiled_mma",
+        "make_smem_layout_a_tma_physical",
+        "make_smem_layout_b_tma_physical",
+        "make_smem_layout_a_consumer",
+        "make_smem_layout_b_consumer",
+        "make_smem_layout_scale_tma_physical",
+        "make_smem_layouts_ab",
+        "make_ab_smem_views",
+        "make_ab_consumer_smem_views",
+        "cluster_shape_to_tma_atom_A",
+        "cluster_shape_to_tma_atom_B",
+        "cluster_shape_to_tma_atom_SFA",
+        "cluster_shape_to_tma_atom_SFB",
+        "make_tiled_tma_atom_A",
+        "make_tiled_tma_atom_B",
+        "make_tiled_tma_atom_SFA",
+        "make_tiled_tma_atom_SFB",
+        "get_ab_tma_tx_bytes",
+        "get_scale_tma_tx_bytes",
+        "get_full_tma_tx_bytes",
+        "get_tma_desc_bytes",
+        "stage_ab_tma_physical_to_consumer_smem",
+        "make_ab_consumer_microtile_views",
+        "make_ab_fragments_from_consumer_smem",
+        "load_ab_fragments_from_consumer_smem",
+        "allocate_scale_fragment_scratch",
+        "make_scale_fragment_scratch_views",
+        "stage_scale_tma_physical_to_fragment_scratch",
+        "make_scale_fragment_views_from_scratch",
+        "make_scale_fragments",
+        "load_sfa_fragment",
+        "load_sfb_fragment",
+        "make_external_tma_desc_ptr",
+        "validate_ab_tma_contract",
+        "validate_scale_tma_contract",
+    ],
+)
+def test_sm120_blackwell_geforce_facade_helpers_are_exported(name):
+    assert hasattr(sm120_utils, name)
+    assert name in sm120_utils.__all__
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "MXF4NVF4_FULL_TMA_BYTES",
+        "make_mxf4nvf4_tiled_mma",
+        "make_mxf4nvf4_scale_smem_fragment_views",
+        "make_trivial_tiled_mma",
+        "get_tmem_load_op",
+        "get_tmem_store_op",
+        "get_smem_store_op",
+        "get_num_tmem_alloc_cols",
+        "make_tmem_layout_sfa",
+        "make_tmem_layout_sfb",
+    ],
+)
+def test_sm120_blackwell_geforce_facade_does_not_export_low_level_or_stub_names(name):
+    assert not hasattr(sm120_utils, name)
+    assert name not in sm120_utils.__all__
+
+
+def test_sm120_blackwell_geforce_facade_transaction_bytes():
+    assert sm120_utils.get_ab_tma_tx_bytes() == sm120.mxf4nvf4_ab_tma_tx_bytes()
+    assert sm120_utils.get_scale_tma_tx_bytes() == sm120.mxf4nvf4_scale_tma_tx_bytes()
+    assert sm120_utils.get_full_tma_tx_bytes() == sm120.mxf4nvf4_full_tma_tx_bytes()
+    assert sm120_utils.get_tma_desc_bytes() == sm120.MXF4NVF4_TMA_DESC_BYTES
+
+
+def test_sm120_blackwell_geforce_facade_cluster_atom_success():
+    atom = sm120_utils.cluster_shape_to_tma_atom_A((1, 1, 1))
+    assert isinstance(atom, cutlass.cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp)
+
+
+@cute.kernel
+def _facade_mma_wrapper_kernel(out: cute.Tensor):
+    sm120_utils.make_blockscaled_trivial_tiled_mma()
+    out[0] = cutlass.Float32(0.0)
+
+
+@cute.jit
+def _launch_facade_mma_wrapper(out: cute.Tensor):
+    _facade_mma_wrapper_kernel(out).launch(grid=[1, 1, 1], block=[32, 1, 1])
+
+
+def test_sm120_blackwell_geforce_facade_mma_wrapper_success():
+    out = make_fake_compact_tensor(cutlass.Float32, (1,))
+    compiled = cute.compile(
+        _launch_facade_mma_wrapper,
+        out,
+        options="--gpu-arch=sm_120a --keep-ptx",
+    )
+    assert compiled.__ptx__
+
+
+@cute.kernel
+def _facade_scale_layout_wrapper_kernel(out: cute.Tensor):
+    sm120_utils.make_smem_layout_scale_tma_physical()
+    out[0] = cutlass.Float32(0.0)
+
+
+@cute.jit
+def _launch_facade_scale_layout_wrapper(out: cute.Tensor):
+    _facade_scale_layout_wrapper_kernel(out).launch(
+        grid=[1, 1, 1], block=[32, 1, 1]
+    )
+
+
+def test_sm120_blackwell_geforce_facade_scale_layout_wrapper_success():
+    out = make_fake_compact_tensor(cutlass.Float32, (1,))
+    compiled = cute.compile(
+        _launch_facade_scale_layout_wrapper,
+        out,
+        options="--gpu-arch=sm_120a --keep-ptx",
+    )
+    assert compiled.__ptx__
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"tile_k": 8},
+        {"sf_vec_size": 8},
+    ],
+)
+def test_sm120_blackwell_geforce_facade_rejects_unsupported_scale_layout_contract(
+    kwargs,
+):
+    with pytest.raises(ValueError):
+        sm120_utils.make_smem_layout_scale_tma_physical(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"a_dtype": cutlass.Float16},
+        {"b_dtype": cutlass.Float16},
+        {"acc_dtype": cutlass.Float16},
+        {"sf_dtype": cutlass.Float8E5M2},
+        {"sf_vec_size": 32},
+    ],
+)
+def test_sm120_blackwell_geforce_facade_rejects_unsupported_mma_contract(kwargs):
+    with pytest.raises(ValueError):
+        sm120_utils.make_blockscaled_trivial_tiled_mma(**kwargs)
+
+
+def test_sm120_blackwell_geforce_facade_rejects_multicast_cluster_shape():
+    with pytest.raises(ValueError):
+        sm120_utils.cluster_shape_to_tma_atom_A((1, 2, 1))
 
 
 def test_sm120_mxf4nvf4_manual_ldsm_compat_helpers_are_not_public_exports():

--- a/test/python/CuTeDSL/test_sm120_tensormap_manager.py
+++ b/test/python/CuTeDSL/test_sm120_tensormap_manager.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import ctypes
+
+import pytest
+
+from cutlass import utils
+from cutlass.base_dsl.common import CudaDriverDependencyError
+from cutlass.utils import tensormap_manager as tm
+
+
+def _cuda_driver():
+    return pytest.importorskip("cuda.bindings.driver")
+
+
+def test_sm120_driver_descriptor_storage_is_64b_aligned():
+    backing, tensor_map, address = tm._make_aligned_cu_tensor_map()
+
+    assert address % 64 == 0
+    assert ctypes.addressof(tensor_map) == address
+    assert len(tm._cu_tensor_map_to_bytes(address)) == utils.SM120_MXF4NVF4_TENSOR_MAP_BYTES
+    assert backing is not None
+
+
+def test_sm120_tensormap_driver_enum_names_resolve():
+    cuda_driver = _cuda_driver()
+
+    assert (
+        tm._cuda_enum_value(
+            cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
+        )
+        >= 0
+    )
+    assert (
+        tm._cuda_enum_value(cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B)
+        >= 0
+    )
+
+
+def test_sm120_fp4_descriptor_validation_default_and_rejections():
+    valid = dict(
+        base_ptr=0x1000,
+        desc_ptr=0x2000,
+        global_dim=(128, 128, 1),
+        global_strides_bytes=(64, 8192),
+        box_dim=(128, 128, 1),
+        element_strides=(1, 1, 1),
+        tx_count=8192,
+    )
+    utils.validate_sm120_mxf4nvf4_tma_desc(**valid)
+
+    rejects = [
+        dict(base_ptr=0x1008),
+        dict(desc_ptr=0x2020),
+        dict(global_dim=(128, 128)),
+        dict(global_dim=(64, 128, 1)),
+        dict(box_dim=(64, 128, 1)),
+        dict(global_strides_bytes=(66, 8192)),
+        dict(global_strides_bytes=(32, 8192)),
+        dict(global_strides_bytes=(64, 4096)),
+        dict(box_dim=(128, 129, 1)),
+        dict(box_dim=(128, 128, 2)),
+        dict(tx_count=4096),
+    ]
+    for update in rejects:
+        with pytest.raises(ValueError):
+            utils.validate_sm120_mxf4nvf4_tma_desc(**dict(valid, **update))
+
+
+def test_sm120_scale_descriptor_validation_default_and_rejections():
+    valid = dict(
+        base_ptr=0x1000,
+        desc_ptr=0x2000,
+        global_dim=(128, 16, 1, 1),
+        global_strides_bytes=(128, 2048, 2048),
+        box_dim=(128, 8, 1, 1),
+        element_strides=(1, 1, 1, 1),
+        tx_count=1024,
+    )
+    utils.validate_sm120_mxf4nvf4_scale_tma_desc(**valid)
+    assert utils.sm120_mxf4nvf4_padded_scale_k_extent(8) == 16
+    assert utils.sm120_mxf4nvf4_padded_scale_k_extent(17) == 32
+
+    rejects = [
+        dict(base_ptr=0x1001),
+        dict(global_dim=(128, 16, 1)),
+        dict(global_dim=(128, 8, 1, 1)),
+        dict(global_strides_bytes=(130, 2048, 2048)),
+        dict(global_strides_bytes=(64, 2048, 2048)),
+        dict(global_strides_bytes=(128, 1024, 2048)),
+        dict(global_dim=(128, 16, 2, 1), global_strides_bytes=(128, 2048, 2048)),
+        dict(box_dim=(129, 8, 1, 1)),
+        dict(box_dim=(128, 17, 1, 1)),
+        dict(box_dim=(128, 8, 2, 1)),
+        dict(tx_count=2048),
+    ]
+    for update in rejects:
+        with pytest.raises(ValueError):
+            utils.validate_sm120_mxf4nvf4_scale_tma_desc(**dict(valid, **update))
+
+
+def _install_fake_encoder(monkeypatch):
+    calls = []
+
+    def encode(
+        tensor_map_ptr,
+        data_type,
+        rank,
+        global_address,
+        global_dim,
+        global_strides,
+        box_dim,
+        element_strides,
+        interleave,
+        swizzle,
+        l2_promotion,
+        oob_fill,
+    ):
+        tensor_map = ctypes.cast(tensor_map_ptr, ctypes.POINTER(tm._CUtensorMap)).contents
+        tensor_map.opaque[0] = data_type
+        tensor_map.opaque[1] = rank
+        calls.append(
+            {
+                "data_type": data_type,
+                "rank": rank,
+                "base": global_address.value,
+                "global_dim": tuple(global_dim[i] for i in range(rank)),
+                "global_strides": tuple(global_strides[i] for i in range(rank - 1)),
+                "box_dim": tuple(box_dim[i] for i in range(rank)),
+                "element_strides": tuple(element_strides[i] for i in range(rank)),
+                "interleave": interleave,
+                "swizzle": swizzle,
+                "l2_promotion": l2_promotion,
+                "oob_fill": oob_fill,
+            }
+        )
+        return 0
+
+    monkeypatch.setattr(tm, "_get_cuda_tensormap_encoder", lambda: encode)
+    return calls
+
+
+def test_sm120_fp4_driver_descriptor_builder_fields(monkeypatch):
+    cuda_driver = _cuda_driver()
+    calls = _install_fake_encoder(monkeypatch)
+
+    desc = utils.make_sm120_mxf4nvf4_tma_desc_bytes(0x1000)
+
+    assert len(desc) == utils.SM120_MXF4NVF4_TENSOR_MAP_BYTES
+    assert calls == [
+        {
+            "data_type": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
+            ),
+            "rank": 3,
+            "base": 0x1000,
+            "global_dim": (128, 128, 1),
+            "global_strides": (64, 8192),
+            "box_dim": (128, 128, 1),
+            "element_strides": (1, 1, 1),
+            "interleave": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE
+            ),
+            "swizzle": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B
+            ),
+            "l2_promotion": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B
+            ),
+            "oob_fill": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+            ),
+        }
+    ]
+
+    with pytest.raises(ValueError):
+        utils.make_sm120_mxf4nvf4_tma_desc_bytes(0x1000, major_extent=0)
+    with pytest.raises(ValueError):
+        utils.make_sm120_mxf4nvf4_tma_desc_bytes(
+            0x1000, major_extent=128, box_major_extent=129
+        )
+
+
+def test_sm120_scale_driver_descriptor_builder_fields(monkeypatch):
+    cuda_driver = _cuda_driver()
+    calls = _install_fake_encoder(monkeypatch)
+
+    desc = utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(0x1000)
+
+    assert len(desc) == utils.SM120_MXF4NVF4_TENSOR_MAP_BYTES
+    assert calls == [
+        {
+            "data_type": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_UINT8
+            ),
+            "rank": 4,
+            "base": 0x1000,
+            "global_dim": (128, 16, 1, 1),
+            "global_strides": (128, 2048, 2048),
+            "box_dim": (128, 8, 1, 1),
+            "element_strides": (1, 1, 1, 1),
+            "interleave": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE
+            ),
+            "swizzle": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B
+            ),
+            "l2_promotion": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B
+            ),
+            "oob_fill": tm._cuda_enum_value(
+                cuda_driver.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+            ),
+        }
+    ]
+
+    with pytest.raises(ValueError):
+        utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(0x1000, tile_extent=0)
+    with pytest.raises(ValueError):
+        utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(
+            0x1000, major_extent=128, box_major_extent=129
+        )
+
+
+def test_sm120_driver_descriptor_builders_real_driver_smoke():
+    _cuda_driver()
+    try:
+        tm._get_cuda_tensormap_encoder()
+    except CudaDriverDependencyError as exc:
+        pytest.skip(f"CUDA Driver tensor-map encoder unavailable: {exc}")
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device unavailable")
+
+    fp4_storage = torch.empty((8192,), device="cuda", dtype=torch.uint8)
+    scale_storage = torch.empty((2048,), device="cuda", dtype=torch.uint8)
+
+    assert len(utils.make_sm120_mxf4nvf4_tma_desc_bytes(fp4_storage.data_ptr())) == 128
+    assert len(
+        utils.make_sm120_mxf4nvf4_scale_tma_desc_bytes(scale_storage.data_ptr())
+    ) == 128

--- a/test/python/CuTeDSL/test_sm120_tma_helpers.py
+++ b/test/python/CuTeDSL/test_sm120_tma_helpers.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from cutlass import pipeline
+from cutlass.cute.nvgpu import cpasync
+import cutlass.pipeline.sm120 as sm120_pipeline
+from cutlass.pipeline.sm90 import PipelineTmaAsync
+
+
+def test_sm120_tma_helpers_are_exported():
+    assert cpasync.sm120_tma_load_2d is not None
+    assert cpasync.sm120_tma_load_3d is not None
+    assert cpasync.sm120_tma_load_4d is not None
+    assert pipeline.PipelineTmaWarpMma is not None
+    assert pipeline.issue_tma_load_3d is sm120_pipeline.issue_tma_load_3d
+    assert pipeline.issue_tma_load_4d is sm120_pipeline.issue_tma_load_4d
+    assert (
+        pipeline.producer_acquire_issue_tma_load_3d
+        is sm120_pipeline.producer_acquire_issue_tma_load_3d
+    )
+    assert (
+        pipeline.producer_acquire_issue_tma_load_4d
+        is sm120_pipeline.producer_acquire_issue_tma_load_4d
+    )
+
+
+def test_pipeline_tma_warp_mma_create_returns_wrapper(monkeypatch):
+    base = object.__new__(PipelineTmaAsync)
+    for name, value in (
+        ("sync_object_full", object()),
+        ("sync_object_empty", object()),
+        ("num_stages", 2),
+        ("producer_mask", None),
+        ("consumer_mask", None),
+        ("is_signalling_thread", True),
+    ):
+        object.__setattr__(base, name, value)
+
+    monkeypatch.setattr(
+        sm120_pipeline.PipelineTmaAsync,
+        "create",
+        staticmethod(lambda **kwargs: base),
+    )
+
+    pipe = sm120_pipeline.PipelineTmaWarpMma.create(
+        num_stages=2,
+        producer_group=object(),
+        consumer_group=object(),
+        tx_count=128,
+        barrier_storage=object(),
+    )
+
+    assert isinstance(pipe, sm120_pipeline.PipelineTmaWarpMma)
+    assert pipe.sync_object_full is base.sync_object_full
+    assert pipe.sync_object_empty is base.sync_object_empty
+    assert pipe.num_stages == 2

--- a/test/utils/test_sharding.py
+++ b/test/utils/test_sharding.py
@@ -34,7 +34,6 @@ from collections import defaultdict, UserDict
 from pathlib import Path
 import inspect
 import re
-import sys
 
 import pytest
 from _pytest.assertion.util import running_on_ci
@@ -256,16 +255,13 @@ def pytest_collection_modifyitems(config, items):
         else:
             compatible_SMs = {f"{target_cc}a", f"{target_cc}f", f"{target_cc}"}
     else:
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        if script_dir not in sys.path:
-            sys.path.append(script_dir)
+        from cutlass.base_dsl.runtime.cuda import get_compute_capability_major_minor
 
-        from device_info import compute_capability
-
-        if compute_capability:
-            target_cc = int(compute_capability)
-        else:
+        major, minor = get_compute_capability_major_minor()
+        if major is None or minor is None:
             raise SystemError("Failed to get CUDA compute capability!")
+
+        target_cc = major * 10 + minor
 
         if target_cc < 90:
             compatible_SMs = {f"{target_cc}"}


### PR DESCRIPTION
This PR adds the CuTe DSL SM120 MXF4NVF4/NVFP4 helper surface needed to build the Blackwell GeForce warp-MMA/TMA mainloop path from Python.

This is stacked on #3204, so this branch includes those 4 commits. Reviewers should focus on the 9 SM120 NVFP4 changes on top of that base.

This PR supersedes #3185 and #3189.

The immediate downstream motivation is to unblock SM120 NVFP4 support for QuACK by Dao AI Lab.

This PR also contains a temporary workaround for #3236 that was found while working on this.

## Table of Contents
- [Supported path](#supported-path)
- [Limitations](#limitations)
- [Performance status](#performance-status)
- [Changes](#changes)
- [Notes](#notes)
- [Validation](#validation)
- [CuTeDSL environment](#cutedsl-environment)

## Supported path

This PR targets the narrow SM120 NVFP4 blockscaled path used by the Blackwell GeForce 79a-style mainloop:

- A/B: `Float4E2M1FN`
- SFA/SFB: `Float8E4M3FN`
- scale vector size: `sf_vec_size=16`
- accumulator: `Float32`
- output epilogue: BF16 D
- CTA tile: `tile_shape_mnk=(128, 128, 128)`
- cluster shape: `(1, 1, 1)`

The implementation uses external-descriptor TMA for A/B/SFA/SFB. A/B TMA writes the physical `ALIGN16B` SMEM layout, then CuTe DSL stages that data into the 79a-style consumer SMEM layout. Scale tensors use a rank-4 TMA physical layout and CuTe DSL scale-fragment scratch. The BF16 epilogue uses the S2G TMA store partition path with the TMA tensor returned by `make_tiled_tma_atom(...)`.

## Limitations

This is not a general SM120 GEMM abstraction. Current limitations are intentional:

- no C/beta path
- no varlen path
- no gather path
- no multicast path
- no non-128 K tile support
- no attempt to generalize all SM100 helper APIs to SM120

## Performance status

This PR is correctness- and enablement-focused, not performance-optimized.

The current implementation is intended to establish the CuTe DSL surface for the narrow SM120 NVFP4 79a-style path and to make the data-movement, descriptor, consumer-SMEM, scale-fragment, and BF16 S2G store contracts testable from Python. It deliberately prioritizes explicit staging, validation, and focused runtime canaries over optimized scheduling.

Known non-optimized areas include:

- A/B TMA data is staged through an explicit physical-to-consumer-SMEM bridge.
- Scale TMA data is staged through explicit physical-to-fragment scratch.
- The example uses a simple one-stage pipeline scaffold.
- Producer/consumer scheduling is intentionally minimal.
- No attempt is made here to tune occupancy, overlap, warp specialization, register pressure, or epilogue throughput.

The goal is to provide a correct and reviewable SM120 NVFP4 foundation for downstream work, including QuACK. Performance tuning should be handled in follow-up work once the helper contracts and descriptor path are accepted.

## Changes

- Add SM120 MXF4NVF4 warp-MMA support in CuTe DSL:
  - bundled `(fragment, scale)` operands for `cute.gemm(...)`
  - `warp.mma_unpack(...)`
  - SFA/SFB register scale-fragment layout and construction helpers
  - validation for the supported SM120 shape, FP4 fragment layout, FP32 accumulator layout, and E4M3 scale layout

- Add external-descriptor TMA support for SM120:
  - CTA-local rank-2/rank-3/rank-4 issue helpers
  - descriptor acquire fences before TMA issue
  - optional tile mode, optional L2 cache hint, and already-elected issue paths
  - SM120 pipeline wrappers for rank-3/rank-4 descriptor loads

- Add temporary Driver API tensor-map builders for SM120 NVFP4:
  - rank-3 packed FP4 A/B descriptors using `CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B`
  - rank-4 UINT8 scale descriptors
  - validation for alignment, extents, strides, box dimensions, and transaction byte counts
  - runtime canaries for descriptor-created TMA copies

- Add the SM120 NVFP4 GEMM helper layer:
  - `cutlass.utils.gemm.sm120`
  - TMA transaction byte helpers
  - descriptor contract validation wrappers
  - TMA atom builders for A/B/SFA/SFB
  - external descriptor pointer helpers
  - physical A/B TMA-to-consumer-SMEM bridge
  - scale physical-to-fragment bridge
  - SM120 NVFP4 scale fragment loading helpers

- Port the 79a-style consumer SMEM bridge:
  - consumer SMEM layouts matching the C++ path
  - position-independent swizzle tensor support
  - A/B physical TMA-to-consumer-SMEM staging
  - tiled-copy-based consumer fragment loading
  - local `m_atom` / `n_atom` selection for consumer microtiles
  - multi-warp lane-index coverage

- Add an SM120 Blackwell GeForce helper façade:
  - SM100-shaped wrapper names for the supported SM120 NVFP4 warp-MMA/TMA path
  - unsupported SM100/TMEM/tcgen05/dense-MMA helpers intentionally omitted

- Fix and document the tiled S2G TMA store partition path:
  - add `cpasync.tma_partition_s2g_tile`
  - clarify that S2G TMA stores should partition the TMA tensor returned by `make_tiled_tma_atom(...)`, not a manually tiled GMEM view
  - add BF16 S2G TMA store partition regression coverage

## Notes

Development of this code used the CUDA/C++ SM120 reference path in:

`examples/79_blackwell_geforce_gemm/79a_blackwell_geforce_nvfp4_bf16_gemm.cu`

as an oracle, while reusing the existing SM100 CuTe DSL scaffolding where it maps cleanly.

The SM120 path is intentionally narrow. It targets the NVFP4/MXF4NVF4 warp-MMA, external-descriptor TMA, 79a-style consumer SMEM bridge, scale bridge, and BF16 S2G TMA epilogue path needed by the current Blackwell GeForce mainloop work.

## Validation

Suggested reviewer commands:

```bash
export CUTE_DSL_CACHE_DIR=/data/agent/CuTeDSL/cache

python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_warp_mma.py
python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_tma_issue_helpers.py
python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_pipeline_tma_issue_helpers.py
python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_canary.py
python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_mainloop.py
python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_bf16_tma_store_partition.py

python -m pytest -q test/python/CuTeDSL/test_sm120_tma_helpers.py
python -m pytest -q test/python/CuTeDSL/test_sm120_tensormap_manager.py
python -m pytest -q test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py

python examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py --compile-only
python examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py --ptx-inspect
python examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py --runtime-check
python examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py --runtime-tma-check

python -m py_compile \
  python/CuTeDSL/cutlass/cute/__init__.py \
  python/CuTeDSL/cutlass/cute/atom.py \
  python/CuTeDSL/cutlass/cute/tensor.py \
  python/CuTeDSL/cutlass/utils/gemm/sm120.py \
  test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_tma_mainloop.py \
  test/examples/CuTeDSL/sm_120a/test_sm120_bf16_tma_store_partition.py \
  test/python/CuTeDSL/test_sm120_blackwell_geforce_helpers.py \
  examples/python/CuTeDSL/blackwell_geforce/sm120_mxf4nvf4_tma_mainloop.py

git diff --cached --check
git diff --check
```

## CuTeDSL environment

This branch needs the CuTeDSL development runtime payload, not the released `4.4.2` or `4.5.0` generated `_mlir` files.

From the CUTLASS repo root:

```bash
python -m pip install -U "nvidia-cutlass-dsl[cu13]==4.5.0.dev0"
```

Then refresh the editable CuTeDSL generated runtime payload:

```bash
python - <<'PY'
from pathlib import Path
import shutil
import site

repo = Path("python/CuTeDSL").resolve()
payload = Path(site.getusersitepackages()) / "nvidia_cutlass_dsl"
src_cutlass = payload / "python_packages/cutlass"

for rel in ["cutlass/_mlir", "lib"]:
    dst = repo / rel
    if dst.exists():
        shutil.rmtree(dst)

shutil.copytree(src_cutlass / "_mlir", repo / "cutlass/_mlir")
shutil.copytree(payload / "lib", repo / "lib")

for rel in ["base_dsl/py.typed", "cute/py.typed"]:
    src = src_cutlass / rel
    if src.exists():
        dst = repo / "cutlass" / rel
        dst.parent.mkdir(parents=True, exist_ok=True)
        shutil.copy2(src, dst)

(repo / "VERSION.EDITABLE").write_text("4.5.0.dev1\n")
PY
```

Install the editable package:

```bash
python -m pip install -e python/CuTeDSL
```

Sanity check:

```bash
python -m pytest -q test/examples/CuTeDSL/sm_120a/test_sm120_mxf4nvf4_warp_mma.py
```

Expected result:

```
11 passed
```

Do not use `nvidia-cutlass-dsl-libs-*=4.5.0` for this branch: its generated `_mlir` bindings are incompatible with the SM120 blockscaled MMA code in this branch and can fail
with errors such as `VectorType` object is not iterable.
