### PR TITLE
Return error for invalid runtime datatypes

### DIFF
--- a/tools/library/src/blockwise_gemm_operation_3x.hpp
+++ b/tools/library/src/blockwise_gemm_operation_3x.hpp
@@ -256,13 +256,13 @@ protected:
       if (iter_runtime_a != mapping.end()) {
           operator_args.mainloop.runtime_data_type_a = iter_runtime_a->second;
       } else {
-        assert("invalid runtime argument for datatype A!");
+        return Status::kErrorInvalidProblem;
       }
 
       if (iter_runtime_b != mapping.end()) {
           operator_args.mainloop.runtime_data_type_b = iter_runtime_b->second;
       } else {
-        assert("invalid runtime argument for datatype B!");
+        return Status::kErrorInvalidProblem;
       }
 
    }

--- a/tools/library/src/gemm_operation_3x.hpp
+++ b/tools/library/src/gemm_operation_3x.hpp
@@ -387,13 +387,13 @@ protected:
       if (iter_runtime_a != mapping.end()) {
           operator_args.mainloop.runtime_data_type_a = iter_runtime_a->second;
       } else {
-        assert("invalid runtime argument for datatype A!");
+        return Status::kErrorInvalidProblem;
       }
 
       if (iter_runtime_b != mapping.end()) {
           operator_args.mainloop.runtime_data_type_b = iter_runtime_b->second;
       } else {
-        assert("invalid runtime argument for datatype B!");
+        return Status::kErrorInvalidProblem;
       }
 
     }

--- a/tools/library/src/sparse_gemm_operation_3x.hpp
+++ b/tools/library/src/sparse_gemm_operation_3x.hpp
@@ -209,13 +209,13 @@ protected:
       if (iter_runtime_a != mapping.end()) {
           operator_args.mainloop.runtime_data_type_a = iter_runtime_a->second;
       } else {
-        assert("invalid runtime argument for datatype A!");
+        return Status::kErrorInvalidProblem;
       }
 
       if (iter_runtime_b != mapping.end()) {
           operator_args.mainloop.runtime_data_type_b = iter_runtime_b->second;
       } else {
-        assert("invalid runtime argument for datatype B!");
+        return Status::kErrorInvalidProblem;
       }
 
     }


### PR DESCRIPTION
## Summary

- Return `Status::kErrorInvalidProblem` when runtime datatype A/B values are not found in the 3.x GEMM runtime datatype mapping.
- Apply the same validation to GEMM, blockwise GEMM, and sparse GEMM update paths.
- Avoid relying on `assert("...")`, which always evaluates true for string literals.

## Testing

- `git diff --check`
- `rg -n "assert\\(\\s*\\\"invalid runtime argument for datatype" tools/library/src/gemm_operation_3x.hpp tools/library/src/blockwise_gemm_operation_3x.hpp tools/library/src/sparse_gemm_operation_3x.hpp`