### PR TITLE
[CuTeDSL] Fix make_ptr ZeroDivisionError on sub-byte dtypes

### DIFF
--- a/python/CuTeDSL/cutlass/cute/runtime.py
+++ b/python/CuTeDSL/cutlass/cute/runtime.py
@@ -79,7 +79,10 @@ class _Pointer(Pointer):
         self._addr_space = mem_space
 
         if assumed_align is None:
-            self._assumed_align = dtype.width // 8
+            # Sub-byte dtypes (e.g. Float4E2M1FN, Int4) have width < 8, so
+            # ``width // 8`` is 0 and the alignment check below divides by zero.
+            # Floor at 1 byte, mirroring make_ptr in cute/core.py.
+            self._assumed_align = max(1, dtype.width // 8)
         else:
             self._assumed_align = assumed_align
 

--- a/test/python/CuTeDSL/test_make_ptr_subbyte.py
+++ b/test/python/CuTeDSL/test_make_ptr_subbyte.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for cute.runtime.make_ptr with sub-byte element types.
+
+make_ptr derived the pointer's assumed alignment as `dtype.width // 8`, which
+is 0 for sub-byte element types (Float4E2M1FN, Int4, Float6*); the subsequent
+`int(ptr) % assumed_align` alignment check then raised ZeroDivisionError on
+every call. Such pointers should default to 1-byte alignment, matching the
+compile-time make_ptr in cute/core.py.
+"""
+
+import unittest
+
+import cutlass
+from cutlass.cute.runtime import make_ptr
+
+
+class TestMakePtrSubByte(unittest.TestCase):
+    def test_sub_byte_dtypes(self):
+        for dtype in (
+            cutlass.Float4E2M1FN,
+            cutlass.Int4,
+            cutlass.Float6E2M3FN,
+            cutlass.Float6E3M2FN,
+        ):
+            with self.subTest(dtype=dtype.__name__):
+                # Must not raise ZeroDivisionError.
+                self.assertIsNotNone(make_ptr(dtype, 0x1000))
+
+    def test_byte_dtypes_unchanged(self):
+        for dtype in (cutlass.Int8, cutlass.Float16, cutlass.Float32):
+            with self.subTest(dtype=dtype.__name__):
+                self.assertIsNotNone(make_ptr(dtype, 0x1000))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`cutlass.cute.runtime.make_ptr` crashes with `ZeroDivisionError` for every sub-byte element type:

```python
import cutlass
from cutlass.cute.runtime import make_ptr

make_ptr(cutlass.Float32, 0x1000)       # OK
make_ptr(cutlass.Float4E2M1FN, 0x1000)  # ZeroDivisionError: integer division or modulo by zero
make_ptr(cutlass.Int4, 0x1000)          # ZeroDivisionError
```

## Root cause

`_Pointer.__init__` (`cute/runtime.py`) derives the assumed alignment as `dtype.width // 8`. For sub-byte dtypes (`Float4E2M1FN`/`Int4` width 4, `Float6E2M3FN`/`Float6E3M2FN` width 6) that is `0`, and the next line — `assert int(ptr) % self._assumed_align == 0` — then divides by zero for any address. The compile-time sibling `make_ptr` in `cute/core.py` already guards this with `max(1, dtype.width // 8)`; the runtime path dropped the floor.

## Fix

Floor the assumed alignment at 1 byte, mirroring `cute/core.py`:

```python
self._assumed_align = max(1, dtype.width // 8)
```

Byte-aligned dtypes are unchanged (`Float32` → 4); sub-byte dtypes default to 1-byte alignment.

## Test

Adds `test/python/CuTeDSL/test_make_ptr_subbyte.py`: `make_ptr` over the sub-byte dtypes must not raise, and byte-aligned dtypes still work.

## Validation

Validated against the released CuTe DSL `4.5.2` wheel (identical to this file at the fix site): on the unmodified wheel all four sub-byte cases raise the reported `ZeroDivisionError`; with the patch they all succeed and byte-aligned types are unaffected. GPU-free — `make_ptr` is pure host code.

 Generated with [Claude Code](https://claude.com/claude-code)
