### PR TITLE
fixes for #3340, stale comments on thread layout shape

### DIFF
--- a/examples/cute/tutorial/hopper/wgmma_sm90.cu
+++ b/examples/cute/tutorial/hopper/wgmma_sm90.cu
@@ -323,10 +323,10 @@ gemm_nt(int m, int n, int k,
 
   // Define the thread layouts (static)
   TiledCopy copyA = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, TA>{},
-                                    Layout<Shape<_16,_8>>{}, // Thr layout 32x4 m-major
+                                    Layout<Shape<_16,_8>>{}, // Thr layout 16x8 m-major
                                     Layout<Shape< _8,_1>>{});// Val layout  8x1 m-major
   TiledCopy copyB = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, TB>{},
-                                    Layout<Shape<_16,_8>>{}, // Thr layout 32x4 n-major
+                                    Layout<Shape<_16,_8>>{}, // Thr layout 16x8 n-major
                                     Layout<Shape< _8,_1>>{});// Val layout  8x1 n-major
 
   TiledMMA tiled_mma = make_tiled_mma(SM90_64x64x16_F16F16F16_SS<GMMA::Major::MN,GMMA::Major::MN>{});


### PR DESCRIPTION
## Summary
fixed #3340 in examples/cute/tutorial/hopper/wgmma_sm90.cu

example code for wgmma-sm90 tutorial uses Layout<Shape<_16,_8>>{} for both copyA and copyB. comments pointed to layout 32x4. corrected comments to 16x8 to match the actual layout shaping for consumer clarity.

## Testing: 
comment-only change for code clarity. none-required.