### PR TITLE
[CuTe] Add missing include for smem_ptr_flag_bits in print_tensor.hpp

### DIFF
--- a/include/cute/util/print_tensor.hpp
+++ b/include/cute/util/print_tensor.hpp
@@ -33,6 +33,7 @@
 #include <cute/config.hpp>           // CUTE_HOST_DEVICE
 
 #include <cute/layout.hpp>
+#include <cute/pointer_flagged.hpp>  // cute::smem_ptr_flag_bits
 #include <cute/tensor_impl.hpp>
 
 namespace cute


### PR DESCRIPTION
### Summary

`cute/util/print_tensor.hpp` references `smem_ptr_flag_bits<B>` (line 92, in the `print_layout` overload for `ComposedLayout`), but its existing includes (`config.hpp`, `layout.hpp`, `tensor_impl.hpp`) do not transitively pull in `cute/pointer_flagged.hpp`, which is the header that defines `smem_ptr_flag_bits`.

In typical usage the header is reached via `cute/tensor.hpp`, which already includes `pointer_flagged.hpp`, so the bug is hidden. It surfaces when:

- a translation unit includes `cute/util/print_tensor.hpp` directly, or
- `clangd` parses the header in isolation (the symptom reported in #3205: *"use of undeclared identifier 'smem_ptr_flag_bits'"*).

This patch adds the missing include so the header is self-contained.

### Fix

```diff
 #include <cute/layout.hpp>
+#include <cute/pointer_flagged.hpp>  // cute::smem_ptr_flag_bits
 #include <cute/tensor_impl.hpp>
```

Mirrors the include style already used in `cute/atom/mma_traits_sm90_gmma.hpp` (`#include <cute/pointer_flagged.hpp>            // cute::smem_ptr_flag`).

### Verification

- Confirmed by inspection that none of `config.hpp`, `layout.hpp`, `tensor_impl.hpp` transitively include `pointer_flagged.hpp`.
- `grep -rn "pointer_flagged" include/cute/` shows only `tensor.hpp` and `mma_traits_sm90_gmma.hpp` pulling it in elsewhere.
- I do not have an NVCC toolchain on this machine to build the full example suite; if CI catches anything unexpected I'll iterate.

### Issue

Fixes #3205