### PR TITLE
fix: handle ComposedLayout slicing with dynamic strides (fixes #3255)

### DIFF
--- a/python/CuTeDSL/cutlass/cute/tensor.py
+++ b/python/CuTeDSL/cutlass/cute/tensor.py
@@ -73,6 +73,7 @@ from .core import (
     select,
     slice_,
     crd2idx,
+    make_composed_layout,
     size,
     leading_dim,
     recast_ptr,
@@ -222,6 +223,31 @@ class _Tensor(Tensor):
             dtype=self.element_type,
         )
 
+    def _composed_slice(
+        self,
+        crd: Coord,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "Tensor":
+        composed = self.layout
+        inner = composed.inner
+        offset = composed.offset
+        outer = composed.outer
+
+        sliced_outer = slice_(outer, crd, loc=loc, ip=ip)
+
+        flat_coord = flatten_to_tuple(crd)
+        offset_coord = tuple(
+            Integer(0) if c is None else c for c in flat_coord
+        )
+        delta = crd2idx(offset_coord, outer, loc=loc, ip=ip)
+        new_offset = offset + delta
+
+        new_composed = make_composed_layout(inner, new_offset, sliced_outer, loc=loc, ip=ip)
+
+        return make_tensor(self.iterator, new_composed, loc=loc, ip=ip)
+
     @dsl_user_op
     def __getitem__(
         self,
@@ -294,6 +320,8 @@ class _Tensor(Tensor):
             val = tensor[0]  # Error: sub-byte scalar dereference not supported
         """
         if has_underscore(crd):
+            if isinstance(self.layout.type, _cute_ir.ComposedLayoutType):
+                return self._composed_slice(crd, loc=loc, ip=ip)
             return slice_(self, crd, loc=loc, ip=ip)
         elif isinstance(self.type, _cute_ir.CoordTensorType):
             res = _cute_ir.get_iter(


### PR DESCRIPTION
When slicing a Tensor whose layout is a ComposedLayout (e.g., Swizzle composed with a dynamic outer Layout), _cute_ir.slice fails because the Swizzle composition requires static stride analysis that cannot be performed with runtime dynamic strides (represented as '?' / unknown values).

The fix intercepts this case in _Tensor.__getitem__ and decomposes the ComposedLayout manually in the Python DSL layer:
1. Extract inner (Swizzle), offset, and outer (Layout) from the ComposedLayout
2. Slice only the outer Layout using slice_ (pure Layout slicing works with dynamic strides)
3. Compute the offset delta via crd2idx(coord_with_none_as_zero, outer)
4. Rebuild the ComposedLayout with the new offset and sliced outer
5. Construct a new Tensor with the original iterator

This avoids passing the composed layout with dynamic strides to the MLIR slice operation, which triggers an MLIR verifier error and segfault.