### PR TITLE
Enable `smem_merge_branch_allocs` option on branched mega-kernel examples

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell/tutorial/tutorial_gemm/fp16_gemm_4.py
+++ b/examples/python/CuTeDSL/cute/blackwell/tutorial/tutorial_gemm/fp16_gemm_4.py
@@ -687,6 +687,8 @@ def kernel(
     )
 
     # As for now, only support preferred cluster kernel via the mega-kernel approach
+    # mega-kernel approach has 2 mutually exclusive code branches, only one path runs per launch,
+    # specify `smem_merge_branch_allocs=True` at launch to enable shared memory reuse between two paths
     if is_preferred_cluster:
         cluster_specific_kernel(
             tiled_mma,
@@ -969,6 +971,7 @@ def host_function(
         block=[224, 1, 1] if use_clc_dynamic_scheduler else [192, 1, 1],
         cluster=preferred_cluster_shape_mnk,
         fallback_cluster=fallback_cluster_shape_mnk,
+        smem_merge_branch_allocs=True,
     )
 
 


### PR DESCRIPTION
4.6.dev version align kernel shared memory allocator default behavior with CUDA C++ (i.e. all static smem allocation will be counted). 

Since mega-kernel approach has 2 mutually exclusive code branches, only one path runs per launch, thus new launch option `smem_merge_branch_allocs` is introduced for mega-kernel to enable shared memory reuse between two paths.

```
OFF (default)          ON
┌────────────┐         ┌────────────┐ ┐
│ Branch A   │ 512B    │ Branch A   │ │
├────────────┤         ├────────────┤ ├─ reuse same region
│ Branch B   │ 512B    │ Branch B   │ │
└────────────┘         └────────────┘ ┘
Total = 1024B          Total = 512B  
```
