### PR TITLE
Fix stale thread-layout comment in wgmma_sm90 tutorial

### DIFF
--- a/examples/cute/tutorial/hopper/wgmma_sm90.cu
+++ b/examples/cute/tutorial/hopper/wgmma_sm90.cu
@@ -323,10 +323,10 @@ gemm_nt(int m, int n, int k,
 
   // Define the thread layouts (static)
   TiledCopy copyA = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, TA>{},
-                                    Layout<Shape<_16,_8>>{}, // Thr layout 32x4 m-major
+                                    Layout<Shape<_16,_8>>{}, // Thr layout 16x8 m-major
                                     Layout<Shape< _8,_1>>{});// Val layout  8x1 m-major
   TiledCopy copyB = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, TB>{},
-                                    Layout<Shape<_16,_8>>{}, // Thr layout 32x4 n-major
+                                    Layout<Shape<_16,_8>>{}, // Thr layout 16x8 n-major
                                     Layout<Shape< _8,_1>>{});// Val layout  8x1 n-major
 
   TiledMMA tiled_mma = make_tiled_mma(SM90_64x64x16_F16F16F16_SS<GMMA::Major::MN,GMMA::Major::MN>{});


### PR DESCRIPTION
## Summary

In `examples/cute/tutorial/hopper/wgmma_sm90.cu`, the `gemm_nt` tiled-copy comments for `copyA`/`copyB` read `Thr layout 32x4`, but the thread layout is `Layout<Shape<_16,_8>>`, i.e. 16x8.

The k-major copies a few lines below already label the same `Shape<_16,_8>` as `16x8`, so this corrects the m-major/n-major comments to match the code and the surrounding convention.

```
- Layout<Shape<_16,_8>>{}, // Thr layout 32x4 m-major
+ Layout<Shape<_16,_8>>{}, // Thr layout 16x8 m-major
- Layout<Shape<_16,_8>>{}, // Thr layout 32x4 n-major
+ Layout<Shape<_16,_8>>{}, // Thr layout 16x8 n-major
```

Comment-only change; no functional impact.

Fixes #3340