### PR TITLE
Fix print_tensor self-contained include

### DIFF
--- a/include/cute/util/print_tensor.hpp
+++ b/include/cute/util/print_tensor.hpp
@@ -33,6 +33,7 @@
 #include <cute/config.hpp>           // CUTE_HOST_DEVICE
 
 #include <cute/layout.hpp>
+#include <cute/pointer_flagged.hpp>
 #include <cute/tensor_impl.hpp>
 
 namespace cute

--- a/test/self_contained_includes/CMakeLists.txt
+++ b/test/self_contained_includes/CMakeLists.txt
@@ -53,6 +53,7 @@ set(header_files_to_check
     cute/tensor.hpp
     cute/tensor_impl.hpp
     cute/underscore.hpp
+    cute/util/print_tensor.hpp
     # cute/algorithm
     cute/algorithm/axpby.hpp
     cute/algorithm/clear.hpp
@@ -275,4 +276,3 @@ endforeach()
 
 # build all generated .cu files into a single library
 cutlass_add_library(test_self_contained_includes MODULE ${_gen_source_files})
-


### PR DESCRIPTION
## Summary
- Include `cute/pointer_flagged.hpp` directly from `cute/util/print_tensor.hpp` for `smem_ptr_flag_bits`.
- Add `cute/util/print_tensor.hpp` to the self-contained include checks.

Fixes #3205.

## Testing
- `git diff --check`
- Not run: self-contained include target, because this local environment does not have nvcc/CUDA headers installed.