### PR TITLE
Fix cross-execution-space error: remove CUTLASS_HOST_DEVICE from CudaHostAdapter::memsetDevice

### DIFF
--- a/include/cutlass/cuda_host_adapter.hpp
+++ b/include/cutlass/cuda_host_adapter.hpp
@@ -407,7 +407,6 @@ public:
 
   /// Fills a buffer in Global Memory with a byte sequence copied from host memory
   template<class FillValueType>
-  CUTLASS_HOST_DEVICE
   Status memsetDevice(
       void* destination,
       FillValueType fill_value, 


### PR DESCRIPTION
Summary:
- Remove CUTLASS_HOST_DEVICE from CudaHostAdapter::memsetDevice in include/cutlass/cuda_host_adapter.hpp.
- memsetDevice calls the pure virtual host method memsetDeviceImpl, which implementations use to dispatch to cudaMemsetAsync / cuMemsetD*Async. It must remain host-only.
- Fixes compile failures under --Werror cross-execution-space-call when memsetDevice<T> is instantiated from `__host__ __device__` code paths.

Context:
- memsetDevice was host-only in 3.5.0 ([#1411](https://github.com/NVIDIA/cutlass/pull/1411)). In 3.5.1 ([#1623](https://github.com/NVIDIA/cutlass/pull/1623)), CUTLASS_HOST_DEVICE was added to copy/move/empty/size so CudaHostAdapter could be used in `__host__ __device__` code. memsetDevice received the same macro by mistake even though it dispatches to virtual host APIs (memsetDeviceImpl → cudaMemsetAsync / cuMemsetD*Async). 
- Callers (zero_workspace, fill_workspace in workspace.h) are host-only.

Error observed when compiling with --Werror cross-execution-space-call:
 
```text
error: calling a `__host__` function("memsetDeviceImpl")
from a `__host__ __device__` function("memsetDevice") is not allowed
```


Fixes downstream build failures (e.g. PyTorch rowwise FP8 CUTLASS on Windows with --Werror cross-execution-space-call).

cc @nkhasbag-nv 
