### PR TITLE
Fix hopper grouped gemm example `elect_sync` api use

### DIFF
--- a/examples/python/CuTeDSL/cute/hopper/kernel/grouped_gemm/grouped_gemm.py
+++ b/examples/python/CuTeDSL/cute/hopper/kernel/grouped_gemm/grouped_gemm.py
@@ -145,7 +145,7 @@ def _tma_load_ab_nvvm_no_mcast(
     desc_a_llvm = desc_a.llvm_ptr
     desc_b_llvm = desc_b.llvm_ptr
     # TMA A: elect one thread and issue the load with predicate.
-    is_elected_a = _nvvm_d.elect_sync(_T.bool(), loc=loc, ip=ip)
+    is_elected_a = _nvvm_d.elect_sync(loc=loc, ip=ip)
     _nvvm_d.CpAsyncBulkTensorGlobalToSharedClusterOp(
         dstMem=smem_a_llvm,
         tmaDescriptor=desc_a_llvm,
@@ -162,7 +162,7 @@ def _tma_load_ab_nvvm_no_mcast(
         ip=ip,
     )
     # TMA B: elect one thread and issue the load with predicate.
-    is_elected_b = _nvvm_d.elect_sync(_T.bool(), loc=loc, ip=ip)
+    is_elected_b = _nvvm_d.elect_sync(loc=loc, ip=ip)
     _nvvm_d.CpAsyncBulkTensorGlobalToSharedClusterOp(
         dstMem=smem_b_llvm,
         tmaDescriptor=desc_b_llvm,


### PR DESCRIPTION
Fix incorrect hopper grouped_gemm.py `nvvm.elect_sync` API use
