### PR TITLE
[CuTeDSL] Fix cute.is_major crash on List[int] mode

### DIFF
--- a/python/CuTeDSL/cutlass/cute/core.py
+++ b/python/CuTeDSL/cutlass/cute/core.py
@@ -2191,7 +2191,9 @@ def is_major(
     """
     Check whether a mode in stride is the major mode.
     """
-    first_stride = front(get(stride, mode=[mode], loc=loc, ip=ip), loc=loc, ip=ip)
+    if isinstance(mode, int):
+        mode = [mode]
+    first_stride = front(get(stride, mode=mode, loc=loc, ip=ip), loc=loc, ip=ip)
     if is_dynamic_expression(first_stride):
         return False
     return True if first_stride == 1 else False

--- a/test/python/CuTeDSL/test_is_major_list_mode.py
+++ b/test/python/CuTeDSL/test_is_major_list_mode.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for cute.is_major mode argument handling.
+
+is_major is typed `mode: Union[int, List[int]]`, but it wrapped its argument
+as `get(stride, mode=[mode])`, which double-listed a list input and raised
+`TypeError: '<=' not supported between instances of 'int' and 'list'` for any
+List[int] mode. A single int mode and its single-element list form must agree,
+and a hierarchical list path must not crash.
+"""
+
+import unittest
+
+from cutlass.cute import is_major
+
+
+class TestIsMajorListMode(unittest.TestCase):
+    def test_single_mode_int_and_list_agree(self):
+        for stride in ((8, 1), (1, 8)):
+            for m in (0, 1):
+                self.assertEqual(
+                    is_major([m], stride),
+                    is_major(m, stride),
+                    msg=f"mode {m} on stride {stride}",
+                )
+
+    def test_hierarchical_list_mode(self):
+        # A multi-index path into a nested stride must resolve, not crash.
+        self.assertIsInstance(is_major([0, 1], ((8, 1), 4)), bool)
+        self.assertIsInstance(is_major([0, 0], ((8, 1), 4)), bool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`cute.is_major` is a public, exported API typed `mode: Union[int, List[int]]`, but it crashes on every `List[int]` mode:

```python
from cutlass.cute import is_major

is_major(1, (8, 1))          # True   (int works)
is_major([1], (8, 1))        # TypeError: '<=' not supported between instances of 'int' and 'list'
is_major([0, 1], ((8, 1), 4))  # TypeError  (same)
```

## Root cause

`core.py` builds the lookup as `get(stride, mode=[mode])`. But `get(..., mode=...)` already takes a list of hierarchical indices, so:
- an `int` mode becomes `[0]` — fine;
- a `List[int]` mode becomes a nested list `[[0, 1]]`, and `get` then compares `rank(input) <= mode[0]` → `int <= list` → `TypeError`.

The two internal callers (`tensor.py`) only ever pass an `int` (guarded by `mode == 0`), which is why the list path went unnoticed despite being advertised in the signature (sibling APIs like `E()`/`select()` genuinely accept list modes).

## Fix

Normalize an `int` mode to a list once, then pass it through — mirroring the existing idiom in `E()` (`if isinstance(mode, int): mode = [mode]`). The `int` path is unchanged; `List[int]` modes now resolve.

## Test

Adds `test/python/CuTeDSL/test_is_major_list_mode.py`: a single int mode and its single-element list form must agree, and a hierarchical list path must return a bool without crashing.

## Validation

Validated against the released CuTe DSL `4.5.2` wheel (identical to this file at the fix site): on the unmodified wheel both tests fail with the reported `TypeError`; with the patch they pass (`is_major([1], s) == is_major(1, s)`, `[0,1]` resolves). GPU-free — `is_major` on static strides returns a Python bool with no kernel launch.

 Generated with [Claude Code](https://claude.com/claude-code)
