### PR TITLE
Fix dense_gemm_fp8_2xacc validation codes

### DIFF
--- a/examples/python/CuTeDSL/cute/hopper/kernel/dense_gemm/dense_gemm_fp8_2xacc.py
+++ b/examples/python/CuTeDSL/cute/hopper/kernel/dense_gemm/dense_gemm_fp8_2xacc.py
@@ -1295,7 +1295,9 @@ def run(
         ref_d = ref_torch_gpu.cpu()
 
         # Assert close results
-        torch.testing.assert_close(d_torch_gpu.cpu(), ref_d, atol=tolerance, rtol=1e-03)
+        torch.testing.assert_close(
+            d_torch_gpu.cpu().float(), ref_d.float(), atol=tolerance, rtol=1e-03
+        )
 
     def generate_tensors():
         a_tensor_workspace, _ = cutlass_torch.cute_tensor_like(


### PR DESCRIPTION
torch.testing.assert_close in newer version refuses non-zero atol / rtol for "low dimensional float" dtypes — FP8 in particular. It now requires exact bitwise comparison (rtol=0.0, atol=0.0) for torch.float8_e4m3fn / float8_e5m2. Older versions silently accepted tolerance args and did tolerance-based comparison.

Cast the dtype back to fp32 for fp8 case before the validation.
