### PR TITLE
Fixed integer overflow in make_cute_packed_stride batch stride computation

### DIFF
--- a/tools/util/include/cutlass/util/packed_stride.hpp
+++ b/tools/util/include/cutlass/util/packed_stride.hpp
@@ -82,7 +82,7 @@ make_cute_packed_stride(cute::Stride<IntT, cute::Int<1>, int64_t> s, cute::Shape
   cute::get<0>(s_copy) = static_cast<IntT>(cute::get<1>(shape_MKL));
   int batch_count =  cute::get<2>(shape_MKL);
   if (batch_count > 1) {
-    cute::get<2>(s_copy) = static_cast<IntT>(cute::get<0>(shape_MKL) * cute::get<1>(shape_MKL));
+    cute::get<2>(s_copy) = static_cast<IntT>(cute::get<0>(shape_MKL)) * static_cast<IntT>(cute::get<1>(shape_MKL));
   }
   else {
     cute::get<2>(s_copy) = static_cast<IntT>(0);
@@ -100,7 +100,7 @@ make_cute_packed_stride(cute::Stride<cute::Int<1>, IntT, int64_t> s, cute::Shape
   cute::get<1>(s_copy) = static_cast<IntT>(cute::get<0>(shape_MKL));
   int batch_count =  cute::get<2>(shape_MKL);
   if (batch_count > 1) {
-    cute::get<2>(s_copy) = static_cast<IntT>(cute::get<0>(shape_MKL) * cute::get<1>(shape_MKL));
+    cute::get<2>(s_copy) = static_cast<IntT>(cute::get<0>(shape_MKL)) * static_cast<IntT>(cute::get<1>(shape_MKL));
   }
   else {
     cute::get<2>(s_copy) = static_cast<IntT>(0);


### PR DESCRIPTION
Problem: make_cute_packed_stride computes the batch stride as get<0>(shape_MKL) * get<1>(shape_MKL) where both operands are int32. For large matrix dimensions (e.g. 49152 × 65536 = 3,221,225,472) this overflows int32 before the cast to IntT occurs, producing a negative batch stride.

Fix: Cast each operand to `IntT` before multiplying so the multiplication occurs in 64-bit space. Applied to both affected overloads.

Fixes #3269