### PR TITLE
Fix QNX fill_workspace status

### DIFF
--- a/include/cutlass/workspace.h
+++ b/include/cutlass/workspace.h
@@ -118,11 +118,10 @@ fill_workspace(void* workspace, T fill_value, size_t fill_count, cudaStream_t st
     else {
       return Status::kErrorInternal;
     }
-#else
+#elif !defined(__QNX__)
     CUdeviceptr d_workspace = reinterpret_cast<CUdeviceptr>(workspace);
     CUresult result = CUDA_SUCCESS;
 
-#ifndef __QNX__
     if (sizeof(T) == 4) {
       result = cuMemsetD32Async(d_workspace, reinterpret_cast<uint32_t&>(fill_value), fill_count, stream);
     }
@@ -132,19 +131,21 @@ fill_workspace(void* workspace, T fill_value, size_t fill_count, cudaStream_t st
     else if (sizeof(T) == 1) {
       result = cuMemsetD8Async(d_workspace, reinterpret_cast<uint8_t&>(fill_value), fill_count, stream);
     }
-#endif
 
     if (CUDA_SUCCESS != result) {
-      const char** error_string_ptr = nullptr;
-      (void) cuGetErrorString(result, error_string_ptr);
-      if (error_string_ptr != nullptr) {
-        CUTLASS_TRACE_HOST("  cuMemsetD" << sizeof(T) * 8 << "Async() returned error " << *error_string_ptr);
+      const char* error_string = nullptr;
+      (void) cuGetErrorString(result, &error_string);
+      if (error_string != nullptr) {
+        CUTLASS_TRACE_HOST("  cuMemsetD" << sizeof(T) * 8 << "Async() returned error " << error_string);
       }
       else {
         CUTLASS_TRACE_HOST("  cuMemsetD" << sizeof(T) * 8 << "Async() returned unrecognized error");
       }
       return Status::kErrorInternal;
     }
+#else
+    CUTLASS_TRACE_HOST("  fill_workspace() is unsupported on QNX without a CUDA host adapter");
+    return Status::kErrorInternal;
 #endif
   }
 


### PR DESCRIPTION
## Summary

`fill_workspace()` currently skips the CUDA driver memset calls on QNX, but leaves `result` initialized to `CUDA_SUCCESS`. That means a non-empty fill can be reported as successful even though the direct-CUDA path did not write the workspace.

This changes the non-adapter QNX path to return `Status::kErrorInternal` instead of silently succeeding. The CUDA host adapter path is left unchanged, so QNX builds that enable and pass an adapter can still use that route.

I also fixed the nearby `cuGetErrorString()` call to pass the address of a `const char*`, instead of passing a null `const char**`.

## Validation

- `git diff --check`
- source-level check that the QNX direct path returns an error and `cuGetErrorString()` receives `&error_string`
