### PR TITLE
fix: missing PDL wait on main_sf_load in sm103 blockscaled GEMM

### DIFF
--- a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
@@ -668,14 +668,14 @@ public:
     Tensor accumulators = cutlass::detail::make_sm100_accumulator<AccumulatorPipelineStageCount, IsOverlappingAccum>(
         tiled_mma, acc_shape, EpilogueTile{});
 
+    // Ensure memory ops in this kernel are not done prior to completion of dependent grids.
+    cutlass::arch::wait_on_dependent_grids();
+
 #if 1
     pipeline_init_wait(cluster_size);
 
     if (is_participant.main_ab_load) {
       set_warpgroup_reg_dealloc();
-      // Ensure that the prefetched kernel does not touch
-      // unflushed global memory prior to this instruction
-      cutlass::arch::wait_on_dependent_grids();
 
       bool do_load_order_arrive = is_epi_load_needed;
       auto load_inputs = collective_mainloop.load_ab_init(
@@ -751,8 +751,6 @@ public:
         // See comment below where this variable is updated for a description of
         // why this variable is needed.
         bool requires_clc_query = true;
-
-        cutlass::arch::wait_on_dependent_grids();
 
         do {
           if (requires_clc_query) {
@@ -957,9 +955,6 @@ public:
     }
     else if (not IsNoSmemEpilogue and is_participant.epi_load) {
       set_warpgroup_reg_dealloc();
-      // Ensure that the prefetched kernel does not touch
-      // unflushed global memory prior to this instruction
-      cutlass::arch::wait_on_dependent_grids();
 
       bool do_load_order_wait = true;
       bool do_tail_load = false;


### PR DESCRIPTION
## Summary
- `main_sf_load` was the only load-capable warp branch in [`sm103_blockscaled_gemm_tma_warpspecialized.hpp`](https://github.com/NVIDIA/cutlass/blob/main/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp) without a preceding `cutlass::arch::wait_on_dependent_grids()`. With PDL enabled, `collective_mainloop.load_sf(...)` issues TMA reads of scale-factor (SF) data before the producer kernel's writes are guaranteed flushed to global memory.
- Fix: hoist `wait_on_dependent_grids()` above the warp specialization region so it covers all warp branches (including `main_sf_load`), and remove the now-redundant inner waits in `main_ab_load` / `sched` / `epi_load`. This matches the cleaned-up pattern already in `sm90_gemm_array_tma_warpspecialized_{pingpong,cooperative}.hpp` (1 outer wait, 0 inner).
- Same class of PDL-placement bug as #2962, but in a kernel that wasn't covered by that fix.

## Why this matters
Observed in TensorRT-LLM on GB300 + DeepSeek-R1 NVFP4 forward (kernel: `DeviceGemmFp4GemmSm103_..._KernelTmaWarpSpecializedBlockScaledSm103`). With a diagnostic probe (`ld.global.cv.u8` reads of the SF buffer in `main_sf_load`):

| Config | producer fence | `main_sf_load` wait | GSM8K | Race probe |
|---|:---:|:---:|---:|---|
| Baseline | ✗ | ✗ | 91.93 | 2.31% poison (0x7f) |
| Producer fence only | ✓ | ✗ | 95.34 | 0 / 2.4M poison |
| **This fix (no producer fence)** | ✗ | ✓ | **95.34** | **0 / 3.2M poison** |
| Reproducer run | ✗ | ✓ | 95.11 | **0 / 3.2M poison** |

Two independent runs, **0 poison events across 6.4M probe samples** — the race is fully eliminated on the CUTLASS side without any modification to the producer kernel.

## Related
- #2962 — same class of bug fixed for sm90/sm100 array variants; this PR addresses the sm103 non-array blockscaled variant not covered by that fix.
- Suggest a follow-up cleanup PR to fully remove leftover inner waits in `sm100_*_array_tma_warpspecialized*.hpp` and `sm103_blockscaled_gemm_array_tma_warpspecialized.hpp` (which still retain redundant inner waits compared to the cleaned sm90 array variants).