### PR TITLE
[CuTeDSL] Fix unsigned integer constant lowering above INT64_MAX (#3312)

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/typing.py
+++ b/python/CuTeDSL/cutlass/base_dsl/typing.py
@@ -849,6 +849,27 @@ def _binary_op_type_promote(
         return a.to(b.dtype), b, b.dtype
 
 
+def _lowered_const_value(operand: "Numeric") -> Any:
+    """Return a compile-time numeric's value, adjusted for MLIR lowering.
+
+    ``IntegerAttr.get()`` takes a signed C ``int64_t``, so an unsigned integer
+    constant whose magnitude exceeds ``INT64_MAX`` must be lowered as its
+    two's-complement signed value (same bit pattern); otherwise the binding
+    raises ``TypeError: get(): incompatible function arguments``. Non-integer
+    and in-range values are returned unchanged. (#3312)
+    """
+    value = operand.value
+    if (
+        getattr(type(operand), "signed", None) is False
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+        and operand.dtype.width <= 64
+        and value >= (1 << 63)
+    ):
+        value -= 1 << operand.dtype.width
+    return value
+
+
 def _binary_op(
     op: Callable[..., Any],
     promote_operand: bool = True,
@@ -931,13 +952,13 @@ def _binary_op(
         if isinstance(lhs.value, ArithValue) and isinstance(lhs, Integer):
             lhs_val = lhs.value.with_signedness(lhs.signed)
         else:
-            lhs_val = lhs.value
+            lhs_val = _lowered_const_value(lhs)
 
         rhs_val: Union[bool, int, float, ir.Value, ArithValue]
         if isinstance(rhs.value, ArithValue) and isinstance(rhs, Integer):
             rhs_val = rhs.value.with_signedness(rhs.signed)
         else:
-            rhs_val = rhs.value
+            rhs_val = _lowered_const_value(rhs)
 
         if flip:
             lhs_val, rhs_val = rhs_val, lhs_val
@@ -1096,7 +1117,10 @@ class Numeric(metaclass=NumericMeta, is_abstract=True):
         elif dtype is ir.Value:
             if isinstance(self.value, (int, float, bool)):
                 res = arith_helper.const(
-                    self.value, self.dtype.mlir_type, loc=loc, ip=ip
+                    _lowered_const_value(self),
+                    self.dtype.mlir_type,
+                    loc=loc,
+                    ip=ip,
                 )
             elif isinstance(self.value, ir.Value):
                 res = self.value

--- a/test/python/CuTeDSL/test_unsigned_constant.py
+++ b/test/python/CuTeDSL/test_unsigned_constant.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for lowering integer constants to MLIR.
+
+Regression for #3312: an unsigned integer constant whose magnitude exceeds
+``INT64_MAX`` (e.g. ``Uint64(2**64 - 1)``) used to raise
+``TypeError: get(): incompatible function arguments`` during IR emission,
+because ``IntegerAttr.get()`` takes a signed C ``int64_t``. Such values must
+be lowered as their two's-complement signed representation (same bit pattern).
+"""
+
+import unittest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int64, Uint32, Uint64
+
+
+def _compile_constant(dtype, value):
+    """Compile a nullary kernel that materializes ``dtype(value)`` into IR."""
+
+    @cute.jit
+    def entry():
+        # Forcing the constant into an MLIR value is the path that used to
+        # raise for unsigned magnitudes above INT64_MAX.
+        dtype(value).ir_value()
+
+    cute.compile(entry)
+
+
+class TestIntegerConstantLowering(unittest.TestCase):
+    def test_uint64_above_int64_max(self):
+        """The reported failing range: Uint64 magnitudes > INT64_MAX."""
+        for value in (2**63, 2**63 + 12345, 2**64 - 1):
+            with self.subTest(value=value):
+                _compile_constant(Uint64, value)
+
+    def test_uint64_within_int64_range(self):
+        """Uint64 values that already fit a signed int64 keep working."""
+        for value in (0, 1, 2**63 - 1):
+            with self.subTest(value=value):
+                _compile_constant(Uint64, value)
+
+    def test_other_integer_types_unaffected(self):
+        """Narrower unsigned and signed types are unchanged."""
+        _compile_constant(Uint32, 2**32 - 1)
+        _compile_constant(Int64, -1)
+        _compile_constant(Int64, 2**63 - 1)
+
+    def test_uint64_above_int64_max_in_binary_ops(self):
+        """The same overflow reached through binary operators on a dynamic
+        operand: masking / offsetting / comparing a Uint64 against a literal
+        above INT64_MAX (e.g. an all-ones 0xFFFFFFFFFFFFFFFF mask). The
+        Numeric.to path fix alone does not cover this operator path. (#3312)"""
+
+        @cute.jit
+        def mask(a: Uint64):
+            (a | (2**64 - 1)).ir_value()
+
+        @cute.jit
+        def offset(a: Uint64):
+            (a + (2**63)).ir_value()
+
+        @cute.jit
+        def compare(a: Uint64):
+            (a < (2**63 + 7)).ir_value()
+
+        cute.compile(mask, Uint64(1))
+        cute.compile(offset, Uint64(1))
+        cute.compile(compare, Uint64(1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Lowering an unsigned-integer DSL constant whose magnitude exceeds `INT64_MAX` raises a `TypeError` during IR emission. `IntegerAttr.get()` takes a signed C `int64_t`, so any value `> INT64_MAX` (i.e. `>= 2**63`) is rejected. `Uint32(2**32-1)` happened to work only because `4294967295 < INT64_MAX`, and signed types are always in range.

Fixes #3312.

This affects **two distinct lowering paths**:

```python
import cutlass.cute as cute
from cutlass import Uint64

@cute.jit
def f(a: Uint64):
    Uint64(2**64 - 1).ir_value()   # path 1: standalone constant
    (a | (2**64 - 1)).ir_value()   # path 2: all-ones mask via an operator

cute.compile(f, Uint64(1))
# TypeError: get(): incompatible function arguments.
```

1. **`Numeric.to(ir.Value)` / `.ir_value()`** — a standalone constant (the case in the issue).
2. **`_binary_op`** — a compile-time unsigned operand combined with a dynamic value, e.g. `a | 0xFFFFFFFFFFFFFFFF` (all-ones mask), `a + (2**63)`, or a comparison `a < (2**63 + 7)`. The operand's raw `.value` is handed to the operator, which builds the constant — so a fix in `Numeric.to` alone does **not** cover it.

## Fix

Add a shared `_lowered_const_value` helper that returns such constants as their **two's-complement signed value** (identical bit pattern), and call it from both paths. Scoped narrowly to unsigned integer types of width ≤ 64 whose value `>= 2**63`, so signed integers, floats, `bool`, and narrower / in-range unsigned values are byte-for-byte unchanged.

```python
def _lowered_const_value(operand):
    value = operand.value
    if (getattr(type(operand), "signed", None) is False
            and isinstance(value, int) and not isinstance(value, bool)
            and operand.dtype.width <= 64 and value >= (1 << 63)):
        value -= 1 << operand.dtype.width
    return value
```

(`Uint128`/`Int128` magnitudes above `INT64_MAX` are a separate concern — they exceed the `int64_t` parameter even after wrapping and would need binding-level support — so they are intentionally out of scope here.)

## Test

Adds `test/python/CuTeDSL/test_unsigned_constant.py` covering Uint64 above `INT64_MAX` via both the standalone-constant path and the binary-operator path (mask / offset / comparison), plus Uint64-in-range and Uint32/Int64 regressions.

## Validation

Validated against the released CuTe DSL `4.5.2` wheel, whose `Numeric.to` and `_binary_op` paths are identical to this file at the fix sites:
- On the unmodified wheel, both the standalone and binary-operator test cases fail with exactly the reported `TypeError`.
- Applying this patch to the wheel makes all cases compile cleanly; Uint32/Int64/in-range cases are unaffected.

The reproduction and fix are host-side IR construction (GPU-free); the original report is on sm_120 (RTX PRO 6000).

 Generated with [Claude Code](https://claude.com/claude-code)
