### PR TITLE
Fix CUDA 12.8 __nv_atomic_load_n call signature in SubbyteReference

### DIFF
--- a/include/cutlass/subbyte_reference.h
+++ b/include/cutlass/subbyte_reference.h
@@ -456,7 +456,7 @@ public:
     //
     Storage assumed;
 #if (__CUDACC_VER_MAJOR__ > 12) || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
-    Storage original = __nv_atomic_load_n(ptr_, __NV_ATOMIC_RELAXED);
+    Storage original = __nv_atomic_load_n(ptr_, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE);
 #else
     Storage original = *const_cast<Storage const volatile *>(ptr_);
 #endif


### PR DESCRIPTION
### Summary
This PR fixes a CUDA 12.8 compatibility issue in SubbyteReference.

### Problem
Building CUTLASS with CUDA 12.8 fails with:
`too few arguments in function call at subbyte_reference.h around __nv_atomic_load_n.
`
### Root cause
In CUDA 12.8, __nv_atomic_load_n requires a thread scope argument.
The existing code only passes memory order.

### Fix
For CUDA >= 12.8, update:
`_nv_atomic_load_n(ptr, __NV_ATOMIC_RELAXED)
`
to:
`_nv_atomic_load_n(ptr, __NV_ATOMIC_RELAXED, __NV_THREAD_SCOPE_DEVICE)
`
### Validation

```
cmake .. -DCUTLASS_NVCC_ARCHS="90a"
make -j32
```
Before fix: build failed in gemm_int4.cu.
After fix: build succeeds.