### PR TITLE
Add Blackwell GeForce blockscaled GEMM examples

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/blockscaled_gemm_dispatch.py
+++ b/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/blockscaled_gemm_dispatch.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""SM120 block-scaled GEMM dispatch helpers shared by the cooperative and
+pingpong examples in this directory. Both examples are otherwise standalone;
+they only depend on this file (and the rest of the cutlass DSL library) and
+not on each other.
+
+Dispatch table:
+    Same-dtype paths:
+        (FP4, FP4, *, Float8E4M3FN, 16) -> MmaMXF4NVF4Op,  use_mxf8f6f4=False, mma_K=64
+        (FP4, FP4, *, Float8E8M0FNU, 32) -> MmaMXF4Op,    use_mxf8f6f4=False, mma_K=64
+        (FP8, FP8, *, Float8E8M0FNU, 32) -> MmaMXF8Op,    use_mxf8f6f4=True,  mma_K=32
+            (FP8 same-dtype is restricted to a_dtype == b_dtype.)
+    Mixed-precision:
+        (FP4, FP8, *, Float8E8M0FNU, 32) -> MmaMXF8F6F4Op, use_mxf8f6f4=True, mma_K=32
+        (FP8, FP4, *, Float8E8M0FNU, 32) -> MmaMXF8F6F4Op, use_mxf8f6f4=True, mma_K=32
+            (Same-width mixed-FP8 (E4M3 + E5M2) and FP6 mixed pairs are not supported.)
+
+`use_mxf8f6f4` is the third argument to
+`cutlass.utils.blackwell_helpers.get_permutation_mnk` and selects perm_k = 32
+(FP8 / mixed warp-MMA shape (16,8,32)) instead of perm_k = 64 (FP4 shape (16,8,64)).
+"""
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu.warp.mma import MXF8F6F4_SUPPORTED_PAIRS
+
+
+# Number of bits to shift the FP4 byte left by before mma.sync.kind::mxf8f6f4.
+# ldsm.b4x16_p64 places the FP4 nibble in the LOW half of the 8-bit register
+# byte; mma.sync.kind::mxf8f6f4 reads the FP4 from the MIDDLE of the byte. The
+# fixed `<< 2` shift moves it into position. See the C++ reference
+# implementation `cute::fp4_shift_A/B` in
+# cutlass/include/cute/atom/mma_traits_sm120.hpp.
+FP4_SHIFT_BITS = 2
+
+_FP8_DTYPES = (cutlass.Float8E4M3FN, cutlass.Float8E5M2)
+
+
+def make_ldmatrix_atom(operand_dtype, transpose, num_matrices=4, mixed_mode=False):
+    """Build a warp-level ldmatrix copy atom for the SM120 block-scaled GEMM
+    A/B SMEM->RMEM path.
+    """
+    if mixed_mode and operand_dtype.width == 4:
+        assert not transpose, "LdMatrix8x16x8bOp does not support transpose"
+        return cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x16x8bOp(
+                transpose=False,
+                num_matrices=num_matrices,
+                unpack_bits=4,
+            ),
+            cutlass.Int8,
+        )
+    atom_element_type = operand_dtype
+    if mixed_mode and operand_dtype.width < 8:
+        atom_element_type = cutlass.Int8
+    return cute.make_copy_atom(
+        cute.nvgpu.warp.LdMatrix8x8x16bOp(
+            transpose=transpose,
+            num_matrices=num_matrices,
+        ),
+        atom_element_type,
+    )
+
+
+def make_sm120_blockscaled_mma_op(a_dtype, b_dtype, acc_dtype, sf_dtype, sf_vec_size):
+    """Dispatch the SM120 block-scaled MMA op for the given operand / scale
+    factor combination.
+
+    Returns
+    -------
+    Tuple[MmaOp, bool]
+        (mma_op, use_mxf8f6f4) where use_mxf8f6f4 is True for FP8 / mixed
+        paths (atom shape (16,8,32)) and False for FP4 same-dtype paths
+        (atom shape (16,8,64)). `use_mxf8f6f4` is consumed by
+        `cutlass.utils.blackwell_helpers.get_permutation_mnk`.
+
+    Raises
+    ------
+    ValueError
+        On any unsupported combination, with a diagnostic that names the
+        offending combination and the supported alternatives.
+    """
+    # Same-dtype paths use the FP4 / FP8 same-dtype atoms.
+    if a_dtype == b_dtype:
+        if a_dtype == cutlass.Float4E2M1FN:
+            if sf_vec_size == 16:
+                if sf_dtype != cutlass.Float8E4M3FN:
+                    raise ValueError(
+                        f"Float4E2M1FN + sf_vec_size=16 requires sf_dtype=Float8E4M3FN, "
+                        f"got sf_dtype={sf_dtype}"
+                    )
+                return (
+                    cute.nvgpu.warp.MmaMXF4NVF4Op(a_dtype, acc_dtype, sf_dtype),
+                    False,
+                )
+            if sf_vec_size == 32:
+                if sf_dtype != cutlass.Float8E8M0FNU:
+                    raise ValueError(
+                        f"Float4E2M1FN + sf_vec_size=32 requires sf_dtype=Float8E8M0FNU, "
+                        f"got sf_dtype={sf_dtype}"
+                    )
+                return (
+                    cute.nvgpu.warp.MmaMXF4Op(a_dtype, acc_dtype, sf_dtype),
+                    False,
+                )
+            raise ValueError(
+                f"Float4E2M1FN requires sf_vec_size in (16, 32), got {sf_vec_size}"
+            )
+        if a_dtype in _FP8_DTYPES:
+            if sf_vec_size != 32:
+                raise ValueError(
+                    f"FP8 ab_dtype ({a_dtype}) requires sf_vec_size=32, "
+                    f"got {sf_vec_size}"
+                )
+            if sf_dtype != cutlass.Float8E8M0FNU:
+                raise ValueError(
+                    f"FP8 ab_dtype + sf_vec_size=32 requires sf_dtype=Float8E8M0FNU, "
+                    f"got sf_dtype={sf_dtype}"
+                )
+            return (
+                cute.nvgpu.warp.MmaMXF8Op(a_dtype, acc_dtype, sf_dtype),
+                True,
+            )
+        raise ValueError(
+            f"Unsupported same-dtype ab_dtype={a_dtype} for SM120 block-scaled GEMM. "
+            f"Supported same-dtype: Float4E2M1FN, Float8E4M3FN, Float8E5M2."
+        )
+    # Mixed-precision FP4 x FP8 paths.
+    is_a_fp4_b_fp8 = a_dtype == cutlass.Float4E2M1FN and b_dtype in _FP8_DTYPES
+    is_a_fp8_b_fp4 = a_dtype in _FP8_DTYPES and b_dtype == cutlass.Float4E2M1FN
+    if is_a_fp4_b_fp8 or is_a_fp8_b_fp4:
+        if sf_vec_size != 32:
+            raise ValueError(
+                f"FP4 x FP8 mixed-precision requires sf_vec_size=32, got {sf_vec_size}"
+            )
+        if sf_dtype != cutlass.Float8E8M0FNU:
+            raise ValueError(
+                f"FP4 x FP8 mixed-precision requires sf_dtype=Float8E8M0FNU, "
+                f"got sf_dtype={sf_dtype}"
+            )
+        return (
+            cute.nvgpu.warp.MmaMXF8F6F4Op(a_dtype, b_dtype, acc_dtype, sf_dtype),
+            True,
+        )
+    # Reject same-width mixed-FP8 (E4M3 + E5M2) and FP6 with named diagnostics.
+    if a_dtype in _FP8_DTYPES and b_dtype in _FP8_DTYPES:
+        raise ValueError(
+            f"same-width mixed-FP8 (a_dtype={a_dtype}, b_dtype={b_dtype}) is not supported. "
+            f"Supported FP4 x FP8 mixed pairs: (Float4E2M1FN, Float8E4M3FN), "
+            f"(Float4E2M1FN, Float8E5M2), (Float8E4M3FN, Float4E2M1FN), "
+            f"(Float8E5M2, Float4E2M1FN). Same-dtype FP8 uses MmaMXF8Op."
+        )
+    raise ValueError(
+        f"Unsupported (a_dtype={a_dtype}, b_dtype={b_dtype}, sf_dtype={sf_dtype}, "
+        f"sf_vec_size={sf_vec_size}) for SM120 block-scaled GEMM. FP6 mixed pairs "
+        f"are not supported; supported mixed pairs are FP4 x FP8 only."
+    )
+
+
+def validate_blockscaled_args(args, fp4_allowed_tiles, fp8_allowed_tiles):
+    """Post-argparse validation of (a_dtype, b_dtype, sf_dtype, sf_vec_size, tile_shape_mnk).
+
+    Same-dtype paths use the FP4 / FP8 same-dtype atoms. Mixed-precision FP4 x FP8
+    is permitted only for the four supported pairs. Same-width mixed-FP8 and FP6
+    are explicitly rejected with named diagnostics.
+
+    Tile-K constraints come from the BlockScaled SF SMEM layout
+    (`sm120_make_smem_layout_sfa`), which requires
+    ``tile_K >= sf_vec_size * blk_sf == sf_vec_size * 4``:
+      * sf_vec_size=16 (NVFP4): tile_K must be a multiple of 64
+      * sf_vec_size=32 (MXFP4 / MXFP8 / mixed): tile_K must be a multiple of 128
+    A K=64 SF block cannot be filled at sf_vec_size=32 (only 2 SFs along K
+    fit in the K=128-required basic chunk), so tile_K=64 is rejected for
+    sf_vec_size=32 even though the FP4 same-dtype path otherwise allows it.
+    """
+    tile = tuple(args.tile_shape_mnk)
+    a_dtype = args.a_dtype
+    b_dtype = args.b_dtype
+    # Generic sf_vec_size sanity check applies to every dtype branch below.
+    if args.sf_vec_size not in (16, 32):
+        raise ValueError(
+            f"--sf_vec_size must be 16 or 32, got {args.sf_vec_size}"
+        )
+    # Mixed-precision A/B: only the four FP4 x FP8 pairs are allowed.
+    if a_dtype != b_dtype:
+        if (a_dtype, b_dtype) not in MXF8F6F4_SUPPORTED_PAIRS:
+            if a_dtype in _FP8_DTYPES and b_dtype in _FP8_DTYPES:
+                raise ValueError(
+                    f"same-width mixed-FP8 (--a_dtype {a_dtype} --b_dtype {b_dtype}) "
+                    f"is not supported. Supported mixed pairs: FP4 x FP8 only."
+                )
+            raise ValueError(
+                f"unsupported mixed (--a_dtype {a_dtype} --b_dtype {b_dtype}). "
+                f"Supported mixed pairs are FP4 x FP8 only: "
+                f"{sorted(repr(p) for p in MXF8F6F4_SUPPORTED_PAIRS)}. "
+                f"FP6 mixed pairs are not supported."
+            )
+        if args.sf_vec_size != 32:
+            raise ValueError(
+                f"FP4 x FP8 mixed-precision requires --sf_vec_size 32, "
+                f"got {args.sf_vec_size}"
+            )
+        if args.sf_dtype != cutlass.Float8E8M0FNU:
+            raise ValueError(
+                f"FP4 x FP8 mixed-precision requires --sf_dtype Float8E8M0FNU, "
+                f"got --sf_dtype {args.sf_dtype}"
+            )
+        if tile not in fp8_allowed_tiles:
+            raise ValueError(
+                f"tile_shape {tile} is not supported for FP4 x FP8 mixed-precision. "
+                f"Allowed mixed tile shapes: {sorted(fp8_allowed_tiles)}."
+            )
+        return
+    # Same-dtype paths.
+    if a_dtype in _FP8_DTYPES:
+        if args.sf_vec_size != 32:
+            raise ValueError(
+                f"FP8 a_dtype ({a_dtype}) requires --sf_vec_size 32, "
+                f"got {args.sf_vec_size}"
+            )
+        if args.sf_dtype != cutlass.Float8E8M0FNU:
+            raise ValueError(
+                f"FP8 a_dtype + sf_vec_size=32 requires --sf_dtype Float8E8M0FNU, "
+                f"got --sf_dtype {args.sf_dtype}"
+            )
+        if tile not in fp8_allowed_tiles:
+            raise ValueError(
+                f"tile_shape {tile} is not supported for MXFP8. "
+                f"Allowed FP8 tile shapes: {sorted(fp8_allowed_tiles)}."
+            )
+    elif a_dtype == cutlass.Float4E2M1FN:
+        if args.sf_vec_size == 16 and args.sf_dtype != cutlass.Float8E4M3FN:
+            raise ValueError(
+                f"FP4 + --sf_vec_size 16 requires --sf_dtype Float8E4M3FN, "
+                f"got {args.sf_dtype}"
+            )
+        if args.sf_vec_size == 32 and args.sf_dtype != cutlass.Float8E8M0FNU:
+            raise ValueError(
+                f"FP4 + --sf_vec_size 32 requires --sf_dtype Float8E8M0FNU, "
+                f"got {args.sf_dtype}"
+            )
+        if tile not in fp4_allowed_tiles:
+            raise ValueError(
+                f"tile_shape {tile} is not supported for FP4 path. "
+                f"Allowed FP4 tile shapes: {sorted(fp4_allowed_tiles)}."
+            )
+        if args.sf_vec_size == 32 and tile[2] % 128 != 0:
+            raise ValueError(
+                f"FP4 + sf_vec_size=32 (MXFP4) requires tile_K to be a "
+                f"multiple of 128, "
+                f"got tile_K={tile[2]}."
+            )
+    else:
+        raise ValueError(
+            f"--a_dtype must be Float4E2M1FN, Float8E4M3FN, or Float8E5M2; "
+            f"got {a_dtype}"
+        )

--- a/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_cooperative.py
+++ b/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_cooperative.py
@@ -1,0 +1,2037 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+from typing import Tuple, Type, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+import cutlass.cute.testing as testing
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.cute.runtime import from_dlpack
+import cutlass.utils.hopper_helpers as sm90_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+import cutlass.utils.blackwell_helpers as sm120_utils
+
+try:
+    from blackwell_geforce.kernel.blockscaled_gemm.blockscaled_gemm_dispatch import (
+        FP4_SHIFT_BITS,
+        make_ldmatrix_atom,
+        make_sm120_blockscaled_mma_op,
+        validate_blockscaled_args,
+    )
+except ImportError:
+    from blockscaled_gemm_dispatch import (
+        FP4_SHIFT_BITS,
+        make_ldmatrix_atom,
+        make_sm120_blockscaled_mma_op,
+        validate_blockscaled_args,
+    )
+
+"""
+A high-performance batched dense blockscaled GEMM (C = A*SF_A * B*SF_B) example for the NVIDIA Blackwell Geforce architecture using CUTE DSL.
+- Matrix A is MxKxL, L is batch dimension, A can only be row-major("K")
+- Matrix B is NxKxL, L is batch dimension, B can only be column-major("K")
+- Matrix C is MxNxL, L is batch dimension, C can only be row-major("N")
+- Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk, which has M×ceil_div(K, sf_vec_size)×L elements respectively
+- Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk, which has N×ceil_div(K, sf_vec_size)×L elements respectively
+- Source formats for matrices A and B: The only supported source format in this example is E2M1.
+- Source formats for matrices SF_A and SF_B are controlled separately. With sf_vec_size=32, the only supported source format is E8. With sf_vec_size=16, the supported source formats are E8 and E4M3.
+
+This GEMM kernel supports the following features:
+    - Utilizes Tensor Memory Access (TMA) for efficient memory operations
+    - Utilizes warp-level block-scaled MMA for matrix multiply-accumulate (MMA) operations
+    - Supports persistent tile scheduling to better overlap memory load/store with MMA between tiles
+    - Supports warp specialization to avoid explicit pipelining between mainloop load and MMA
+    - Uses a cooperative schedule: both warp groups work together to process a single output tile.
+      The two warp groups collaboratively execute the MMA mainloop, each computing a portion of
+      the tile, and then jointly perform the epilogue. This increases computational throughput
+      per tile by leveraging both warp groups simultaneously.
+
+This GEMM works as follows:
+1. DMA warp group:
+    - Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+    - Load scale factor A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+2. MMA warp groups (both warp groups cooperate on the same tile):
+    - Load A/B from shared memory (SMEM) to registers (RMEM) using ldmatrix instruction.
+    - Load scale factor A/B from shared memory (SMEM) to registers (RMEM) using universal copy.
+    - Perform matrix multiply-accumulate (MMA) operations using warp-level block-scaled MMA instruction.
+    - Store C matrix from registers (RMEM) to shared memory (SMEM), then to global memory (GMEM) with TMA operations.
+    Note: Both MMA warp groups jointly handle MMA and epilogue for the same tile.
+
+Warp-level block-scaled MMA instructions operate as follows:
+- Set matrix scale factor A/B from registers
+- Read matrix A/B from registers
+- Perform MMA operation and store the result in Accumulator(register)
+
+To run this example:
+
+.. code-block:: bash
+
+    python examples/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_cooperative.py      \
+      --mnkl 1024,1024,1024,1 --tile_shape_mnk 128,128,128                      \
+      --a_dtype Float4E2M1FN --b_dtype Float4E2M1FN                             \
+      --c_dtype Float16 --acc_dtype Float32                                     \
+      --sf_dtype Float8E4M3FN --sf_vec_size 16
+
+The above example command compute batched gemm with M=1024, N=1024, K=1024,
+batch_count=1. The tile shape is 128x128x128 and the cluster shape is (1,1).
+The input, mma accumulator and output data type are set as fp4, fp32
+and fp16, respectively.
+
+To collect performance with NCU profiler:
+
+.. code-block:: bash
+
+    ncu python examples/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_cooperative.py  \
+      --mnkl 1024,1024,1024,1 --tile_shape_mnk 128,128,128                      \
+      --a_dtype Float4E2M1FN --b_dtype Float4E2M1FN                             \
+      --c_dtype Float16 --acc_dtype Float32                                     \
+      --sf_dtype Float8E4M3FN --sf_vec_size 16
+
+Constraints:
+* Supported input data types: Float4E2M1FN
+* Only Float32 accumulation is supported in FP4 mma
+* CTA tile shape M/N/K:
+ - tile_shape_m should be divisible by 128
+ - tile_shape_n should be divisible by 128
+ - tile_shape_k should be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
+* Cluster shape M/N must be [1, 1] for Blackwell Gefore
+"""
+
+
+# /////////////////////////////////////////////////////////////////////////////
+#  Helpers to parse args
+# /////////////////////////////////////////////////////////////////////////////
+def parse_comma_separated_ints(s: str):
+    try:
+        return tuple([int(x.strip()) for x in s.split(",")])
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            "Invalid format. Expected comma-separated integers."
+        )
+
+
+# /////////////////////////////////////////////////////////////////////////////
+#  Host setup and device kernel launch
+# /////////////////////////////////////////////////////////////////////////////
+
+
+class Sm120BlockScaledGemmKernel:
+    def __init__(
+        self,
+        acc_dtype,
+        sf_vec_size,
+        tile_shape_mnk,
+        epi_tile,
+    ):
+        self.acc_dtype = acc_dtype
+        self.sf_vec_size = sf_vec_size
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.tile_shape_mnk = tuple(tile_shape_mnk)
+        self.epi_tile = tuple(epi_tile)
+        self.tiled_mma = None
+
+        self.occupancy = 1
+        self.num_mma_warps = 8
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (
+            self.num_mma_warps + 1  # 1 warp for DMA
+        ) * self.num_threads_per_warp
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+
+        self.ab_stage = None
+        self.epi_stage = None
+
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+
+        self.buffer_align_bytes = 1024
+
+        self.mma_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+
+    def _setup_attributes(self):
+        mma_op, use_mxf8f6f4 = make_sm120_blockscaled_mma_op(
+            self.a_dtype,
+            self.b_dtype,
+            self.acc_dtype,
+            self.sf_dtype,
+            self.sf_vec_size,
+        )
+        self.mixed_mode = self.a_dtype != self.b_dtype
+        # a_fp4_in_mixed / b_fp4_in_mixed: this side carries an FP4 operand in the
+        # mixed FP4 x FP8 mode, so SMEM/TMA see Int8 storage and the mma.sync
+        # consumer needs the LDSM b4x16_p64 unpack + register `<< FP4_SHIFT_BITS`.
+        a_fp4_in_mixed = self.mixed_mode and self.a_dtype.width < 8
+        b_fp4_in_mixed = self.mixed_mode and self.b_dtype.width < 8
+        self.smem_alloc_a_dtype = cutlass.Int8 if a_fp4_in_mixed else self.a_dtype
+        self.smem_alloc_b_dtype = cutlass.Int8 if b_fp4_in_mixed else self.b_dtype
+        # `internal_type` for `_make_tma_atoms_and_tensors` — None when the dtype
+        # already matches (TMA sees the native dtype), Int8 when we recast for FP4.
+        self.tma_internal_a_dtype = cutlass.Int8 if a_fp4_in_mixed else None
+        self.tma_internal_b_dtype = cutlass.Int8 if b_fp4_in_mixed else None
+        atom_shape = (4, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
+        permutation_mnk = sm120_utils.get_permutation_mnk(
+            self.tile_shape_mnk, self.sf_vec_size, use_mxf8f6f4
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+
+        # Compute the smem size of SFA/SFB
+        sfa_smem_layout_per_stage = blockscaled_utils.sm120_make_smem_layout_sfa(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        sfb_smem_layout_per_stage = blockscaled_utils.sm120_make_smem_layout_sfb(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        # Compute stage before compute smem layout
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.smem_alloc_a_dtype,
+            self.smem_alloc_b_dtype,
+            self.sf_dtype,
+            sfa_smem_layout_per_stage,
+            sfb_smem_layout_per_stage,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        assert self.epi_stage > 0, (
+            "epi_stage <= 0, no enough shared memory. This case will be skipped."
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.smem_alloc_a_dtype,
+            self.a_layout,
+            self.smem_alloc_b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+            self.sf_vec_size,
+            self.tiled_mma,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        c: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a: Input tensor A
+        :type a: cute.Tensor
+        :param b: Input tensor B
+        :type b: cute.Tensor
+        :param c: Output tensor C
+        :type c: cute.Tensor
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        """
+
+        # setup static attributes before smem/grid/tma computation
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.sf_dtype = sfa.element_type
+
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        self.sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa.iterator, self.sfa_layout)
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        self.sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b.shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb.iterator, self.sfb_layout)
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            1,
+            internal_type=self.tma_internal_a_dtype,
+        )
+
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+            internal_type=self.tma_internal_b_dtype,
+        )
+
+        tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
+            sfa_tensor,
+            self.sfa_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            1,
+            internal_type=cutlass.Int16,
+        )
+
+        tma_atom_sfb, tma_tensor_sfb = self._make_tma_atoms_and_tensors(
+            sfb_tensor,
+            self.sfb_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+            internal_type=cutlass.Int16,
+        )
+
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        tile_sched_params, grid = self._compute_grid(
+            c,
+            self.tile_shape_mnk,
+            max_active_clusters,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.smem_alloc_a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.smem_alloc_b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype, cute.cosize(self.epi_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+        )
+        return
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+    ):
+        """
+        GPU device kernel performing the batched GEMM computation.
+
+        :param tma_atom_a: TMA copy atom for A tensor
+        :type tma_atom_a: cute.CopyAtom
+        :param mA_mkl: Input tensor A
+        :type mA_mkl: cute.Tensor
+        :param tma_atom_b: TMA copy atom for B tensor
+        :type tma_atom_b: cute.CopyAtom
+        :param mB_nkl: Input tensor B
+        :type mB_nkl: cute.Tensor
+        :param tma_atom_c: TMA copy atom for C tensor
+        :type tma_atom_c: cute.CopyAtom
+        :param mC_mnl: Output tensor C
+        :type mC_mnl: cute.Tensor
+        :param tiled_mma: Tiled MMA object
+        :type tiled_mma: cute.TiledMma
+        :param cta_layout_mnk: CTA layout
+        :type cta_layout_mnk: cute.Layout
+        :param a_smem_layout_staged: Shared memory layout for A
+        :type a_smem_layout_staged: cute.ComposedLayout
+        :param b_smem_layout_staged: Shared memory layout for B
+        :type b_smem_layout_staged: cute.ComposedLayout
+        :param epi_smem_layout_staged: Shared memory layout for epilogue
+        :type epi_smem_layout_staged: cute.ComposedLayout
+        """
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Get cta/warp/thread idx
+        # ///////////////////////////////////////////////////////////////////////////////
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        # bidx, bidy, bidz = cute.arch.block_idx()
+        # bdimx, bdimy, bdimz = cute.arch.grid_dim()
+
+        # /////////////////////////////////////////////////////////////////////////////
+        #  Prefetch Tma desc
+        # /////////////////////////////////////////////////////////////////////////////
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = (
+            cute.size_in_bytes(self.a_dtype, a_smem_layout)
+            + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        )
+
+        # /////////////////////////////////////////////////////////////////////////////
+        #  Alloc and init AB full/empty + ACC full mbar (pipeline)
+        # /////////////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # mbar arrays
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+
+        # Threads/warps participating in this pipeline
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps
+        )
+
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=mainloop_pipeline_array_ptr,
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+
+        #  Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Generate smem tensor A/B
+        # ///////////////////////////////////////////////////////////////////////////////
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner
+        )
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Local_tile partition global tensors
+        # ///////////////////////////////////////////////////////////////////////////////
+        # (bM, bK, loopM, loopK, loopL)
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        # (bN, bK, loopN, loopK, loopL)
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        # (tM, tK, loopM, loopK, loopL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        # (tN, tK, loopN, loopK, loopL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        # (bM, bN, loopM, loopN, loopL)
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        # //////////////////////////////////////////////////////////////////////////////
+        #  Partition global tensor for TiledMMA_A/B/C
+        # //////////////////////////////////////////////////////////////////////////////
+        thr_mma = tiled_mma.get_slice(tidx)
+
+        # //////////////////////////////////////////////////////////////////////////////
+        #  Partition shared tensor for TMA load A/B
+        # //////////////////////////////////////////////////////////////////////////////
+        #  TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA_mkl, 0, 2),
+        )
+
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_nkl, 0, 2),
+        )
+
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_atom_sfa,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sSFA, 0, 2),
+            cute.group_modes(gSFA_mkl, 0, 2),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        tBsSFB, tBgSFB = cpasync.tma_partition(
+            tma_atom_sfb,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_nkl, 0, 2),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        #  Make frangments
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCrSFA = sm120_utils.partition_fragment_SFA(sSFA[None, None, 0], thr_mma, tidx)
+        tCrSFB = sm120_utils.partition_fragment_SFB(sSFB[None, None, 0], thr_mma, tidx)
+        # Keep residual K modes nested to match the C++ SM120 block-scaled mainloop.
+        tCrSFA = cute.group_modes(tCrSFA, 2, cute.rank(tCrSFA))
+        tCrSFB = cute.group_modes(tCrSFB, 2, cute.rank(tCrSFB))
+
+        tCgC = thr_mma.partition_C(gC_mnl)
+        acc_shape = tCgC.shape[:3]
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        # cluster wait for barrier init
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.sync_threads()
+
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        # Create the tile scheduler
+        tile_sched = utils.StaticPersistentTileScheduler.create(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        # Create the pipeline states for producer and consumer
+        mainloop_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        mainloop_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        # MMA warp group
+        if warp_idx < self.num_mma_warps:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Copy Atom A/B retiling for TMA load A/B
+            # ///////////////////////////////////////////////////////////////////////////////
+            atom_copy_ldmatrix_A = make_ldmatrix_atom(
+                self.a_dtype,
+                transpose=self.a_layout.is_m_major_a(),
+                num_matrices=4,
+                mixed_mode=self.mixed_mode,
+            )
+            atom_copy_ldmatrix_B = make_ldmatrix_atom(
+                self.b_dtype,
+                transpose=self.b_layout.is_n_major_b(),
+                num_matrices=4,
+                mixed_mode=self.mixed_mode,
+            )
+            smem_tiled_copy_A = cute.make_tiled_copy_A(atom_copy_ldmatrix_A, tiled_mma)
+            smem_tiled_copy_B = cute.make_tiled_copy_B(atom_copy_ldmatrix_B, tiled_mma)
+
+            atom_copy_ldmatrix_SF = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.sf_dtype,
+            )
+            smem_tiled_copy_SFA = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                sm120_utils.get_layoutSFA_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[0]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            smem_tiled_copy_SFB = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                sm120_utils.get_layoutSFB_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[1]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+
+            thr_copy_ldmatrix_A = smem_tiled_copy_A.get_slice(tidx)
+            thr_copy_ldmatrix_B = smem_tiled_copy_B.get_slice(tidx)
+            tCsA_copy_view = thr_copy_ldmatrix_A.partition_S(sA)
+            tCrA_copy_view = thr_copy_ldmatrix_A.retile(tCrA)
+            tCsB_copy_view = thr_copy_ldmatrix_B.partition_S(sB)
+            tCrB_copy_view = thr_copy_ldmatrix_B.retile(tCrB)
+
+            thr_copy_ldmatrix_SFA = smem_tiled_copy_SFA.get_slice(tidx)
+            thr_copy_ldmatrix_SFB = smem_tiled_copy_SFB.get_slice(tidx)
+            tCsSFA_copy_view = thr_copy_ldmatrix_SFA.partition_S(sSFA)
+            tCrSFA_copy_view = thr_copy_ldmatrix_SFA.retile(tCrSFA)
+            tCsSFB_copy_view = thr_copy_ldmatrix_SFB.partition_S(sSFB)
+            tCrSFB_copy_view = thr_copy_ldmatrix_SFB.retile(tCrSFB)
+
+            epi_buffer = cutlass.Int32(0)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
+                # Clear the accumulator
+                accumulators.fill(0.0)
+
+                # /////////////////////////////////////////////////////////////////////////////
+                #  Pipelined MAINLOOP
+                # /////////////////////////////////////////////////////////////////////////////
+
+                mainloop_consumer_state.reset_count()
+
+                peek_ab_full_status = cutlass.Boolean(1)
+                if mainloop_consumer_state.count < k_tile_cnt:
+                    peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                        mainloop_consumer_state
+                    )
+
+                #  Wait for TMA copies to complete
+                mainloop_pipeline.consumer_wait(
+                    mainloop_consumer_state, peek_ab_full_status
+                )
+                # tCsA_p: (MMA, (4, MMA_M / 4), MMA_K), tCsA_p: (MMA, (4, MMA_N / 4), MMA_K)
+                tCsA_p = tCsA_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsB_p = tCsB_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsSFA_p = tCsSFA_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                tCsSFB_p = tCsSFB_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                cute.copy(
+                    smem_tiled_copy_A,
+                    tCsA_p[None, None, 0],
+                    tCrA_copy_view[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_B,
+                    tCsB_p[None, None, 0],
+                    tCrB_copy_view[None, None, 0],
+                )
+
+                tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_copy_view)
+                tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_copy_view)
+
+                cute.copy(
+                    smem_tiled_copy_SFA,
+                    tCsSFA_p_filtered[None, None, 0],
+                    tCrSFA_copy_view_filtered[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_SFB,
+                    tCsSFB_p_filtered[None, None, 0],
+                    tCrSFB_copy_view_filtered[None, None, 0],
+                )
+
+                for k_tile in range(0, k_tile_cnt - 1, 1, unroll=1):
+                    # unroll the loop
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+
+                        if k_block_idx == num_k_blocks - 1:
+                            mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                            mainloop_consumer_state.advance()
+
+                            peek_ab_full_status = cutlass.Boolean(1)
+                            peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                                mainloop_consumer_state
+                            )
+
+                            tCsA_p = tCsA_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsB_p = tCsB_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFA_p = tCsSFA_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFB_p = tCsSFB_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            mainloop_pipeline.consumer_wait(
+                                mainloop_consumer_state, peek_ab_full_status
+                            )
+
+                        # Mixed FP4 x FP8 register-side bit shift before mma.sync
+                        # to move the FP4 nibble (in low half of each byte after
+                        # b4x16_p64 ldmatrix) into the middle as mxf8f6f4 expects.
+                        if cutlass.const_expr(
+                            self.mixed_mode and self.a_dtype.width < 8
+                        ):
+                            a_view = cute.recast_tensor(
+                                tCrA[None, None, k_block_idx], cutlass.Int8
+                            )
+                            for _i in cutlass.range_constexpr(cute.size(a_view)):
+                                a_view[_i] = cutlass.Int8(
+                                    a_view[_i] << FP4_SHIFT_BITS
+                                )
+                        if cutlass.const_expr(
+                            self.mixed_mode and self.b_dtype.width < 8
+                        ):
+                            b_view = cute.recast_tensor(
+                                tCrB[None, None, k_block_idx], cutlass.Int8
+                            )
+                            for _i in cutlass.range_constexpr(cute.size(b_view)):
+                                b_view[_i] = cutlass.Int8(
+                                    b_view[_i] << FP4_SHIFT_BITS
+                                )
+                        cute.gemm(
+                            tiled_mma,
+                            accumulators,
+                            [
+                                tCrA[None, None, k_block_idx],
+                                tCrSFA[None, None, k_block_idx],
+                            ],
+                            [
+                                tCrB[None, None, k_block_idx],
+                                tCrSFB[None, None, k_block_idx],
+                            ],
+                            accumulators,
+                        )
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+
+                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_copy_view)
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_copy_view)
+                        cute.copy(
+                            smem_tiled_copy_SFA,
+                            tCsSFA_p_filtered[None, None, k_block_next],
+                            tCrSFA_copy_view_filtered[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFB,
+                            tCsSFB_p_filtered[None, None, k_block_next],
+                            tCrSFB_copy_view_filtered[None, None, k_block_next],
+                        )
+
+                        # end of for loop
+                # end of for loop
+                # Hoist out last k_tile
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_block_next = (
+                        0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    )
+
+                    if k_block_idx == num_k_blocks - 1:
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                        mainloop_consumer_state.advance()
+
+                    if k_block_next > 0:
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_copy_view)
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_copy_view)
+                        cute.copy(
+                            smem_tiled_copy_SFA,
+                            tCsSFA_p_filtered[None, None, k_block_next],
+                            tCrSFA_copy_view_filtered[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFB,
+                            tCsSFB_p_filtered[None, None, k_block_next],
+                            tCrSFB_copy_view_filtered[None, None, k_block_next],
+                        )
+                    # Mixed FP4 x FP8 register-side bit shift before mma.sync (hoisted tail).
+                    if cutlass.const_expr(
+                        self.mixed_mode and self.a_dtype.width < 8
+                    ):
+                        a_view_h = cute.recast_tensor(
+                            tCrA[None, None, k_block_idx], cutlass.Int8
+                        )
+                        for _i in cutlass.range_constexpr(cute.size(a_view_h)):
+                            a_view_h[_i] = cutlass.Int8(
+                                a_view_h[_i] << FP4_SHIFT_BITS
+                            )
+                    if cutlass.const_expr(
+                        self.mixed_mode and self.b_dtype.width < 8
+                    ):
+                        b_view_h = cute.recast_tensor(
+                            tCrB[None, None, k_block_idx], cutlass.Int8
+                        )
+                        for _i in cutlass.range_constexpr(cute.size(b_view_h)):
+                            b_view_h[_i] = cutlass.Int8(
+                                b_view_h[_i] << FP4_SHIFT_BITS
+                            )
+                    cute.gemm(
+                        tiled_mma,
+                        accumulators,
+                        [
+                            tCrA[None, None, k_block_idx],
+                            tCrSFA[None, None, k_block_idx],
+                        ],
+                        [
+                            tCrB[None, None, k_block_idx],
+                            tCrSFB[None, None, k_block_idx],
+                        ],
+                        accumulators,
+                    )
+
+                # /////////////////////////////////////////////////////////////////////////////
+                #  EPILOG
+                # /////////////////////////////////////////////////////////////////////////////
+
+                copy_atom_r2s = sm120_utils.sm120_get_smem_store_op(
+                    self.c_layout,
+                    elem_ty_d=self.c_dtype,
+                    elem_ty_acc=self.acc_dtype,
+                )
+
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(
+                        self.c_layout.is_m_major_c(),
+                        2,
+                    ),
+                    self.c_dtype,
+                )
+
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s,
+                    tiled_copy_C_Atom,
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                # (R2S, R2S_M, R2S_N, PIPE_D)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                # (R2S, R2S_M, R2S_N)
+                tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+                # Allocate D registers.
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+                _size_tRS_rD = cute.size(tRS_rD)
+
+                sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+                tcgc_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+
+                bSG_sD, bSG_gD = cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    sepi_for_tma_partition,
+                    tcgc_for_tma_partition,
+                )
+
+                # Initialize tma store pipeline
+                tma_store_producer_group = pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    self.num_mma_warps * self.num_threads_per_warp,
+                )
+                tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=self.epi_stage,
+                    producer_group=tma_store_producer_group,
+                )
+
+                epi_rest_m = bSG_gD.shape[1][0]
+                epi_rest_n = bSG_gD.shape[1][1]
+                epi_tile_m = self.epi_tile[0]
+                epi_tile_n = self.epi_tile[1]
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
+
+                for epi_m in cutlass.range_constexpr(epi_rest_m):
+                    for epi_n in cutlass.range_constexpr(epi_rest_n):
+                        MmaMPerEpiM = epi_tile_m // mma_tile_m
+                        MmaNPerEpiN = epi_tile_n // mma_tile_n
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
+                                mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                tRS_rAcc_slice = tRS_rAcc[(None, mma_m, mma_n)]
+                                for elem_idx in cutlass.range_constexpr(
+                                    cute.size(tRS_rD_slice)
+                                ):
+                                    tRS_rD_slice[elem_idx] = tRS_rAcc_slice[elem_idx]
+
+                        # Type conversion
+                        tRS_rD_out = cute.make_rmem_tensor(
+                            tRS_rD_layout.shape, self.c_dtype
+                        )
+                        acc_vec = tRS_rD.load()
+                        tRS_rD_out.store(acc_vec.to(self.c_dtype))
+
+                        # Register to shared memory
+                        epi_buffer = epi_buffer + 1
+                        epi_buffer = epi_buffer % cute.size(
+                            tRS_sD, mode=[3]
+                        )
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, epi_buffer)],
+                        )
+                        cute.arch.fence_proxy(
+                            "async.shared",
+                            space="cta",
+                        )
+                        # barrier for sync
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        # Get the global memory coordinate for the current epi tile.
+                        gmem_coord = (epi_m, epi_n)
+                        # Copy from shared memory to global memory
+                        if warp_idx == 0:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sD[(None, epi_buffer)],
+                                bSG_gD[(None, gmem_coord)],
+                            )
+                            tma_store_pipeline.producer_commit()
+                            tma_store_pipeline.producer_acquire()
+
+                # Advance to the next work tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                # End of for k_tile loop
+            # End of while loop
+        # End of MMA warp group
+        # Start of DMA warp group
+        elif warp_idx == self.tma_load_warp_id:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
+                tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+                tAgSFA_mkl = tAgSFA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
+                tBgSFB_nkl = tBgSFB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+
+                mainloop_producer_state.reset_count()
+
+                for k_tile in range(0, k_tile_cnt, 1, unroll=1):
+                    # /////////////////////////////////////////////////////////////////////////////
+                    #  Wait for A/B buffers to be empty before loading into them
+                    #  Also sets the transaction barrier for the A/B buffers
+                    # /////////////////////////////////////////////////////////////////////////////
+                    mainloop_pipeline.producer_acquire(mainloop_producer_state)
+
+                    # /////////////////////////////////////////////////////////////////////////////
+                    #  Slice to global/shared memref to current k_tile
+                    # /////////////////////////////////////////////////////////////////////////////
+                    tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                    tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+
+                    tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                    tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                    tAgSFA_k = tAgSFA_mkl[(None, mainloop_producer_state.count)]
+                    tAsSFA_pipe = tAsSFA[(None, mainloop_producer_state.index)]
+
+                    tBgSFB_k = tBgSFB_nkl[(None, mainloop_producer_state.count)]
+                    tBsSFB_pipe = tBsSFB[(None, mainloop_producer_state.index)]
+
+                    # /////////////////////////////////////////////////////////////////////////////
+                    #  TMA load A/B
+                    # /////////////////////////////////////////////////////////////////////////////
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_k,
+                        tAsA_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_k,
+                        tBsB_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_k,
+                        tAsSFA_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_k,
+                        tBsSFB_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                    )
+                    # Mainloop pipeline's producer commit is a NOP
+                    mainloop_pipeline.producer_commit(mainloop_producer_state)
+                    mainloop_producer_state.advance()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            # end of while loop
+
+            # Wait A/B buffer empty
+            mainloop_pipeline.producer_tail(mainloop_producer_state)
+        return
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk: tuple[int, int, int],
+        a_dtype: type[cutlass.Numeric],
+        b_dtype: type[cutlass.Numeric],
+        sf_dtype: type[cutlass.Numeric],
+        sfa_smem_layout: cute.Layout,
+        sfb_smem_layout: cute.Layout,
+        epi_tile: tuple[int, int],
+        c_dtype: type[cutlass.Numeric],
+        smem_capacity: int,
+        occupancy: int,
+    ) -> tuple[int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
+
+        :param tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type tile_shape_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (A/B operand stages, epilogue stages)
+        :rtype: tuple[int, int]
+        """
+
+        epi_stage_max = (tile_shape_mnk[1] // epi_tile[1]) * (
+            tile_shape_mnk[0] // epi_tile[0]
+        )
+        epi_stage = min(epi_stage_max, 4)
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_bytes = c_bytes_per_stage * epi_stage
+
+        # A/B shared memory size
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        # SFA/SFB shared memory size
+        sf_bytes_per_stage = (
+            cute.size(cute.filter_zeros(sfa_smem_layout).shape) * sf_dtype.width // 8
+            + cute.size(cute.filter_zeros(sfb_smem_layout).shape) * sf_dtype.width // 8
+        )
+        # Mbar helpers size
+        mbar_helpers_bytes = 1024
+
+        ab_stage = (
+            (smem_capacity - occupancy * 1024) // occupancy
+            - mbar_helpers_bytes
+            - epi_bytes
+        ) // (ab_bytes_per_stage + sf_bytes_per_stage)
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk: tuple[int, int, int],
+        epi_tile: tuple[int, int],
+        a_dtype: type[cutlass.Numeric],
+        a_layout: cute.Layout,
+        b_dtype: type[cutlass.Numeric],
+        b_layout: cute.Layout,
+        ab_stage: int,
+        c_dtype: type[cutlass.Numeric],
+        c_layout: cute.Layout,
+        epi_stage: int,
+        sf_vec_size: int,
+        tiled_mma: cute.TiledMma,
+    ) -> tuple[cute.ComposedLayout, cute.ComposedLayout, cute.ComposedLayout]:
+        """Create shared memory layouts for A, B, and C tensors.
+
+        :param tile_shape_mnk: CTA tile shape (M,N,K)
+        :type tile_shape_mnk: Tuple[int, int, int]
+        :param epi_tile: Epilogue tile shape
+        :type epi_tile: Tuple[int, int]
+        :param a_dtype: Data type for matrix A
+        :type a_dtype: type[cutlass.Numeric]
+        :param a_layout: Layout for matrix A
+        :type a_layout: Layout
+        :param b_dtype: Data type for matrix B
+        :type b_dtype: type[cutlass.Numeric]
+        :param b_layout: Layout for matrix B
+        :type b_layout: Layout
+        :param ab_stage: Number of stages for A/B tensors
+        :type ab_stage: int
+        :param c_dtype: Data type for output matrix C
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: leading dimension of the output matrix C
+        :type c_layout: Layout
+        :param epi_stage: Number of epilogue stages
+        :type epi_stage: int
+
+        :return: Tuple of shared memory layouts for A, B, and C
+        :rtype: Tuple[cute.ComposedLayout, cute.ComposedLayout, cute.ComposedLayout]
+        """
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+
+        a_is_k_major = a_layout.is_k_major_a()
+        b_is_k_major = b_layout.is_k_major_b()
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                a_layout,
+                a_dtype,
+                a_major_mode_size,
+            ),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        sfa_smem_layout_staged = blockscaled_utils.sm120_make_smem_layout_sfa(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+
+        sfb_smem_layout_staged = blockscaled_utils.sm120_make_smem_layout_sfb(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                c_layout,
+                c_dtype,
+                c_major_mode_size,
+            ),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+
+        return (
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            sfa_smem_layout_staged,
+            sfb_smem_layout_staged,
+            epi_smem_layout_staged,
+        )
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        tile_shape_mnk: tuple[int, int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> tuple[int, int, int]:
+        """Compute grid shape for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type tile_shape_mnk: tuple[int, int, int]
+
+        :return: Grid shape for kernel launch.
+        :rtype: tuple[int, int, int]
+        """
+
+        c_shape = cute.slice_(tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (1, 1, 1)
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(
+        tensor_c: cute.Tensor,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: tuple[int, int],
+    ) -> tuple[cute.CopyAtom, cute.Tensor]:
+        """Create TMA atoms and tensors for C tensor storage.
+
+        :param tensor_c: Output tensor C
+        :type tensor_c: cute.Tensor
+        :param epi_smem_layout_staged: Shared memory layout for epilogue
+        :type epi_smem_layout_staged: cute.ComposedLayout
+        :param epi_tile: Epilogue tile shape
+        :type epi_tile: Tuple[int, int]
+
+        :return: TMA atom and tensor for C
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor]
+        """
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+
+        return tma_atom_c, tma_tensor_c
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(
+        tensor: cute.Tensor,
+        smem_layout_staged: cute.ComposedLayout,
+        smem_tile: tuple[int, int],
+        mcast_dim: int,
+        internal_type: Optional[Type[cutlass.Numeric]] = None,
+    ) -> tuple[cute.CopyAtom, cute.Tensor]:
+        """Create TMA atoms and tensors for input tensors.
+
+        :param tensor: Input tensor (A or B)
+        :type tensor: cute.Tensor
+        :param smem_layout_staged: Shared memory layout for the tensor
+        :type smem_layout_staged: cute.ComposedLayout
+        :param smem_tile: Shared memory tile shape
+        :type smem_tile: Tuple[int, int]
+        :param mcast_dim: Multicast dimension
+        :type mcast_dim: int
+
+        :return: TMA atom and tensor
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor]
+        """
+        op = (
+            cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+            op,
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=mcast_dim,
+            internal_type=internal_type,
+        )
+
+        return tma_atom, tma_tensor
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        return is_valid
+
+
+@cute.jit
+def cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+    sf_ref_tensor: cute.Tensor,
+    sf_mma_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from MKL layout to mma specification M(32x4xrest_m)xK(4xrest_k)xL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_mma_tensor[mkl_coord] = sf_ref_tensor[mkl_coord]
+
+
+def run(
+    mnkl: Tuple[int, int, int, int],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    c_dtype: Type[cutlass.Numeric],
+    a_major: str = "k",
+    b_major: str = "k",
+    c_major: str = "n",
+    tile_shape_mnk: Tuple[int, int, int] = (128, 128, 128),
+    epi_tile: Tuple[int, int] = (128, 128),
+    tolerance: float = 1e-01,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    **kwargs,
+):
+    """Perf-framework-compatible entry point.
+
+    FP4 MMA only supports Float32 accumulation, so acc_dtype is always
+    Float32 regardless of what the caller passes.
+    """
+    return run_bs(
+        mnkl=mnkl,
+        a_dtype=a_dtype,
+        b_dtype=b_dtype,
+        sf_dtype=sf_dtype,
+        sf_vec_size=sf_vec_size,
+        c_dtype=c_dtype,
+        acc_dtype=cutlass.Float32,
+        a_major=a_major,
+        b_major=b_major,
+        c_major=c_major,
+        tile_shape_mnk=tile_shape_mnk,
+        epi_tile=epi_tile,
+        tolerance=tolerance,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        skip_ref_check=skip_ref_check,
+        use_cold_l2=use_cold_l2,
+    )
+
+
+def run_bs(
+    mnkl: Tuple[int, int, int, int],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    c_dtype: Type[cutlass.Numeric],
+    acc_dtype: Type[cutlass.Numeric],
+    a_major: str,
+    b_major: str,
+    c_major: str,
+    tile_shape_mnk: Tuple[int, int, int],
+    epi_tile: Tuple[int, int],
+    tolerance: float,
+    warmup_iterations: int,
+    iterations: int,
+    skip_ref_check: bool,
+    use_cold_l2: bool = False,
+    **kwargs,
+):
+    import torch
+    import cutlass.torch as cutlass_torch
+
+    print("Running Blackwell Geforce Blockscaled Dense GEMM with:")
+    print(f"mnkl: {mnkl}")
+    print(
+        f"A dtype: {a_dtype}, B dtype: {b_dtype}, A/B scale factor dtype: {sf_dtype}, C dtype: {c_dtype}, Acc dtype: {acc_dtype}"
+    )
+    print(f"Matrix majors - A: {a_major}, B: {b_major}, C: {c_major}")
+    print(f"Tile Shape: {tile_shape_mnk}")
+    print(f"Epilogue tile: {epi_tile}")
+    print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use cold L2: {use_cold_l2}")
+
+    m, n, k, l = mnkl
+
+    if not Sm120BlockScaledGemmKernel.is_valid_tensor_alignment(
+        m, n, k, l, a_dtype, c_dtype, a_major, b_major, c_major
+    ):
+        raise ValueError("Invalid tensor alignment")
+
+    a_dtype = getattr(cutlass, a_dtype) if isinstance(a_dtype, str) else a_dtype
+    b_dtype = getattr(cutlass, b_dtype) if isinstance(b_dtype, str) else b_dtype
+    c_dtype = getattr(cutlass, c_dtype) if isinstance(c_dtype, str) else c_dtype
+    acc_dtype = getattr(cutlass, acc_dtype) if isinstance(acc_dtype, str) else acc_dtype
+
+    # Unpack parameters
+    m, n, k, l = mnkl
+    cluster_shape_mnk = (1, 1, 1)
+
+    # Prepare pytorch tensors: A, B (random from 0 to 2) and C (all zero)
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    a_ref = cutlass_torch.matrix(l, m, k, a_major == "m", cutlass.Float32)
+    b_ref = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
+    c_ref = cutlass_torch.matrix(l, m, n, c_major == "m", cutlass.Float32)
+
+    a_tensor, a_torch = cutlass_torch.cute_tensor_like(
+        a_ref, a_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, b_torch = cutlass_torch.cute_tensor_like(
+        b_ref, b_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    c_tensor, c_torch = cutlass_torch.cute_tensor_like(
+        c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Mark tensor to be byte aligned
+    a_tensor.mark_compact_shape_dynamic(
+        mode=1 if a_major == "k" else 0,
+        stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+        divisibility=2 if a_dtype == cutlass.Float4E2M1FN else 1,
+    )
+    b_tensor.mark_compact_shape_dynamic(
+        mode=1 if b_major == "k" else 0,
+        stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+        divisibility=2 if b_dtype == cutlass.Float4E2M1FN else 1,
+    )
+    c_tensor.mark_compact_shape_dynamic(
+        mode=1 if c_major == "n" else 0,
+        stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+        divisibility=2 if c_dtype == cutlass.Float4E2M1FN else 1,
+    )
+
+    # Create scale factor tensor SFA/SFB
+    def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):
+        def ceil_div(a, b):
+            return (a + b - 1) // b
+
+        sf_k = ceil_div(k, sf_vec_size)
+        ref_shape = (l, mn, sf_k)
+
+        # The A, C, and D matrices are row-major whereas the B matrix is column-major.
+        # So only k-major (A/B) is supported.
+
+        atom_m = (32, 4)
+        atom_k = 4
+        mma_shape = (
+            l,
+            ceil_div(mn, atom_m[0] * atom_m[1]),
+            ceil_div(sf_k, atom_k),
+            atom_m[0],
+            atom_m[1],
+            atom_k,
+        )
+
+        ref_permute_order = (1, 2, 0)
+        mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+        # Create f32 ref torch tensor (cpu)
+        ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            ref_shape,
+            torch.float32,
+            permute_order=ref_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=1,
+                max_val=3,
+            ),
+        )
+
+        # Create f32 cute torch tensor (cpu)
+        cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            mma_shape,
+            torch.float32,
+            permute_order=mma_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=0,
+                max_val=1,
+            ),
+        )
+
+        # convert ref f32 tensor to cute f32 tensor
+        cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+            from_dlpack(ref_f32_torch_tensor_cpu),
+            from_dlpack(cute_f32_torch_tensor_cpu),
+        )
+        cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
+
+        # reshape makes memory contiguous
+        ref_f32_torch_tensor_cpu = (
+            ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+            .unsqueeze(-1)
+            .expand(l, mn, sf_k, sf_vec_size)
+            .reshape(l, mn, sf_k * sf_vec_size)
+            .permute(*ref_permute_order)
+        )
+        # prune to mkl for reference check.
+        ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+
+        # Create dtype cute torch tensor (cpu)
+        cute_tensor, torch_tensor = cutlass_torch.cute_tensor_like(
+            cute_f32_torch_tensor_cpu,
+            dtype,
+            is_dynamic_layout=True,
+            assumed_align=16,
+        )
+
+        # Convert f32 cute tensor to dtype cute tensor
+        cute_tensor = cutlass_torch.convert_cute_tensor(
+            cute_f32_torch_tensor,
+            cute_tensor,
+            dtype,
+            is_dynamic_layout=True,
+        )
+
+        return ref_f32_torch_tensor_cpu, cute_tensor, torch_tensor
+
+    sfa_ref, sfa_tensor, sfa_torch = create_scale_factor_tensor(
+        l, m, k, sf_vec_size, sf_dtype
+    )
+
+    sfb_ref, sfb_tensor, sfb_torch = create_scale_factor_tensor(
+        l, n, k, sf_vec_size, sf_dtype
+    )
+
+    # configure gemm kernel
+    gemm = Sm120BlockScaledGemmKernel(
+        acc_dtype,
+        sf_vec_size,
+        tile_shape_mnk,
+        epi_tile,
+    )
+
+    # Compute max active clusters on current device
+    hardware_info = cutlass.utils.HardwareInfo()
+    max_active_clusters = hardware_info.get_max_active_clusters(
+        cluster_shape_mnk[0] * cluster_shape_mnk[1]
+    )
+
+    # Initialize stream
+    stream = cutlass_torch.default_stream()
+
+    # compile gemm kernel
+    compiled_gemm = cute.compile(
+        gemm,
+        a_tensor,
+        b_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        c_tensor,
+        max_active_clusters,
+        stream,
+    )
+
+    if not skip_ref_check:
+        print("Reference checking ...")
+        # execution
+        compiled_gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, stream)
+        torch.cuda.synchronize()
+
+        # Ref check
+        res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
+        res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
+        ref = torch.einsum("mkl,nkl->mnl", res_a, res_b)
+
+        # Convert c back to f32 for comparison.
+        c_ref_device = c_ref.cuda()
+        cute.testing.convert(
+            c_tensor,
+            from_dlpack(c_ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=(1 if c_major == "n" else 0)
+            ),
+        )
+        c_ref = c_ref_device.cpu()
+
+        if c_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        elif c_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN):
+            # Convert ref : f32 -> f8 -> f32
+            ref_f8_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            ref_f8.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f8)
+            cute.testing.convert(ref_f8, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        elif c_dtype is cutlass.Float4E2M1FN:
+            # Convert ref : f32 -> f4 -> f32
+            ref_f4_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f4 = from_dlpack(ref_f4_, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            ref_f4.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f4)
+            cute.testing.convert(ref_f4, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+
+    def generate_tensors():
+        a_tensor, _ = cutlass_torch.cute_tensor_like(
+            a_ref, a_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        b_tensor, _ = cutlass_torch.cute_tensor_like(
+            b_ref, b_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        c_tensor, _ = cutlass_torch.cute_tensor_like(
+            c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        # Mark tensor to be byte aligned
+        a_tensor.mark_compact_shape_dynamic(
+            mode=1 if a_major == "k" else 0,
+            stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+            divisibility=2 if a_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        b_tensor.mark_compact_shape_dynamic(
+            mode=1 if b_major == "k" else 0,
+            stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+            divisibility=2 if b_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        c_tensor.mark_compact_shape_dynamic(
+            mode=1 if c_major == "n" else 0,
+            stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+            divisibility=2 if c_dtype == cutlass.Float4E2M1FN else 1,
+        )
+
+        _, sfa_tensor, _ = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
+        _, sfb_tensor, _ = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
+        return cute.testing.JitArguments(
+            a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, stream
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            a_ref.numel() * a_ref.element_size()
+            + b_ref.numel() * b_ref.element_size()
+            + sfa_ref.numel() * sfa_ref.element_size()
+            + sfb_ref.numel() * sfb_ref.element_size()
+            + c_ref.numel() * c_ref.element_size()
+        )
+        workspace_count = testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    exec_time = testing.benchmark(
+        compiled_gemm,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+    )
+
+    gflop = 2 * m * n * k / 1e9
+    gflops = gflop / exec_time * 1e6
+
+    print(f"Execution time: {exec_time} microseconds per iteration")
+    print(f"GFLOPS: {gflops}")
+
+    return exec_time  # Return execution time in microseconds
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Example of MxNxKxL GEMM on Blackwell Geforce."
+    )
+
+    parser.add_argument(
+        "--mnkl",
+        type=parse_comma_separated_ints,
+        default=(
+            1024,
+            1024,
+            1024,
+            1,
+        ),
+        help="mnkl dimensions (comma-separated)",
+    )
+    parser.add_argument(
+        "--tile_shape_mnk",
+        type=parse_comma_separated_ints,
+        choices=[
+            (128, 128, 128),
+            (128, 128, 256),
+        ],
+        default=(128, 128, 128),
+        help="CTA tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--epi_tile",
+        type=parse_comma_separated_ints,
+        choices=[
+            (128, 128),
+            (64, 32),
+        ],
+        default=(128, 128),
+        help="Epilogue tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--a_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float4E2M1FN,
+    )
+    parser.add_argument(
+        "--b_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float4E2M1FN,
+    )
+    parser.add_argument(
+        "--sf_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float8E4M3FN,
+    )
+    parser.add_argument(
+        "--sf_vec_size",
+        type=int,
+        choices=[16, 32],  # 16 for NVFP4, 32 for MXFP4 / MXFP8.
+        default=16,
+    )
+    parser.add_argument(
+        "--c_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float16,
+    )
+    parser.add_argument(
+        "--acc_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float32,
+    )
+    parser.add_argument("--a_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--b_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--c_major", choices=["n"], type=str, default="n")
+    parser.add_argument(
+        "--tolerance", type=float, default=1e-01, help="Tolerance for validation"
+    )
+    parser.add_argument(
+        "--warmup_iterations", type=int, default=0, help="Warmup iterations"
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of iterations to run the kernel",
+    )
+    parser.add_argument(
+        "--skip_ref_check",
+        action="store_true",
+        default=False,
+        help="Skip reference checking",
+    )
+    parser.add_argument(
+        "--use_cold_l2",
+        action="store_true",
+        default=False,
+        help="Use circular buffer tensor sets to ensure L2 cold cache",
+    )
+
+    args = parser.parse_args()
+
+    if len(args.mnkl) != 4:
+        parser.error("--mnkl must contain exactly 4 values")
+
+    fp4_allowed_tiles = {(128, 128, 128), (128, 128, 256)}
+    fp8_allowed_tiles = {(128, 128, 128)}
+    try:
+        validate_blockscaled_args(args, fp4_allowed_tiles, fp8_allowed_tiles)
+    except ValueError as e:
+        parser.error(str(e))
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    run_bs(
+        args.mnkl,
+        args.a_dtype,
+        args.b_dtype,
+        args.sf_dtype,
+        args.sf_vec_size,
+        args.c_dtype,
+        args.acc_dtype,
+        args.a_major,
+        args.b_major,
+        args.c_major,
+        args.tile_shape_mnk,
+        args.epi_tile,
+        args.tolerance,
+        args.warmup_iterations,
+        args.iterations,
+        args.skip_ref_check,
+        args.use_cold_l2,
+    )
+    print("PASS")

--- a/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_pingpong.py
+++ b/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_pingpong.py
@@ -1,0 +1,2102 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+from typing import Tuple, Type, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+import cutlass.cute.testing as testing
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.cute.runtime import from_dlpack
+import cutlass.utils.hopper_helpers as sm90_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+import cutlass.utils.blackwell_helpers as sm120_utils
+
+try:
+    from blackwell_geforce.kernel.blockscaled_gemm.blockscaled_gemm_dispatch import (
+        FP4_SHIFT_BITS,
+        make_ldmatrix_atom,
+        make_sm120_blockscaled_mma_op,
+        validate_blockscaled_args,
+    )
+except ImportError:
+    from blockscaled_gemm_dispatch import (
+        FP4_SHIFT_BITS,
+        make_ldmatrix_atom,
+        make_sm120_blockscaled_mma_op,
+        validate_blockscaled_args,
+    )
+
+"""
+A high-performance batched dense blockscaled GEMM (C = A*SF_A * B*SF_B) example for the NVIDIA Blackwell Geforce architecture using CUTE DSL.
+- Matrix A is MxKxL, L is batch dimension, A can only be row-major("K")
+- Matrix B is NxKxL, L is batch dimension, B can only be column-major("K")
+- Matrix C is MxNxL, L is batch dimension, C can only be row-major("N")
+- Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk, which has M×ceil_div(K, sf_vec_size)×L elements respectively
+- Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk, which has N×ceil_div(K, sf_vec_size)×L elements respectively
+- Source formats for matrices A and B: The only supported source format in this example is E2M1.
+- Source formats for matrices SF_A and SF_B are controlled separately. With sf_vec_size=32, the only supported source format is E8. With sf_vec_size=16, the supported source formats are E8 and E4M3.
+
+This GEMM kernel supports the following features:
+    - Utilizes Tensor Memory Access (TMA) for efficient memory operations
+    - Utilizes warp-level block-scaled MMA for matrix multiply-accumulate (MMA) operations
+    - Supports persistent tile scheduling to better overlap memory load/store with MMA between tiles
+    - Supports warp specialization to avoid explicit pipelining between mainloop load and MMA
+    - Uses a ping-pong schedule: each warp group independently processes one output tile at a time.
+      The two warp groups alternate execution in a pipelined fashion — while the first warp group
+      executes the epilogue for the current tile, the second warp group executes the MMA mainloop
+      for the next tile, and vice versa. This overlaps epilogue and mainloop across warp groups,
+      improving math utilization by hiding epilogue latency behind useful computation.
+
+This GEMM works as follows:
+1. DMA warp group:
+    - Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+    - Load scale factor A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+2. MMA warp group (two warp groups alternate on separate tiles):
+    - Load A/B from shared memory (SMEM) to registers (RMEM) using ldmatrix instruction.
+    - Load scale factor A/B from shared memory (SMEM) to registers (RMEM) using universal copy.
+    - Perform matrix multiply-accumulate (MMA) operations using warp-level block-scaled MMA instruction.
+    - Store C matrix from registers (RMEM) to shared memory (SMEM), then to global memory (GMEM) with TMA operations.
+    Note: Each MMA warp group handles both MMA and epilogue for its tile. While one warp group
+    is executing the epilogue, the other warp group is executing MMA on the next tile.
+
+Warp-level block-scaled MMA instructions operate as follows:
+- Set matrix scale factor A/B from registers
+- Read matrix A/B from registers
+- Perform MMA operation and store the result in Accumulator(register)
+
+To run this example:
+
+.. code-block:: bash
+
+    python examples/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_pingpong.py     \
+      --mnkl 8192,8192,8192,1 --tile_shape_mnk 128,128,128                      \
+      --a_dtype Float4E2M1FN --b_dtype Float4E2M1FN                             \
+      --c_dtype Float16 --acc_dtype Float32                                     \
+      --sf_dtype Float8E4M3FN --sf_vec_size 16 --epi_tile 64,32
+
+The above example command compute batched gemm with M=1024, N=1024, K=1024,
+batch_count=1. The tile shape is 128x128x128 and the cluster shape is (1,1).
+The input, mma accumulator and output data type are set as fp4, fp32
+and fp16, respectively.
+
+To collect performance with NCU profiler:
+
+.. code-block:: bash
+
+    ncu python examples/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_pingpong.py  \
+      --mnkl 1024,1024,1024,1 --tile_shape_mnk 128,128,128                      \
+      --a_dtype Float4E2M1FN --b_dtype Float4E2M1FN                             \
+      --c_dtype Float16 --acc_dtype Float32                                     \
+      --sf_dtype Float8E4M3FN --sf_vec_size 16 --epi_tile 64,32
+
+Constraints:
+* Supported input data types: Float4E2M1FN
+* Only Float32 accumulation is supported in FP4 mma
+* CTA tile shape M/N/K:
+ - tile_shape_m should be divisible by 128
+ - tile_shape_n should be divisible by 128
+ - tile_shape_k should be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
+* Cluster shape M/N must be [1, 1] for Blackwell Gefore
+"""
+
+
+# /////////////////////////////////////////////////////////////////////////////
+#  Helpers to parse args
+# /////////////////////////////////////////////////////////////////////////////
+def parse_comma_separated_ints(s: str):
+    try:
+        return tuple([int(x.strip()) for x in s.split(",")])
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            "Invalid format. Expected comma-separated integers."
+        )
+
+
+# /////////////////////////////////////////////////////////////////////////////
+#  Host setup and device kernel launch
+# /////////////////////////////////////////////////////////////////////////////
+
+
+class Sm120BlockScaledGemmKernel:
+    def __init__(
+        self,
+        acc_dtype,
+        sf_vec_size,
+        tile_shape_mnk,
+        epi_tile,
+    ):
+        self.acc_dtype = acc_dtype
+        self.sf_vec_size = sf_vec_size
+        self.cluster_shape_mnk = (1, 1, 1)
+        self.tile_shape_mnk = tuple(tile_shape_mnk)
+        self.epi_tile = tuple(epi_tile)
+        self.tiled_mma = None
+
+        self.occupancy = 1
+        self.num_mma_warps = 8
+        self.tma_load_warp_id = self.num_mma_warps
+        self.num_threads_per_warp = 32
+        self.threads_per_cta = (
+            self.num_mma_warps + 1  # 1 warp for DMA
+        ) * self.num_threads_per_warp
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+
+        self.ab_stage = None
+        self.epi_stage = None
+
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+
+        self.buffer_align_bytes = 1024
+
+        self.mma_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.num_mma_warps * self.num_threads_per_warp // 2,
+        )
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+
+    def _setup_attributes(self):
+        mma_op, use_mxf8f6f4 = make_sm120_blockscaled_mma_op(
+            self.a_dtype,
+            self.b_dtype,
+            self.acc_dtype,
+            self.sf_dtype,
+            self.sf_vec_size,
+        )
+        self.mixed_mode = self.a_dtype != self.b_dtype
+        # a_fp4_in_mixed / b_fp4_in_mixed: this side carries an FP4 operand in the
+        # mixed FP4 x FP8 mode, so SMEM/TMA see Int8 storage and the mma.sync
+        # consumer needs the LDSM b4x16_p64 unpack + register `<< FP4_SHIFT_BITS`.
+        a_fp4_in_mixed = self.mixed_mode and self.a_dtype.width < 8
+        b_fp4_in_mixed = self.mixed_mode and self.b_dtype.width < 8
+        self.smem_alloc_a_dtype = cutlass.Int8 if a_fp4_in_mixed else self.a_dtype
+        self.smem_alloc_b_dtype = cutlass.Int8 if b_fp4_in_mixed else self.b_dtype
+        # `internal_type` for `_make_tma_atoms_and_tensors` — None when the dtype
+        # already matches (TMA sees the native dtype), Int8 when we recast for FP4.
+        self.tma_internal_a_dtype = cutlass.Int8 if a_fp4_in_mixed else None
+        self.tma_internal_b_dtype = cutlass.Int8 if b_fp4_in_mixed else None
+        atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
+        permutation_mnk = sm120_utils.get_permutation_mnk(
+            self.tile_shape_mnk, self.sf_vec_size, use_mxf8f6f4
+        )
+        self.tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            atom_layout,
+            permutation_mnk=permutation_mnk,
+        )
+
+        self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+
+        # Compute the smem size of SFA/SFB
+        sfa_smem_layout_per_stage = blockscaled_utils.sm120_make_smem_layout_sfa(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        sfb_smem_layout_per_stage = blockscaled_utils.sm120_make_smem_layout_sfb(
+            self.tiled_mma,
+            self.tile_shape_mnk,
+            self.sf_vec_size,
+            1,
+        )
+
+        # Compute stage before compute smem layout
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.smem_alloc_a_dtype,
+            self.smem_alloc_b_dtype,
+            self.sf_dtype,
+            sfa_smem_layout_per_stage,
+            sfb_smem_layout_per_stage,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        assert self.epi_stage > 0, (
+            "epi_stage <= 0, no enough shared memory. This case will be skipped."
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.smem_alloc_a_dtype,
+            self.a_layout,
+            self.smem_alloc_b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+            self.sf_vec_size,
+            self.tiled_mma,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        c: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a: Input tensor A
+        :type a: cute.Tensor
+        :param b: Input tensor B
+        :type b: cute.Tensor
+        :param c: Output tensor C
+        :type c: cute.Tensor
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        """
+
+        # setup static attributes before smem/grid/tma computation
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.sf_dtype = sfa.element_type
+
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        self.sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa.iterator, self.sfa_layout)
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        self.sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b.shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb.iterator, self.sfb_layout)
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            1,
+            internal_type=self.tma_internal_a_dtype,
+        )
+
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+            internal_type=self.tma_internal_b_dtype,
+        )
+
+        tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
+            sfa_tensor,
+            self.sfa_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            1,
+            internal_type=cutlass.Int16,
+        )
+
+        tma_atom_sfb, tma_tensor_sfb = self._make_tma_atoms_and_tensors(
+            sfb_tensor,
+            self.sfb_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            1,
+            internal_type=cutlass.Int16,
+        )
+
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        tile_sched_params, grid = self._compute_grid(
+            c,
+            self.tile_shape_mnk,
+            max_active_clusters,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            math_wg_order_barrier_array_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.smem_alloc_a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.smem_alloc_b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype, cute.cosize(self.epi_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.threads_per_cta = (self.threads_per_cta + 128) // 128 * 128
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+            max_number_threads=[self.threads_per_cta, 1, 1],
+            min_blocks_per_mp=1,
+        )
+        return
+
+    @cute.jit
+    def advance(self, state: pipeline.PipelineState, iterations):
+        if iterations < state.stages and ((state._index + iterations) >= state.stages):
+            state._phase ^= 1
+        if (
+            iterations >= state.stages
+            and (((state._index + iterations) // state.stages) % 2) == 1
+        ):
+            state._phase ^= 1
+        state._index = (state._index + iterations) % state.stages
+        state._count += iterations
+        return state
+
+    @cute.jit
+    def make_and_init_order_barrier(self, order_mbar_ptr, group_id):
+        StagesPerMathWarpGroup = 2
+        return pipeline.PipelineOrder.create(
+            barrier_storage=order_mbar_ptr,
+            depth=StagesPerMathWarpGroup,
+            length=2,
+            group_id=group_id,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                128,
+            ),
+            defer_sync=True,
+        )
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+    ):
+        """
+        GPU device kernel performing the batched GEMM computation.
+
+        :param tma_atom_a: TMA copy atom for A tensor
+        :type tma_atom_a: cute.CopyAtom
+        :param mA_mkl: Input tensor A
+        :type mA_mkl: cute.Tensor
+        :param tma_atom_b: TMA copy atom for B tensor
+        :type tma_atom_b: cute.CopyAtom
+        :param mB_nkl: Input tensor B
+        :type mB_nkl: cute.Tensor
+        :param tma_atom_c: TMA copy atom for C tensor
+        :type tma_atom_c: cute.CopyAtom
+        :param mC_mnl: Output tensor C
+        :type mC_mnl: cute.Tensor
+        :param tiled_mma: Tiled MMA object
+        :type tiled_mma: cute.TiledMma
+        :param cta_layout_mnk: CTA layout
+        :type cta_layout_mnk: cute.Layout
+        :param a_smem_layout_staged: Shared memory layout for A
+        :type a_smem_layout_staged: cute.ComposedLayout
+        :param b_smem_layout_staged: Shared memory layout for B
+        :type b_smem_layout_staged: cute.ComposedLayout
+        :param epi_smem_layout_staged: Shared memory layout for epilogue
+        :type epi_smem_layout_staged: cute.ComposedLayout
+        """
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Get cta/warp/thread idx
+        # ///////////////////////////////////////////////////////////////////////////////
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        bidx, bidy, bidz = cute.arch.block_idx()
+        # bdimx, bdimy, bdimz = cute.arch.grid_dim()
+
+        # /////////////////////////////////////////////////////////////////////////////
+        #  Prefetch Tma desc
+        # /////////////////////////////////////////////////////////////////////////////
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = (
+            cute.size_in_bytes(self.a_dtype, a_smem_layout)
+            + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+            + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        )
+
+        # /////////////////////////////////////////////////////////////////////////////
+        #  Alloc and init AB full/empty + ACC full mbar (pipeline)
+        # /////////////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # mbar arrays
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+        math_wg_order_barrier_array_ptr = (
+            storage.math_wg_order_barrier_array_ptr.data_ptr()
+        )
+
+        # Threads/warps participating in this pipeline
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mma_warps // 2
+        )
+
+        cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            barrier_storage=mainloop_pipeline_array_ptr,
+            cta_layout_vmnk=cta_layout_vmnk,
+        )
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // 128)
+        math_wg_order_barrier = self.make_and_init_order_barrier(
+            math_wg_order_barrier_array_ptr, warp_group_idx
+        )
+        cute.arch.mbarrier_init_fence()
+        math_wg_order_state = math_wg_order_barrier.state
+
+        #  Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Generate smem tensor A/B
+        # ///////////////////////////////////////////////////////////////////////////////
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner
+        )
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Local_tile partition global tensors
+        # ///////////////////////////////////////////////////////////////////////////////
+        # (bM, bK, loopM, loopK, loopL)
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        # (bN, bK, loopN, loopK, loopL)
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        # (tM, tK, loopM, loopK, loopL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        # (tN, tK, loopN, loopK, loopL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        # (bM, bN, loopM, loopN, loopL)
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        # //////////////////////////////////////////////////////////////////////////////
+        #  Partition global tensor for TiledMMA_A/B/C
+        # //////////////////////////////////////////////////////////////////////////////
+        thr_mma = tiled_mma.get_slice(tidx % 128)
+
+        # //////////////////////////////////////////////////////////////////////////////
+        #  Partition shared tensor for TMA load A/B
+        # //////////////////////////////////////////////////////////////////////////////
+        #  TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA_mkl, 0, 2),
+        )
+
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_nkl, 0, 2),
+        )
+
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_atom_sfa,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sSFA, 0, 2),
+            cute.group_modes(gSFA_mkl, 0, 2),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        tBsSFB, tBgSFB = cpasync.tma_partition(
+            tma_atom_sfb,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sSFB, 0, 2),
+            cute.group_modes(gSFB_nkl, 0, 2),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        #  Make frangments
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCrSFA = sm120_utils.partition_fragment_SFA(sSFA[None, None, 0], thr_mma, tidx)
+        tCrSFB = sm120_utils.partition_fragment_SFB(sSFB[None, None, 0], thr_mma, tidx)
+        # Keep residual K modes nested to match the C++ SM120 block-scaled mainloop.
+        tCrSFA = cute.group_modes(tCrSFA, 2, cute.rank(tCrSFA))
+        tCrSFB = cute.group_modes(tCrSFB, 2, cute.rank(tCrSFB))
+
+        tCgC = thr_mma.partition_C(gC_mnl)
+        acc_shape = tCgC.shape[:3]
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        # cluster wait for barrier init
+        if cute.size(self.cluster_shape_mnk) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.sync_threads()
+
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        # Create the tile scheduler
+        tile_sched = utils.StaticPersistentTileScheduler.create(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        # Create the pipeline states for producer and consumer
+        mainloop_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.ab_stage
+        )
+        mainloop_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.ab_stage
+        )
+
+        # MMA warp group
+        if warp_idx >= self.tma_load_warp_id:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+            if warp_idx == self.tma_load_warp_id:
+                work_tile = tile_sched.initial_work_tile_info()
+                while work_tile.is_valid_tile:
+                    tile_coord_mnl = work_tile.tile_idx
+                    tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
+                    tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+                    tAgSFA_mkl = tAgSFA[
+                        (None, tile_coord_mnl[0], None, tile_coord_mnl[2])
+                    ]
+                    tBgSFB_nkl = tBgSFB[
+                        (None, tile_coord_mnl[1], None, tile_coord_mnl[2])
+                    ]
+
+                    mainloop_producer_state.reset_count()
+
+                    for k_tile in range(0, k_tile_cnt, 1, unroll=1):
+                        # /////////////////////////////////////////////////////////////////////////////
+                        #  Wait for A/B buffers to be empty before loading into them
+                        #  Also sets the transaction barrier for the A/B buffers
+                        # /////////////////////////////////////////////////////////////////////////////
+                        mainloop_pipeline.producer_acquire(mainloop_producer_state)
+
+                        # /////////////////////////////////////////////////////////////////////////////
+                        #  Slice to global/shared memref to current k_tile
+                        # /////////////////////////////////////////////////////////////////////////////
+                        tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                        tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+
+                        tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                        tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                        tAgSFA_k = tAgSFA_mkl[(None, mainloop_producer_state.count)]
+                        tAsSFA_pipe = tAsSFA[(None, mainloop_producer_state.index)]
+
+                        tBgSFB_k = tBgSFB_nkl[(None, mainloop_producer_state.count)]
+                        tBsSFB_pipe = tBsSFB[(None, mainloop_producer_state.index)]
+
+                        # /////////////////////////////////////////////////////////////////////////////
+                        #  TMA load A/B
+                        # /////////////////////////////////////////////////////////////////////////////
+                        cute.copy(
+                            tma_atom_a,
+                            tAgA_k,
+                            tAsA_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+                        cute.copy(
+                            tma_atom_b,
+                            tBgB_k,
+                            tBsB_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+                        cute.copy(
+                            tma_atom_sfa,
+                            tAgSFA_k,
+                            tAsSFA_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+                        cute.copy(
+                            tma_atom_sfb,
+                            tBgSFB_k,
+                            tBsSFB_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+                        # Mainloop pipeline's producer commit is a NOP
+                        mainloop_pipeline.producer_commit(mainloop_producer_state)
+                        mainloop_producer_state.advance()
+
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
+                # end of while loop
+
+                # Wait A/B buffer empty
+                mainloop_pipeline.producer_tail(mainloop_producer_state)
+        elif warp_idx < self.tma_load_warp_id:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Copy Atom A/B retiling for TMA load A/B
+            # ///////////////////////////////////////////////////////////////////////////////
+            atom_copy_ldmatrix_A = make_ldmatrix_atom(
+                self.a_dtype,
+                transpose=self.a_layout.is_m_major_a(),
+                num_matrices=4,
+                mixed_mode=self.mixed_mode,
+            )
+            atom_copy_ldmatrix_B = make_ldmatrix_atom(
+                self.b_dtype,
+                transpose=self.b_layout.is_n_major_b(),
+                num_matrices=4,
+                mixed_mode=self.mixed_mode,
+            )
+            smem_tiled_copy_A = cute.make_tiled_copy_A(atom_copy_ldmatrix_A, tiled_mma)
+            smem_tiled_copy_B = cute.make_tiled_copy_B(atom_copy_ldmatrix_B, tiled_mma)
+
+            atom_copy_ldmatrix_SF = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.sf_dtype,
+            )
+            smem_tiled_copy_SFA = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                sm120_utils.get_layoutSFA_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[0]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+            smem_tiled_copy_SFB = cute.make_tiled_copy(
+                atom_copy_ldmatrix_SF,
+                sm120_utils.get_layoutSFB_TV(tiled_mma),
+                (
+                    cute.size(tiled_mma.permutation_mnk[1]),
+                    cute.size(tiled_mma.permutation_mnk[2]),
+                ),
+            )
+
+            thr_copy_ldmatrix_A = smem_tiled_copy_A.get_slice(tidx % 128)
+            thr_copy_ldmatrix_B = smem_tiled_copy_B.get_slice(tidx % 128)
+            tCsA_copy_view = thr_copy_ldmatrix_A.partition_S(sA)
+            tCrA_copy_view = thr_copy_ldmatrix_A.retile(tCrA)
+            tCsB_copy_view = thr_copy_ldmatrix_B.partition_S(sB)
+            tCrB_copy_view = thr_copy_ldmatrix_B.retile(tCrB)
+
+            thr_copy_ldmatrix_SFA = smem_tiled_copy_SFA.get_slice(tidx % 128)
+            thr_copy_ldmatrix_SFB = smem_tiled_copy_SFB.get_slice(tidx % 128)
+            tCsSFA_copy_view = thr_copy_ldmatrix_SFA.partition_S(sSFA)
+            tCrSFA_copy_view = thr_copy_ldmatrix_SFA.retile(tCrSFA)
+            tCsSFB_copy_view = thr_copy_ldmatrix_SFB.partition_S(sSFB)
+            tCrSFB_copy_view = thr_copy_ldmatrix_SFB.retile(tCrSFB)
+
+            epi_buffer = cutlass.Int32(0)
+
+            if warp_group_idx == 1:
+                tile_sched.advance_to_next_work()
+                mainloop_consumer_state = self.advance(
+                    mainloop_consumer_state, k_tile_cnt
+                )
+                work_tile = tile_sched.get_current_work()
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
+                # Clear the accumulator
+                accumulators.fill(0.0)
+
+                # /////////////////////////////////////////////////////////////////////////////
+                #  Pipelined MAINLOOP
+                # /////////////////////////////////////////////////////////////////////////////
+
+                mainloop_consumer_state.reset_count()
+
+                math_wg_order_barrier.wait(math_wg_order_state)
+
+                peek_ab_full_status = cutlass.Boolean(1)
+                if mainloop_consumer_state.count < k_tile_cnt:
+                    peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                        mainloop_consumer_state
+                    )
+
+                #  Wait for TMA copies to complete
+                mainloop_pipeline.consumer_wait(
+                    mainloop_consumer_state, peek_ab_full_status
+                )
+                # tCsA_p: (MMA, (4, MMA_M / 4), MMA_K), tCsA_p: (MMA, (4, MMA_N / 4), MMA_K)
+                tCsA_p = tCsA_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsB_p = tCsB_copy_view[None, None, None, mainloop_consumer_state.index]
+                tCsSFA_p = tCsSFA_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                tCsSFB_p = tCsSFB_copy_view[
+                    None, None, None, mainloop_consumer_state.index
+                ]
+                cute.copy(
+                    smem_tiled_copy_A,
+                    tCsA_p[None, None, 0],
+                    tCrA_copy_view[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_B,
+                    tCsB_p[None, None, 0],
+                    tCrB_copy_view[None, None, 0],
+                )
+
+                tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_copy_view)
+                tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_copy_view)
+
+                cute.copy(
+                    smem_tiled_copy_SFA,
+                    tCsSFA_p_filtered[None, None, 0],
+                    tCrSFA_copy_view_filtered[None, None, 0],
+                )
+                cute.copy(
+                    smem_tiled_copy_SFB,
+                    tCsSFB_p_filtered[None, None, 0],
+                    tCrSFB_copy_view_filtered[None, None, 0],
+                )
+
+                for k_tile in range(0, k_tile_cnt - 1, 1, unroll=1):
+                    # unroll the loop
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_next = (
+                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                        )
+
+                        if k_block_idx == num_k_blocks - 1:
+                            mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                            mainloop_consumer_state.advance()
+
+                            peek_ab_full_status = cutlass.Boolean(1)
+                            peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
+                                mainloop_consumer_state
+                            )
+
+                            tCsA_p = tCsA_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsB_p = tCsB_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFA_p = tCsSFA_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            tCsSFB_p = tCsSFB_copy_view[
+                                None, None, None, mainloop_consumer_state.index
+                            ]
+                            mainloop_pipeline.consumer_wait(
+                                mainloop_consumer_state, peek_ab_full_status
+                            )
+                        # Copy data from smem to tCrA/tCrB for the next k_block
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+
+                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_copy_view)
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_copy_view)
+                        cute.copy(
+                            smem_tiled_copy_SFA,
+                            tCsSFA_p_filtered[None, None, k_block_next],
+                            tCrSFA_copy_view_filtered[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFB,
+                            tCsSFB_p_filtered[None, None, k_block_next],
+                            tCrSFB_copy_view_filtered[None, None, k_block_next],
+                        )
+                        # Mixed FP4 x FP8 register-side bit shift before mma.sync to
+                        # move the FP4 nibble (loaded into the LOW half of each Int8
+                        # register byte by ldsm.b4x16_p64) into the MIDDLE of the byte
+                        # where mma.sync.kind::mxf8f6f4 reads it. See blockscaled_gemm_dispatch.FP4_SHIFT_BITS.
+                        if cutlass.const_expr(
+                            self.mixed_mode and self.a_dtype.width < 8
+                        ):
+                            a_view = cute.recast_tensor(
+                                tCrA[None, None, k_block_idx], cutlass.Int8
+                            )
+                            for _i in cutlass.range_constexpr(cute.size(a_view)):
+                                a_view[_i] = cutlass.Int8(
+                                    a_view[_i] << FP4_SHIFT_BITS
+                                )
+                        if cutlass.const_expr(
+                            self.mixed_mode and self.b_dtype.width < 8
+                        ):
+                            b_view = cute.recast_tensor(
+                                tCrB[None, None, k_block_idx], cutlass.Int8
+                            )
+                            for _i in cutlass.range_constexpr(cute.size(b_view)):
+                                b_view[_i] = cutlass.Int8(
+                                    b_view[_i] << FP4_SHIFT_BITS
+                                )
+                        cute.gemm(
+                            tiled_mma,
+                            accumulators,
+                            [
+                                tCrA[None, None, k_block_idx],
+                                tCrSFA[None, None, k_block_idx],
+                            ],
+                            [
+                                tCrB[None, None, k_block_idx],
+                                tCrSFB[None, None, k_block_idx],
+                            ],
+                            accumulators,
+                        )
+                        # end of for loop
+                # end of for loop
+                # Hoist out last k_tile
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_block_next = (
+                        0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    )
+
+                    if k_block_idx == num_k_blocks - 1:
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        mainloop_pipeline.consumer_release(mainloop_consumer_state)
+                        mainloop_consumer_state.advance()
+
+                    if k_block_next > 0:
+                        cute.copy(
+                            smem_tiled_copy_A,
+                            tCsA_p[None, None, k_block_next],
+                            tCrA_copy_view[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_B,
+                            tCsB_p[None, None, k_block_next],
+                            tCrB_copy_view[None, None, k_block_next],
+                        )
+                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_copy_view)
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_copy_view)
+                        cute.copy(
+                            smem_tiled_copy_SFA,
+                            tCsSFA_p_filtered[None, None, k_block_next],
+                            tCrSFA_copy_view_filtered[None, None, k_block_next],
+                        )
+                        cute.copy(
+                            smem_tiled_copy_SFB,
+                            tCsSFB_p_filtered[None, None, k_block_next],
+                            tCrSFB_copy_view_filtered[None, None, k_block_next],
+                        )
+                    # Mixed FP4 x FP8 register-side bit shift before mma.sync (hoisted tail).
+                    if cutlass.const_expr(
+                        self.mixed_mode and self.a_dtype.width < 8
+                    ):
+                        a_view_h = cute.recast_tensor(
+                            tCrA[None, None, k_block_idx], cutlass.Int8
+                        )
+                        for _i in cutlass.range_constexpr(cute.size(a_view_h)):
+                            a_view_h[_i] = cutlass.Int8(
+                                a_view_h[_i] << FP4_SHIFT_BITS
+                            )
+                    if cutlass.const_expr(
+                        self.mixed_mode and self.b_dtype.width < 8
+                    ):
+                        b_view_h = cute.recast_tensor(
+                            tCrB[None, None, k_block_idx], cutlass.Int8
+                        )
+                        for _i in cutlass.range_constexpr(cute.size(b_view_h)):
+                            b_view_h[_i] = cutlass.Int8(
+                                b_view_h[_i] << FP4_SHIFT_BITS
+                            )
+                    cute.gemm(
+                        tiled_mma,
+                        accumulators,
+                        [
+                            tCrA[None, None, k_block_idx],
+                            tCrSFA[None, None, k_block_idx],
+                        ],
+                        [
+                            tCrB[None, None, k_block_idx],
+                            tCrSFB[None, None, k_block_idx],
+                        ],
+                        accumulators,
+                    )
+
+                math_wg_order_state = math_wg_order_barrier.arrive(math_wg_order_state)
+                math_wg_order_barrier.wait(math_wg_order_state)
+                mainloop_consumer_state = self.advance(
+                    mainloop_consumer_state, k_tile_cnt
+                )
+                # /////////////////////////////////////////////////////////////////////////////
+                #  EPILOG
+                # /////////////////////////////////////////////////////////////////////////////
+
+                copy_atom_r2s = sm120_utils.sm120_get_smem_store_op(
+                    self.c_layout,
+                    elem_ty_d=self.c_dtype,
+                    elem_ty_acc=self.acc_dtype,
+                )
+
+                copy_atom_C = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(
+                        self.c_layout.is_m_major_c(),
+                        2,
+                    ),
+                    self.c_dtype,
+                )
+
+                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+
+                tiled_copy_r2s = cute.make_tiled_copy_S(
+                    copy_atom_r2s,
+                    tiled_copy_C_Atom,
+                )
+
+                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx % 128)
+                # (R2S, R2S_M, R2S_N, PIPE_D)
+                tRS_sD = thr_copy_r2s.partition_D(sC)
+                # (R2S, R2S_M, R2S_N)
+                tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+                # Allocate D registers.
+                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+                size_tRS_rD = cute.size(tRS_rD)
+
+                sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+                tcgc_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+
+                bSG_sD, bSG_gD = cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    sepi_for_tma_partition,
+                    tcgc_for_tma_partition,
+                )
+
+                # Initialize tma store pipeline
+                tma_store_producer_group = pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    self.num_mma_warps * self.num_threads_per_warp,
+                )
+                tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=self.epi_stage,
+                    producer_group=tma_store_producer_group,
+                )
+
+                epi_rest_m = bSG_gD.shape[1][0]
+                epi_rest_n = bSG_gD.shape[1][1]
+                epi_tile_m = self.epi_tile[0]
+                epi_tile_n = self.epi_tile[1]
+                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
+                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
+
+                for epi_m in cutlass.range_constexpr(epi_rest_m):
+                    for epi_n in cutlass.range_constexpr(epi_rest_n):
+                        MmaMPerEpiM = epi_tile_m // mma_tile_m
+                        MmaNPerEpiN = epi_tile_n // mma_tile_n
+                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
+                                mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
+                                tRS_rD_slice = tRS_rD[
+                                    (None, mma_m_in_epi, mma_n_in_epi)
+                                ]
+                                tRS_rAcc_slice = tRS_rAcc[(None, mma_m, mma_n)]
+                                for elem_idx in cutlass.range_constexpr(
+                                    cute.size(tRS_rD_slice)
+                                ):
+                                    tRS_rD_slice[elem_idx] = tRS_rAcc_slice[elem_idx]
+
+                        # Type conversion
+                        tRS_rD_out = cute.make_rmem_tensor(
+                            tRS_rD_layout.shape, self.c_dtype
+                        )
+                        acc_vec = tRS_rD.load()
+                        tRS_rD_out.store(acc_vec.to(self.c_dtype))
+
+                        # Register to shared memory
+                        epi_buffer = epi_buffer + 1
+                        epi_buffer = epi_buffer % cute.size(
+                            tRS_sD, mode=[3]
+                        )
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD_out,
+                            tRS_sD[(None, None, None, epi_buffer)],
+                        )
+                        cute.arch.fence_proxy(
+                            "async.shared",
+                            space="cta",
+                        )
+                        # barrier for sync
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        # Get the global memory coordinate for the current epi tile.
+                        gmem_coord = (epi_m, epi_n)
+                        # Copy from shared memory to global memory
+                        if warp_idx % 4 == 0:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sD[(None, epi_buffer)],
+                                bSG_gD[(None, gmem_coord)],
+                            )
+                            tma_store_pipeline.producer_commit()
+                            tma_store_pipeline.producer_acquire()
+                # Advance to the next work tile
+                tile_sched.advance_to_next_work()
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                math_wg_order_state = math_wg_order_barrier.arrive(math_wg_order_state)
+                # End of for k_tile loop
+            # End of while loop
+        # End of MMA warp group
+        # Start of DMA warp group
+        return
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk: tuple[int, int, int],
+        a_dtype: type[cutlass.Numeric],
+        b_dtype: type[cutlass.Numeric],
+        sf_dtype: type[cutlass.Numeric],
+        sfa_smem_layout: cute.Layout,
+        sfb_smem_layout: cute.Layout,
+        epi_tile: tuple[int, int],
+        c_dtype: type[cutlass.Numeric],
+        smem_capacity: int,
+        occupancy: int,
+    ) -> tuple[int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
+
+        :param tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type tile_shape_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (A/B operand stages, epilogue stages)
+        :rtype: tuple[int, int]
+        """
+
+        epi_stage_max = (tile_shape_mnk[1] // epi_tile[1]) * (
+            tile_shape_mnk[0] // epi_tile[0]
+        )
+        epi_stage = min(epi_stage_max, 4)
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_bytes = c_bytes_per_stage * epi_stage
+
+        # A/B shared memory size
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        # SFA/SFB shared memory size
+        sf_bytes_per_stage = (
+            cute.size(cute.filter_zeros(sfa_smem_layout).shape) * sf_dtype.width // 8
+            + cute.size(cute.filter_zeros(sfb_smem_layout).shape) * sf_dtype.width // 8
+        )
+        # Mbar helpers size
+        mbar_helpers_bytes = 1024
+
+        ab_stage = (
+            (smem_capacity - occupancy * 1024) // occupancy
+            - mbar_helpers_bytes
+            - epi_bytes
+        ) // (ab_bytes_per_stage + sf_bytes_per_stage)
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk: tuple[int, int, int],
+        epi_tile: tuple[int, int],
+        a_dtype: type[cutlass.Numeric],
+        a_layout: cute.Layout,
+        b_dtype: type[cutlass.Numeric],
+        b_layout: cute.Layout,
+        ab_stage: int,
+        c_dtype: type[cutlass.Numeric],
+        c_layout: cute.Layout,
+        epi_stage: int,
+        sf_vec_size: int,
+        tiled_mma: cute.TiledMma,
+    ) -> tuple[cute.ComposedLayout, cute.ComposedLayout, cute.ComposedLayout]:
+        """Create shared memory layouts for A, B, and C tensors.
+
+        :param tile_shape_mnk: CTA tile shape (M,N,K)
+        :type tile_shape_mnk: Tuple[int, int, int]
+        :param epi_tile: Epilogue tile shape
+        :type epi_tile: Tuple[int, int]
+        :param a_dtype: Data type for matrix A
+        :type a_dtype: type[cutlass.Numeric]
+        :param a_layout: Layout for matrix A
+        :type a_layout: Layout
+        :param b_dtype: Data type for matrix B
+        :type b_dtype: type[cutlass.Numeric]
+        :param b_layout: Layout for matrix B
+        :type b_layout: Layout
+        :param ab_stage: Number of stages for A/B tensors
+        :type ab_stage: int
+        :param c_dtype: Data type for output matrix C
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: leading dimension of the output matrix C
+        :type c_layout: Layout
+        :param epi_stage: Number of epilogue stages
+        :type epi_stage: int
+
+        :return: Tuple of shared memory layouts for A, B, and C
+        :rtype: Tuple[cute.ComposedLayout, cute.ComposedLayout, cute.ComposedLayout]
+        """
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+
+        a_is_k_major = a_layout.is_k_major_a()
+        b_is_k_major = b_layout.is_k_major_b()
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                a_layout,
+                a_dtype,
+                a_major_mode_size,
+            ),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        sfa_smem_layout_staged = blockscaled_utils.sm120_make_smem_layout_sfa(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+
+        sfb_smem_layout_staged = blockscaled_utils.sm120_make_smem_layout_sfb(
+            tiled_mma,
+            tile_shape_mnk,
+            sf_vec_size,
+            ab_stage,
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                c_layout,
+                c_dtype,
+                c_major_mode_size,
+            ),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+
+        return (
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            sfa_smem_layout_staged,
+            sfb_smem_layout_staged,
+            epi_smem_layout_staged,
+        )
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        tile_shape_mnk: tuple[int, int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> tuple[int, int, int]:
+        """Compute grid shape for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type tile_shape_mnk: tuple[int, int, int]
+
+        :return: Grid shape for kernel launch.
+        :rtype: tuple[int, int, int]
+        """
+
+        c_shape = cute.slice_(tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (1, 1, 1)
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(
+        tensor_c: cute.Tensor,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: tuple[int, int],
+    ) -> tuple[cute.CopyAtom, cute.Tensor]:
+        """Create TMA atoms and tensors for C tensor storage.
+
+        :param tensor_c: Output tensor C
+        :type tensor_c: cute.Tensor
+        :param epi_smem_layout_staged: Shared memory layout for epilogue
+        :type epi_smem_layout_staged: cute.ComposedLayout
+        :param epi_tile: Epilogue tile shape
+        :type epi_tile: Tuple[int, int]
+
+        :return: TMA atom and tensor for C
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor]
+        """
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+
+        return tma_atom_c, tma_tensor_c
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(
+        tensor: cute.Tensor,
+        smem_layout_staged: cute.ComposedLayout,
+        smem_tile: tuple[int, int],
+        mcast_dim: int,
+        internal_type: Optional[Type[cutlass.Numeric]] = None,
+    ) -> tuple[cute.CopyAtom, cute.Tensor]:
+        """Create TMA atoms and tensors for input tensors.
+
+        :param tensor: Input tensor (A or B)
+        :type tensor: cute.Tensor
+        :param smem_layout_staged: Shared memory layout for the tensor
+        :type smem_layout_staged: cute.ComposedLayout
+        :param smem_tile: Shared memory tile shape
+        :type smem_tile: Tuple[int, int]
+        :param mcast_dim: Multicast dimension
+        :type mcast_dim: int
+
+        :return: TMA atom and tensor
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor]
+        """
+        op = (
+            cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+            op,
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=mcast_dim,
+            internal_type=internal_type,
+        )
+
+        return tma_atom, tma_tensor
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        return is_valid
+
+
+@cute.jit
+def cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+    sf_ref_tensor: cute.Tensor,
+    sf_mma_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from MKL layout to mma specification M(32x4xrest_m)xK(4xrest_k)xL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_mma_tensor[mkl_coord] = sf_ref_tensor[mkl_coord]
+
+
+def run(
+    mnkl: Tuple[int, int, int, int],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    c_dtype: Type[cutlass.Numeric],
+    a_major: str = "k",
+    b_major: str = "k",
+    c_major: str = "n",
+    tile_shape_mnk: Tuple[int, int, int] = (128, 128, 128),
+    epi_tile: Tuple[int, int] = (128, 128),
+    tolerance: float = 1e-01,
+    warmup_iterations: int = 0,
+    iterations: int = 1,
+    skip_ref_check: bool = False,
+    use_cold_l2: bool = False,
+    **kwargs,
+):
+    """Perf-framework-compatible entry point.
+
+    FP4 MMA only supports Float32 accumulation, so acc_dtype is always
+    Float32 regardless of what the caller passes.
+    """
+    return run_bs(
+        mnkl=mnkl,
+        a_dtype=a_dtype,
+        b_dtype=b_dtype,
+        sf_dtype=sf_dtype,
+        sf_vec_size=sf_vec_size,
+        c_dtype=c_dtype,
+        acc_dtype=cutlass.Float32,
+        a_major=a_major,
+        b_major=b_major,
+        c_major=c_major,
+        tile_shape_mnk=tile_shape_mnk,
+        epi_tile=epi_tile,
+        tolerance=tolerance,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+        skip_ref_check=skip_ref_check,
+        use_cold_l2=use_cold_l2,
+    )
+
+
+def run_bs(
+    mnkl: Tuple[int, int, int, int],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    c_dtype: Type[cutlass.Numeric],
+    acc_dtype: Type[cutlass.Numeric],
+    a_major: str,
+    b_major: str,
+    c_major: str,
+    tile_shape_mnk: Tuple[int, int, int],
+    epi_tile: Tuple[int, int],
+    tolerance: float,
+    warmup_iterations: int,
+    iterations: int,
+    skip_ref_check: bool,
+    use_cold_l2: bool = False,
+    **kwargs,
+):
+    import torch
+    import cutlass.torch as cutlass_torch
+
+    print("Running Blackwell Geforce Blockscaled Dense GEMM with:")
+    print(f"mnkl: {mnkl}")
+    print(
+        f"A dtype: {a_dtype}, B dtype: {b_dtype}, A/B scale factor dtype: {sf_dtype}, C dtype: {c_dtype}, Acc dtype: {acc_dtype}"
+    )
+    print(f"Matrix majors - A: {a_major}, B: {b_major}, C: {c_major}")
+    print(f"Tile Shape: {tile_shape_mnk}")
+    print(f"Epilogue tile: {epi_tile}")
+    print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use cold L2: {use_cold_l2}")
+
+    m, n, k, l = mnkl
+
+    if not Sm120BlockScaledGemmKernel.is_valid_tensor_alignment(
+        m, n, k, l, a_dtype, c_dtype, a_major, b_major, c_major
+    ):
+        raise ValueError("Invalid tensor alignment")
+
+    a_dtype = getattr(cutlass, a_dtype) if isinstance(a_dtype, str) else a_dtype
+    b_dtype = getattr(cutlass, b_dtype) if isinstance(b_dtype, str) else b_dtype
+    c_dtype = getattr(cutlass, c_dtype) if isinstance(c_dtype, str) else c_dtype
+    acc_dtype = getattr(cutlass, acc_dtype) if isinstance(acc_dtype, str) else acc_dtype
+
+    # Unpack parameters
+    m, n, k, l = mnkl
+    cluster_shape_mnk = (1, 1, 1)
+
+    # Prepare pytorch tensors: A, B (random from 0 to 2) and C (all zero)
+    if not torch.cuda.is_available():
+        raise RuntimeError("GPU is required to run this example!")
+
+    a_ref = cutlass_torch.matrix(l, m, k, a_major == "m", cutlass.Float32)
+    b_ref = cutlass_torch.matrix(l, n, k, b_major == "n", cutlass.Float32)
+    c_ref = cutlass_torch.matrix(l, m, n, c_major == "m", cutlass.Float32)
+
+    a_tensor, a_torch = cutlass_torch.cute_tensor_like(
+        a_ref, a_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    b_tensor, b_torch = cutlass_torch.cute_tensor_like(
+        b_ref, b_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+    c_tensor, c_torch = cutlass_torch.cute_tensor_like(
+        c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+    )
+
+    # Mark tensor to be byte aligned
+    a_tensor.mark_compact_shape_dynamic(
+        mode=1 if a_major == "k" else 0,
+        stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+        divisibility=2 if a_dtype == cutlass.Float4E2M1FN else 1,
+    )
+    b_tensor.mark_compact_shape_dynamic(
+        mode=1 if b_major == "k" else 0,
+        stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+        divisibility=2 if b_dtype == cutlass.Float4E2M1FN else 1,
+    )
+    c_tensor.mark_compact_shape_dynamic(
+        mode=1 if c_major == "n" else 0,
+        stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+        divisibility=2 if c_dtype == cutlass.Float4E2M1FN else 1,
+    )
+
+    # Create scale factor tensor SFA/SFB
+    def create_scale_factor_tensor(l, mn, k, sf_vec_size, dtype):
+        def ceil_div(a, b):
+            return (a + b - 1) // b
+
+        sf_k = ceil_div(k, sf_vec_size)
+        ref_shape = (l, mn, sf_k)
+
+        # The A, C, and D matrices are row-major whereas the B matrix is column-major.
+        # So only k-major (A/B) is supported.
+
+        atom_m = (32, 4)
+        atom_k = 4
+        mma_shape = (
+            l,
+            ceil_div(mn, atom_m[0] * atom_m[1]),
+            ceil_div(sf_k, atom_k),
+            atom_m[0],
+            atom_m[1],
+            atom_k,
+        )
+
+        ref_permute_order = (1, 2, 0)
+        mma_permute_order = (3, 4, 1, 5, 2, 0)
+
+        # Create f32 ref torch tensor (cpu)
+        ref_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            ref_shape,
+            torch.float32,
+            permute_order=ref_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=1,
+                max_val=3,
+            ),
+        )
+
+        # Create f32 cute torch tensor (cpu)
+        cute_f32_torch_tensor_cpu = cutlass_torch.create_and_permute_torch_tensor(
+            mma_shape,
+            torch.float32,
+            permute_order=mma_permute_order,
+            init_type=cutlass_torch.TensorInitType.RANDOM,
+            init_config=cutlass_torch.RandomInitConfig(
+                min_val=0,
+                max_val=1,
+            ),
+        )
+
+        # convert ref f32 tensor to cute f32 tensor
+        cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+            from_dlpack(ref_f32_torch_tensor_cpu),
+            from_dlpack(cute_f32_torch_tensor_cpu),
+        )
+        cute_f32_torch_tensor = cute_f32_torch_tensor_cpu.cuda()
+
+        # reshape makes memory contiguous
+        ref_f32_torch_tensor_cpu = (
+            ref_f32_torch_tensor_cpu.permute(2, 0, 1)
+            .unsqueeze(-1)
+            .expand(l, mn, sf_k, sf_vec_size)
+            .reshape(l, mn, sf_k * sf_vec_size)
+            .permute(*ref_permute_order)
+        )
+        # prune to mkl for reference check.
+        ref_f32_torch_tensor_cpu = ref_f32_torch_tensor_cpu[:, :k, :]
+
+        # Create dtype cute torch tensor (cpu)
+        cute_tensor, torch_tensor = cutlass_torch.cute_tensor_like(
+            cute_f32_torch_tensor_cpu,
+            dtype,
+            is_dynamic_layout=True,
+            assumed_align=16,
+        )
+
+        # Convert f32 cute tensor to dtype cute tensor
+        cute_tensor = cutlass_torch.convert_cute_tensor(
+            cute_f32_torch_tensor,
+            cute_tensor,
+            dtype,
+            is_dynamic_layout=True,
+        )
+
+        return ref_f32_torch_tensor_cpu, cute_tensor, torch_tensor
+
+    sfa_ref, sfa_tensor, sfa_torch = create_scale_factor_tensor(
+        l, m, k, sf_vec_size, sf_dtype
+    )
+
+    sfb_ref, sfb_tensor, sfb_torch = create_scale_factor_tensor(
+        l, n, k, sf_vec_size, sf_dtype
+    )
+
+    # configure gemm kernel
+    gemm = Sm120BlockScaledGemmKernel(
+        acc_dtype,
+        sf_vec_size,
+        tile_shape_mnk,
+        epi_tile,
+    )
+
+    # Compute max active clusters on current device
+    hardware_info = cutlass.utils.HardwareInfo()
+    max_active_clusters = hardware_info.get_max_active_clusters(
+        cluster_shape_mnk[0] * cluster_shape_mnk[1]
+    )
+
+    # Initialize stream
+    stream = cutlass_torch.default_stream()
+
+    # compile gemm kernel
+    compiled_gemm = cute.compile(
+        gemm,
+        a_tensor,
+        b_tensor,
+        sfa_tensor,
+        sfb_tensor,
+        c_tensor,
+        max_active_clusters,
+        stream,
+    )
+
+    if not skip_ref_check:
+        print("Reference checking ...")
+        # execution
+        compiled_gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, stream)
+        torch.cuda.synchronize()
+
+        # Ref check
+        res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
+        res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
+        ref = torch.einsum("mkl,nkl->mnl", res_a, res_b)
+
+        # Convert c back to f32 for comparison.
+        c_ref_device = c_ref.cuda()
+        cute.testing.convert(
+            c_tensor,
+            from_dlpack(c_ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=(1 if c_major == "n" else 0)
+            ),
+        )
+        c_ref = c_ref_device.cpu()
+
+        if c_dtype in (cutlass.Float32, cutlass.Float16, cutlass.BFloat16):
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        elif c_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN):
+            # Convert ref : f32 -> f8 -> f32
+            ref_f8_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f8 = from_dlpack(ref_f8_, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            ref_f8.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f8)
+            cute.testing.convert(ref_f8, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+        elif c_dtype is cutlass.Float4E2M1FN:
+            # Convert ref : f32 -> f4 -> f32
+            ref_f4_ = torch.empty(*(l, m, n), dtype=torch.uint8, device="cuda").permute(
+                1, 2, 0
+            )
+            ref_f4 = from_dlpack(ref_f4_, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            ref_f4.element_type = c_dtype
+            ref_device = ref.permute(2, 0, 1).contiguous().permute(1, 2, 0).cuda()
+            ref_tensor = from_dlpack(ref_device, assumed_align=16).mark_layout_dynamic(
+                leading_dim=1
+            )
+            cute.testing.convert(ref_tensor, ref_f4)
+            cute.testing.convert(ref_f4, ref_tensor)
+            ref = ref_device.cpu()
+            torch.testing.assert_close(c_ref, ref, atol=tolerance, rtol=1e-02)
+
+    def generate_tensors():
+        a_tensor, _ = cutlass_torch.cute_tensor_like(
+            a_ref, a_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        b_tensor, _ = cutlass_torch.cute_tensor_like(
+            b_ref, b_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        c_tensor, _ = cutlass_torch.cute_tensor_like(
+            c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        # Mark tensor to be byte aligned
+        a_tensor.mark_compact_shape_dynamic(
+            mode=1 if a_major == "k" else 0,
+            stride_order=(2, 0, 1) if a_major == "k" else (2, 1, 0),
+            divisibility=2 if a_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        b_tensor.mark_compact_shape_dynamic(
+            mode=1 if b_major == "k" else 0,
+            stride_order=(2, 0, 1) if b_major == "k" else (2, 1, 0),
+            divisibility=2 if b_dtype == cutlass.Float4E2M1FN else 1,
+        )
+        c_tensor.mark_compact_shape_dynamic(
+            mode=1 if c_major == "n" else 0,
+            stride_order=(2, 0, 1) if c_major == "n" else (2, 1, 0),
+            divisibility=2 if c_dtype == cutlass.Float4E2M1FN else 1,
+        )
+
+        _, sfa_tensor, _ = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
+        _, sfb_tensor, _ = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
+        return cute.testing.JitArguments(
+            a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, stream
+        )
+
+    workspace_count = 1
+    if use_cold_l2:
+        one_workspace_bytes = (
+            a_ref.numel() * a_ref.element_size()
+            + b_ref.numel() * b_ref.element_size()
+            + sfa_ref.numel() * sfa_ref.element_size()
+            + sfb_ref.numel() * sfb_ref.element_size()
+            + c_ref.numel() * c_ref.element_size()
+        )
+        workspace_count = testing.get_workspace_count(
+            one_workspace_bytes, warmup_iterations, iterations
+        )
+
+    exec_time = testing.benchmark(
+        compiled_gemm,
+        workspace_generator=generate_tensors,
+        workspace_count=workspace_count,
+        stream=stream,
+        warmup_iterations=warmup_iterations,
+        iterations=iterations,
+    )
+
+    gflop = 2 * m * n * k / 1e9
+    gflops = gflop / exec_time * 1e6
+
+    print(f"Execution time: {exec_time} microseconds per iteration")
+    print(f"GFLOPS: {gflops}")
+
+    return exec_time  # Return execution time in microseconds
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Example of MxNxKxL GEMM on Blackwell Geforce."
+    )
+
+    parser.add_argument(
+        "--mnkl",
+        type=parse_comma_separated_ints,
+        default=(
+            1024,
+            1024,
+            1024,
+            1,
+        ),
+        help="mnkl dimensions (comma-separated)",
+    )
+    parser.add_argument(
+        "--tile_shape_mnk",
+        type=parse_comma_separated_ints,
+        choices=[
+            (128, 128, 128),
+            (128, 128, 256),
+        ],
+        default=(128, 128, 128),
+        help="CTA tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--epi_tile",
+        type=parse_comma_separated_ints,
+        choices=[
+            (128, 128),
+            (64, 32),
+        ],
+        default=(128, 128),
+        help="Epilogue tile shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--a_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float4E2M1FN,
+    )
+    parser.add_argument(
+        "--b_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float4E2M1FN,
+    )
+    parser.add_argument(
+        "--sf_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float8E4M3FN,
+    )
+    parser.add_argument(
+        "--sf_vec_size",
+        type=int,
+        choices=[16, 32],  # 16 for NVFP4, 32 for MXFP4 / MXFP8.
+        default=16,
+    )
+    parser.add_argument(
+        "--c_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float16,
+    )
+    parser.add_argument(
+        "--acc_dtype",
+        type=cutlass.dtype,
+        default=cutlass.Float32,
+    )
+    parser.add_argument("--a_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--b_major", choices=["k"], type=str, default="k")
+    parser.add_argument("--c_major", choices=["n"], type=str, default="n")
+    parser.add_argument(
+        "--tolerance", type=float, default=1e-01, help="Tolerance for validation"
+    )
+    parser.add_argument(
+        "--warmup_iterations", type=int, default=0, help="Warmup iterations"
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Number of iterations to run the kernel",
+    )
+    parser.add_argument(
+        "--skip_ref_check",
+        action="store_true",
+        default=False,
+        help="Skip reference checking",
+    )
+    parser.add_argument(
+        "--use_cold_l2",
+        action="store_true",
+        default=False,
+        help="Use circular buffer tensor sets to ensure L2 cold cache",
+    )
+
+    args = parser.parse_args()
+
+    if len(args.mnkl) != 4:
+        parser.error("--mnkl must contain exactly 4 values")
+
+    fp4_allowed_tiles = {(128, 128, 128), (128, 128, 256)}
+    fp8_allowed_tiles = {(128, 128, 128)}
+    try:
+        validate_blockscaled_args(args, fp4_allowed_tiles, fp8_allowed_tiles)
+    except ValueError as e:
+        parser.error(str(e))
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    run_bs(
+        args.mnkl,
+        args.a_dtype,
+        args.b_dtype,
+        args.sf_dtype,
+        args.sf_vec_size,
+        args.c_dtype,
+        args.acc_dtype,
+        args.a_major,
+        args.b_major,
+        args.c_major,
+        args.tile_shape_mnk,
+        args.epi_tile,
+        args.tolerance,
+        args.warmup_iterations,
+        args.iterations,
+        args.skip_ref_check,
+        args.use_cold_l2,
+    )
+    print("PASS")


### PR DESCRIPTION
This PR adds two CuTeDSL Blackwell GeForce block-scaled dense GEMM examples:

  - `dense_blockscaled_gemm_persistent_cooperative.py`
  - `dense_blockscaled_gemm_persistent_pingpong.py`

  The examples support persistent scheduling with cooperative and ping-pong warp-group schedules, and add shared dispatch support for SM120 block-scaled MMA variants.

  Supported A/B datatype modes:

  | Mode | A/B dtype | Scale dtype | SF vec size | Supported tile shapes |
  | --- | --- | --- | --- | --- |
  | NVFP4 | E2M1 x E2M1 | E4M3 | 16 | 128x128x128, 128x128x256 |
  | MXFP4 | E2M1 x E2M1 | E8M0 | 32 | 128x128x128, 128x128x256 |
  | MXFP8 | E4M3 x E4M3 | E8M0 | 32 | 128x128x128 |
  | Mixed FP4 x FP8 | E2M1 x E4M3 / E4M3 x E2M1 | E8M0 | 32 | 128x128x128 |

  Measured on RTX PRO 6000 Blackwell Server Edition with M=N=K=8192, warmup=50, iterations=100:

  | Mode | Best TFLOPS |
  | --- | ---: |
  | NVFP4 | ~1629 TFLOPS |
  | MXFP4 | ~1615 TFLOPS |
  | MXFP8 | ~802 TFLOPS |
  | Mixed FP4 x FP8 | ~806 TFLOPS |