### PR TITLE
Fix CUDA Device import for distributed CuTeDSL examples

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_one_shot_lamport.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_one_shot_lamport.py
@@ -34,7 +34,10 @@ import numpy as np
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 import cuda.bindings.driver as cuda
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 import cutlass

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_simple.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_simple.py
@@ -35,7 +35,10 @@ import argparse
 import numpy as np
 import torch
 import torch.distributed as dist
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 import cutlass

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_tma.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_tma.py
@@ -480,7 +480,10 @@ import math
 import numpy as np
 import torch
 import torch.distributed as dist
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 from cutlass.cute.runtime import from_dlpack

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_two_shot_multimem.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/all_reduce_two_shot_multimem.py
@@ -34,7 +34,10 @@ import argparse
 import numpy as np
 import torch
 import torch.distributed as dist
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 import cutlass

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/distributed_all_gather_gemm_blackwell.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/distributed_all_gather_gemm_blackwell.py
@@ -36,7 +36,10 @@ import torch.distributed._symmetric_memory as symm_mem
 import torch.distributed as dist
 import cuda.bindings.driver as cuda
 from cuda.bindings import driver
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 import cutlass

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/distributed_gemm_all_reduce_blackwell.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/distributed_gemm_all_reduce_blackwell.py
@@ -34,7 +34,10 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import cuda.bindings.driver as cuda
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 import cutlass

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/distributed_gemm_reduce_scatter_blackwell.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/distributed/distributed_gemm_reduce_scatter_blackwell.py
@@ -34,7 +34,10 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import cuda.bindings.driver as cuda
-from cuda.core.experimental import Device
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
 from cuda.pathfinder import load_nvidia_dynamic_lib
 
 import cutlass


### PR DESCRIPTION
Description

This PR fixes distributed CuTeDSL example failures caused by newer cuda-core packages no longer exposing Device through cuda.core.experimental.

Root cause:

The distributed examples imported Device from cuda.core.experimental.
Newer cuda-core versions promote this API to cuda.core.
As a result, the examples failed at import time with:
ModuleNotFoundError: No module named 'cuda.core.experimental'
Fix:

Prefer importing Device from cuda.core.
Fall back to cuda.core.experimental for older CUDA Python environments.