### PR TITLE
[cutlass-library] Alias cutlass_lib to the static target when shared is off (fixes #3179)

### DIFF
--- a/tools/library/CMakeLists.txt
+++ b/tools/library/CMakeLists.txt
@@ -293,9 +293,14 @@ cutlass_add_cutlass_library(
 
   )
 
-# For backward compatibility with the old name
+# For backward compatibility with the old name.
+# `cutlass_lib` consumers (e.g. tools/profiler) need a single target to link
+# against regardless of whether the user opted for a shared or static-only
+# build, so fall back to the static target when shared is disabled.
 if(CUTLASS_BUILD_SHARED_LIBS)
   add_library(cutlass_lib ALIAS cutlass_library)
+elseif(CUTLASS_BUILD_STATIC_LIBS)
+  add_library(cutlass_lib ALIAS cutlass_library_static)
 endif()
 
 if(CUTLASS_BUILD_STATIC_LIBS)


### PR DESCRIPTION
### Summary

When CUTLASS is built with a static-only configuration (`-DCUTLASS_BUILD_SHARED_LIBS=OFF -DCUTLASS_BUILD_STATIC_LIBS=ON`), `tools/profiler` fails to compile:

```
fatal error: cutlass/library/library.h: No such file or directory
```

### Root cause

In `tools/library/CMakeLists.txt` the legacy `cutlass_lib` ALIAS is only created when `CUTLASS_BUILD_SHARED_LIBS=ON`:

```cmake
if(CUTLASS_BUILD_SHARED_LIBS)
  add_library(cutlass_lib ALIAS cutlass_library)
endif()
```

But `tools/profiler/CMakeLists.txt` unconditionally consumes it (line 89):

```cmake
target_link_libraries(cutlass_profiler PRIVATE cutlass_lib ...)
```

When shared is disabled, `cutlass_lib` doesn't exist; CMake silently treats it as a plain `-lcutlass_lib` linker flag, so the transitive include directories from `cutlass_library_includes` (which expose `tools/library/include/`) are never propagated, hence the missing-header error.

### Fix

Fall back to aliasing `cutlass_lib` to the static target when shared is disabled:

```cmake
if(CUTLASS_BUILD_SHARED_LIBS)
  add_library(cutlass_lib ALIAS cutlass_library)
elseif(CUTLASS_BUILD_STATIC_LIBS)
  add_library(cutlass_lib ALIAS cutlass_library_static)
endif()
```

Behavior when `SHARED_LIBS=ON` (the default and most common configuration) is unchanged.

### Verification

I don't have a CUDA build environment on this machine, so I have not run a full static-only build locally. The diff matches the diagnosis in the issue body verbatim, and the change is local to a single backwards-compatibility alias.

### Issue

Fixes #3179