### PR TITLE
Warn on deprecated CooperativeGroup alignment argument

### DIFF
--- a/python/CuTeDSL/cutlass/pipeline/helpers.py
+++ b/python/CuTeDSL/cutlass/pipeline/helpers.py
@@ -56,6 +56,15 @@ class CooperativeGroup:
     def __init__(
         self, agent: Agent, size: Union[int, Int32] = 1, alignment: Optional[int] = None
     ):
+        if alignment is not None:
+            warnings.warn(
+                "The 'alignment' parameter of CooperativeGroup's constructor is "
+                "deprecated and will be removed in a subsequent release, please "
+                "remove it from your code.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if agent in [
             Agent.Thread,
             Agent.Warp,

--- a/test/python/CuTeDSL/test_pipeline_helpers.py
+++ b/test/python/CuTeDSL/test_pipeline_helpers.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+import unittest
+
+import cutlass.pipeline as pipeline
+
+
+class TestPipelineHelpers(unittest.TestCase):
+    def test_cooperative_group_accepts_deprecated_alignment_argument(self):
+        with self.assertWarnsRegex(DeprecationWarning, "alignment"):
+            group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 128, 32)
+
+        self.assertIs(group.agent, pipeline.Agent.Thread)
+        self.assertEqual(group.size, 128)
+
+    def test_cooperative_group_rejects_non_positive_thread_size_with_alignment(self):
+        with self.assertWarnsRegex(DeprecationWarning, "alignment"):
+            with self.assertRaisesRegex(ValueError, "greater than 0"):
+                pipeline.CooperativeGroup(pipeline.Agent.Thread, 0, 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Emit a `DeprecationWarning` when the deprecated `alignment` argument is passed to `cutlass.pipeline.CooperativeGroup`.
- Add focused regression coverage for the deprecated positional argument and invalid thread-group size behavior.

## Rationale
Some downstream examples and integrations still call `CooperativeGroup(agent, size, alignment)`. Keeping the argument accepted while warning provides a migration path instead of failing at runtime.

## Testing
- `python -m py_compile test\python\CuTeDSL\test_pipeline_helpers.py`
- `git diff --check`

The focused runtime unittest was not run locally because this checkout does not have the built `cutlass._mlir` extension installed.
