### PR TITLE
Fix typo in 0t_mma_atom.md

### DIFF
--- a/media/docs/cpp/cute/0t_mma_atom.md
+++ b/media/docs/cpp/cute/0t_mma_atom.md
@@ -403,7 +403,7 @@ using CLayout = Layout<Shape <Shape <  _4, _8, ...>, Shape < _2, _2>>,
                        Stride<Stride<_128, _1, ...>, Stride<_64, _8>>>;
 ```
 
-Finally, we get this entire pattern repeating four times, once for each warp, down the `M`-mode starting at `(m,n) = (16,0) = 16`, where four core matrices that belong to the same warp are stacked on top of each other. This makes the size of the final sub-mode of `thrID` 4 (there are four warps) with a stride of `16` (to take us to coordinate `(16,0) = 16`).
+Finally, we get this entire pattern repeating four times, once for each warp, down the `M`-mode starting at `(m,n) = (16,0) = 16`, where two core matrices that belong to the same warp are stacked on top of each other. This makes the size of the final sub-mode of `thrID` 4 (there are four warps) with a stride of `16` (to take us to coordinate `(16,0) = 16`).
 
 ```cpp
 // (T128,V4) -> (M64,N8)


### PR DESCRIPTION
I believe there should be two core matrices that belong to the same warp and then we repeat these two matrices 4 times.
