### PR TITLE
Enable SM110 for Blackwell FMHA and warpgroup reg reconfig

### DIFF
--- a/examples/77_blackwell_fmha/kernel/sm100_fmha_bwd_kernel_tma_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/kernel/sm100_fmha_bwd_kernel_tma_warpspecialized.hpp
@@ -1509,7 +1509,8 @@ struct Sm100FmhaBwdKernelTmaWarpSpecialized {
 
   CUTLASS_DEVICE void operator()(Params const& params, char* smem) {
 #if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
-    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM110A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM110F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
     int warp_idx = cutlass::canonical_warp_idx_sync();

--- a/examples/77_blackwell_fmha/kernel/sm100_fmha_bwd_mla_kernel_tma_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/kernel/sm100_fmha_bwd_mla_kernel_tma_warpspecialized.hpp
@@ -1481,7 +1481,8 @@ struct Sm100FmhaBwdMlaKernelTmaWarpSpecialized {
 
   CUTLASS_DEVICE void operator()(Params const& params, char* smem) {
 #if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
-    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM110A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM110F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else    
     int warp_idx = cutlass::canonical_warp_idx_sync();

--- a/examples/77_blackwell_fmha/kernel/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/kernel/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
@@ -252,7 +252,8 @@ struct Sm100FmhaFwdKernelTmaWarpspecialized {
 
   CUTLASS_DEVICE void operator()(const Params &params, char* smem) {
 #if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
-    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM110A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM110F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
 

--- a/examples/77_blackwell_fmha/kernel/sm100_fmha_gen_kernel_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/kernel/sm100_fmha_gen_kernel_warpspecialized.hpp
@@ -248,7 +248,8 @@ struct Sm100FmhaGenKernelWarpspecialized {
 
   CUTLASS_DEVICE void operator()(const Params &params, char* smem) {
 #if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
-    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM110A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM110F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
 

--- a/examples/77_blackwell_fmha/kernel/sm100_fmha_mla_tma_warpspecialized.hpp
+++ b/examples/77_blackwell_fmha/kernel/sm100_fmha_mla_tma_warpspecialized.hpp
@@ -508,7 +508,8 @@ struct Sm100FmhaMlaKernelTmaWarpspecialized {
 
   CUTLASS_DEVICE void operator()(Params const& params, char* smem_raw) {
 #if (! defined(CUTLASS_ARCH_MMA_SM100A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM100F_ENABLED) && \
-    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED))
+    ! defined(CUTLASS_ARCH_MMA_SM103A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM103F_ENABLED) && \
+    ! defined(CUTLASS_ARCH_MMA_SM110A_ENABLED) && ! defined(CUTLASS_ARCH_MMA_SM110F_ENABLED))
     CUTE_INVALID_CONTROL_PATH("ERROR : Arch conditional MMA instruction used without targeting appropriate compute capability. Aborting.\n");
 #else
 

--- a/include/cutlass/arch/reg_reconfig.h
+++ b/include/cutlass/arch/reg_reconfig.h
@@ -47,6 +47,7 @@
          (__CUDA_ARCH__ ==  900 && defined(__CUDA_ARCH_FEAT_SM90_ALL))      \
       || (__CUDA_ARCH__ == 1000 && defined(__CUDA_ARCH_FEAT_SM100_ALL))     \
       || (__CUDA_ARCH__ == 1010 && defined(__CUDA_ARCH_FEAT_SM101_ALL))     \
+      || (__CUDA_ARCH__ == 1100 && defined(__CUDA_ARCH_FEAT_SM110_ALL))     \
       || (__CUDA_ARCH__ == 1030 && defined(__CUDA_ARCH_FEAT_SM103_ALL))     \
       || (__CUDA_ARCH__ == 1200 && defined(__CUDA_ARCH_FEAT_SM120_ALL))     \
       || (__CUDA_ARCH__ == 1210 && defined(__CUDA_ARCH_FEAT_SM121_ALL))     \
@@ -57,6 +58,7 @@
   #if defined(__CUDA_ARCH__) && __CUDACC_VER_MAJOR__ >= 12 && (          \
          (__CUDA_ARCH__ == 1000 && CUDA_ARCH_FAMILY(1000))  \
       || (__CUDA_ARCH__ == 1010 && CUDA_ARCH_FAMILY(1010))  \
+      || (__CUDA_ARCH__ == 1100 && CUDA_ARCH_FAMILY(1100))  \
       || (__CUDA_ARCH__ == 1030 && CUDA_ARCH_FAMILY(1030))  \
       || (__CUDA_ARCH__ == 1200 && CUDA_ARCH_FAMILY(1200))  \
       || (__CUDA_ARCH__ == 1210 && CUDA_ARCH_CONDITIONAL_OR_FAMILY(1210))  \


### PR DESCRIPTION
Adds SM110 (sm_110a / Thor) support that CUTLASS does not have:

- Extend Blackwell FMHA kernel arch guards to accept SM110A/SM110F (same pattern as existing SM103 guards on main). This allows SM110 to work again with CUDA >= 13.0.
- Add SM110 (1100) to warpgroup setmaxnreg activation in reg_reconfig.h so FMHA softmax warpgroups get their intended register budget instead of compiling reg alloc/dealloc to no-ops. This restores perf for SM110 with CUDA >= 13.0.

[Cutlass 4.2 Change log](https://docs.nvidia.com/cutlass/latest/CHANGELOG.html#id27) has the following comment:

```
From CUDA 13.0, the Blackwell SM101 for Thor GPUs is renamed to SM110.
For CUDA toolkit version < 13.0, SM101 is still used for Thor GPUs.
For CUDA toolkit version >= 13.0, SM110 is used for Thor GPUs and SM101 is no longer valid.
```