### PR TITLE
feat: Add BF16 float-accumulator TensorOp epilogue specialization

### DIFF
--- a/include/cutlass/epilogue/threadblock/default_epilogue_tensor_op.h
+++ b/include/cutlass/epilogue/threadblock/default_epilogue_tensor_op.h
@@ -225,6 +225,44 @@ struct DefaultIteratorsTensorOp<
   static int const kFragmentsPerIteration = 2;
 };
 
+/// Partial specialization for bfloat16 <= float x 8 epilogues avoids shared memory bank conflicts.
+template <
+  typename ThreadblockShape,
+  typename WarpShape,
+  typename InstructionShape,
+  typename ThreadMap
+>
+struct DefaultIteratorsTensorOp<
+  bfloat16_t,
+  float,
+  8,
+  ThreadblockShape,
+  WarpShape,
+  InstructionShape,
+  ThreadMap> {
+
+  using WarpTileIterator = cutlass::epilogue::warp::TileIteratorTensorOpMixed<
+    WarpShape,
+    InstructionShape,
+    float,
+    32,
+    16,
+    8,
+    8
+  >;
+
+  using SharedLoadIterator = cutlass::epilogue::threadblock::SharedLoadIteratorMixed<
+    ThreadMap,
+    float,
+    32,
+    16,
+    8,
+    8
+  >;
+
+  static int const kFragmentsPerIteration = 2;
+};
+
 /// Partial specialization for half <= int32_t x 8 epilogues avoids shared memory bank conflicts.
 template <
   typename ThreadblockShape,


### PR DESCRIPTION
## Summary

This PR adds a `DefaultIteratorsTensorOp<bfloat16_t, float, 8, ...>` specialization for TensorOp epilogues.

CUTLASS already has a `half_t, float, 8` specialization that uses `TileIteratorTensorOpMixed` and `SharedLoadIteratorMixed` to optimize mixed-precision epilogues with FP32 accumulators and 16-bit outputs. BF16 output with FP32 accumulators has the same 32-bit accumulator / 16-bit output / 8-elements-per-access structure, but currently falls back to the generic iterator path.

This patch mirrors the existing `half_t, float, 8` specialization for `bfloat16_t, float, 8`.

## Motivation

For mixed-precision TensorOp epilogues where accumulators are FP32 and outputs are 16-bit, the mixed iterator path uses a shared-memory layout designed to avoid bank conflicts. BF16 output should be able to use the same iterator structure as FP16 output.

## Changes

- Add `DefaultIteratorsTensorOp<bfloat16_t, float, 8, ...>`
- Use `TileIteratorTensorOpMixed<..., float, 32, 16, 8, 8>`
- Use `SharedLoadIteratorMixed<..., float, 32, 16, 8, 8>`
- Set `kFragmentsPerIteration = 2`, matching the existing `half_t, float, 8` specialization

## Notes

This does not change the output operator, numerical conversion, or GEMM mainloop. It only changes the epilogue shared-memory staging iterator selection for this BF16 mixed-precision case.
