### PR TITLE
Fix SM120 blockscaled FP32 epilogue store layout

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_cooperative.py
+++ b/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_cooperative.py
@@ -988,9 +988,11 @@ class Sm120BlockScaledGemmKernel:
                 )
 
                 copy_atom_C = cute.make_copy_atom(
+                    # Use x4 so make_tiled_copy_C_atom covers the full C TV
+                    # layout for 32-bit outputs, whose r2s atom is CopyUniversalOp.
                     cute.nvgpu.warp.StMatrix8x8x16bOp(
                         self.c_layout.is_m_major_c(),
-                        2,
+                        4,
                     ),
                     self.c_dtype,
                 )

--- a/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_pingpong.py
+++ b/examples/python/CuTeDSL/cute/blackwell_geforce/kernel/blockscaled_gemm/dense_blockscaled_gemm_persistent_pingpong.py
@@ -1130,9 +1130,11 @@ class Sm120BlockScaledGemmKernel:
                 )
 
                 copy_atom_C = cute.make_copy_atom(
+                    # Use x4 so make_tiled_copy_C_atom covers the full C TV
+                    # layout for 32-bit outputs, whose r2s atom is CopyUniversalOp.
                     cute.nvgpu.warp.StMatrix8x8x16bOp(
                         self.c_layout.is_m_major_c(),
-                        2,
+                        4,
                     ),
                     self.c_dtype,
                 )


### PR DESCRIPTION
Both kernels used `StMatrix8x8x16bOp(..., 2)` to build the C atom passed to `make_tiled_copy_C_atom`. For `Float32` outputs, the actual register-to-SMEM copy atom is `CopyUniversalOp`, but the C TV layout is still derived from this stmatrix C atom. The x2 layout does not cover the full C fragment for this epilogue path, causing incomplete SMEM writes before the final TMA  store. Changing the C atom to `StMatrix8x8x16bOp(..., 4)` provides a C TV layout that covers the full C fragment and fixes the observed FP32 output mismatch.  In fact, unless there is a special case, we do not use x2; by default, we always use x4. Therefore, I think x2 came from a typo.