### PR TITLE
[DOC] Drop empty duplicated Numeric Conversion code block from fundamental_types.md

### DIFF
--- a/media/docs/cpp/fundamental_types.md
+++ b/media/docs/cpp/fundamental_types.md
@@ -344,17 +344,6 @@ multiply_add<Array<half_t, kN>> mad_op;
 d = mad_op(a, b, c);   // efficient multiply-add for Array of half-precision elements
 ```
 
-## Numeric Conversion
-
-Operators are define to convert between numeric types in `numeric_conversion.h`. Conversion operators are defined in
-terms of individual numeric elements and on arrays which enable the possibility of efficient hardware
-support on current and future NVIDIA GPUs.
-
-**Example:** Converting between 32-b and 8-b integers.
-```c++
-
-```
-
 ### Copyright
 
 Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.


### PR DESCRIPTION
## Summary

`media/docs/cpp/fundamental_types.md` contained a second `## Numeric Conversion` heading whose fenced code block was empty (`Example: Converting between 32-b and 8-b integers.` followed by an empty `c++` block).

This duplicates the earlier `### Numeric Conversion` subsection (already a complete, populated section with multiple worked examples), so the empty trailing copy adds no information and renders as a broken docs section.

This PR removes the duplicate empty section so the topic only appears once, with content.

Fixes #3064

## Test plan

- [x] Pure docs change, no code touched
- [x] Verified the remaining `### Numeric Conversion` section (around line 198) still contains the full explanation and code examples
- [x] Commit is DCO signed-off