### PR TITLE
[SM120] Emit grouped NVFP4 (ue4m3) block-scaled GEMM in cutlass_library

### DIFF
--- a/python/cutlass_library/generator.py
+++ b/python/cutlass_library/generator.py
@@ -11438,9 +11438,13 @@ def GenerateSM120_TensorOp_fp4_UMMA_gemm_with_block_scaled(manifest, cuda_versio
       for tile_size in tile_sizes:
         # nvf4 kernel only supports ue4m3 SF
         # mxf4 kernel only supports ue8m0 SF
-        # grouped schedules only support ue8m0 (MXF4); NVF4 (ue4m3) grouped requires
-        # NVF4-specific PtrArray schedule tags not yet available
+        # Grouped (PtrArray) schedules support BOTH MXF4 (ue8m0) and NVF4 (ue4m3) on SM120:
+        # to_grouped_schedule() maps the Nvf4/Mxf4 Sm120 tags onto the same PtrArray tags, so
+        # the SF type is what distinguishes them (example 79d runs the NVF4 grouped kernel on
+        # SM120). is_nvf4() only matches the non-grouped Sm120 tags, so the grouped branch keys
+        # on the SF type directly.
         if (is_grouped_schedule and math_inst.element_scale_factor == DataType.ue8m0) or \
+           (is_grouped_schedule and math_inst.element_scale_factor == DataType.ue4m3) or \
            (not is_grouped_schedule and math_inst.element_scale_factor == DataType.ue4m3 and is_nvf4(kernel_schedule)) or \
            (not is_grouped_schedule and math_inst.element_scale_factor == DataType.ue8m0 and not is_nvf4(kernel_schedule)):
           tile_descriptions.append(


### PR DESCRIPTION
The SM120 fp4 block-scaled generator skipped grouped NVFP4 (ue4m3) kernels behind a stale
"not yet available" comment, even though `to_grouped_schedule()` already maps the Nvf4 Sm120
tags onto the PtrArray tags and example `79d_blackwell_geforce_nvfp4_grouped_gemm.cu` runs that
exact kernel. Because the grouped tags collapse to `PtrArray*`, `is_nvf4(kernel_schedule)` is
`False` in the grouped branch, so it must key on the SF type. This adds the
`is_grouped && ue4m3` clause and corrects the stale comment.

Emits 14 grouped NVFP4 SM120 kernels that were previously absent (verified by driving the
grouped generator path: 0 -> 14). The kernel template is the one proven by example 79d.

Fixes #3343.

## Test plan / limits
- Verified emission 0 -> 14 by driving `GenerateSM120_TensorOp_fp4_UMMA_gemm_with_block_scaled(..., gemm_kind=GemmKind.GroupedBlockScaledUniversal3x)`.
- Verified the kernel template via example 79d on RTX PRO 6000 (SM120, CUDA 13): both schedules `Disposition: Passed`, 303 / 253 TFLOPS.
- I did **not** run a full `cutlass_profiler` build of all 14 emitted tile variants locally (heavy). Please run internal CI to confirm every emitted tile compiles — some SM120 tiles may hit Stages>=2 constraints; if so they can be pruned in the same clause.
