### PR TITLE
[CuTeDSL] Drop Ampere/Ada from cvt_i8_bf16_intrinsic.supported_archs

### DIFF
--- a/python/CuTeDSL/cutlass/cute/arch/numeric_conversion.py
+++ b/python/CuTeDSL/cutlass/cute/arch/numeric_conversion.py
@@ -301,8 +301,6 @@ def sext_unpacked_i4_i8_intrinsic(
 
 # Expose supported architectures via the intrinsic symbol
 cvt_i8_bf16_intrinsic.supported_archs = (  # type: ignore[attr-defined]
-    *Arch.AmpereArchs(),
-    *Arch.AdaArchs(),
     *Arch.HopperArchs(),
     *Arch.BlackwellArchs(),
 )

--- a/python/CuTeDSL/cutlass/cute/arch/numeric_conversion.py
+++ b/python/CuTeDSL/cutlass/cute/arch/numeric_conversion.py
@@ -365,8 +365,6 @@ def sext_unpacked_i4_i8_intrinsic(
 
 # Expose supported architectures via the intrinsic symbol
 cvt_i8_bf16_intrinsic.supported_archs = (  # type: ignore[attr-defined]
-    *base_dsl.Arch.AmpereArchs(),
-    *base_dsl.Arch.AdaArchs(),
     *base_dsl.Arch.HopperArchs(),
     *base_dsl.Arch.BlackwellArchs(),
 )


### PR DESCRIPTION
cvt.rn.bf16.s8 requires sm_90+, so pre-Hopper targets should fall through to the existing itofp software fallback instead of emitting an instruction ptxas rejects. Matches the sibling cvt_i4_bf16_intrinsic gate.

Fixes #3354