### PR TITLE
Update fence_proxy API to string-based arguments in cutlass_api GEMM …

### DIFF
--- a/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_contiguous_offset_2d3d_dense_gemm_impl.py
+++ b/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_contiguous_offset_2d3d_dense_gemm_impl.py
@@ -958,10 +958,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
                     sInfo_pipe[3] = m_remaining_in_cur_group
 
                 # fence view async shared
-                cute.arch.fence_proxy(
-                    cute.arch.ProxyKind.async_shared,
-                    space=cute.arch.SharedSpace.shared_cta,
-                )
+                cute.arch.fence_proxy("async.shared", space="cta")
                 self.sched_sync_barrier.arrive_and_wait()
                 # commit tile info pipeline
                 sched_pipeline.producer_commit(sched_producer_state)
@@ -994,10 +991,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
             for idx in cutlass.range(4, unroll_full=True):
                 tile_info[idx] = sInfo[(idx, sched_consumer_state.index)]
             is_valid_tile = tile_info[2] < group_count
-            cute.arch.fence_proxy(
-                cute.arch.ProxyKind.async_shared,
-                space=cute.arch.SharedSpace.shared_cta,
-            )
+            cute.arch.fence_proxy("async.shared", space="cta")
             sched_pipeline.consumer_release(sched_consumer_state)
             sched_consumer_state.advance()
 
@@ -1069,10 +1063,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
                 for idx in cutlass.range(4, unroll_full=True):
                     tile_info[idx] = sInfo[(idx, sched_consumer_state.index)]
                 is_valid_tile = tile_info[2] < group_count
-                cute.arch.fence_proxy(
-                    cute.arch.ProxyKind.async_shared,
-                    space=cute.arch.SharedSpace.shared_cta,
-                )
+                cute.arch.fence_proxy("async.shared", space="cta")
                 sched_pipeline.consumer_release(sched_consumer_state)
                 sched_consumer_state.advance()
 
@@ -1115,10 +1106,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
             for idx in cutlass.range(4, unroll_full=True):
                 tile_info[idx] = sInfo[(idx, sched_consumer_state.index)]
             is_valid_tile = tile_info[2] < group_count
-            cute.arch.fence_proxy(
-                cute.arch.ProxyKind.async_shared,
-                space=cute.arch.SharedSpace.shared_cta,
-            )
+            cute.arch.fence_proxy("async.shared", space="cta")
             sched_pipeline.consumer_release(sched_consumer_state)
             sched_consumer_state.advance()
 
@@ -1189,10 +1177,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
                 for idx in cutlass.range(4, unroll_full=True):
                     tile_info[idx] = sInfo[(idx, sched_consumer_state.index)]
                 is_valid_tile = tile_info[2] < group_count
-                cute.arch.fence_proxy(
-                    cute.arch.ProxyKind.async_shared,
-                    space=cute.arch.SharedSpace.shared_cta,
-                )
+                cute.arch.fence_proxy("async.shared", space="cta")
                 sched_pipeline.consumer_release(sched_consumer_state)
                 sched_consumer_state.advance()
 
@@ -1288,10 +1273,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
             for idx in cutlass.range(4, unroll_full=True):
                 tile_info[idx] = sInfo[(idx, sched_consumer_state.index)]
             is_valid_tile = tile_info[2] < group_count
-            cute.arch.fence_proxy(
-                cute.arch.ProxyKind.async_shared,
-                space=cute.arch.SharedSpace.shared_cta,
-            )
+            cute.arch.fence_proxy("async.shared", space="cta")
 
             num_prev_subtiles = cutlass.Int32(0)
 
@@ -1374,10 +1356,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
                             tRS_sC[(None, None, None, c_buffer)],
                         )
                         # Fence and barrier to make sure shared memory store is visible to TMA store
-                        cute.arch.fence_proxy(
-                            cute.arch.ProxyKind.async_shared,
-                            space=cute.arch.SharedSpace.shared_cta,
-                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
                         self.epilog_sync_barrier.arrive_and_wait()
 
                         #
@@ -1467,10 +1446,7 @@ class ContiguousOffset2D3DGemmDenseKernelImpl:
                 for idx in cutlass.range(4, unroll_full=True):
                     tile_info[idx] = sInfo[(idx, sched_consumer_state.index)]
                 is_valid_tile = tile_info[2] < group_count
-                cute.arch.fence_proxy(
-                    cute.arch.ProxyKind.async_shared,
-                    space=cute.arch.SharedSpace.shared_cta,
-                )
+                cute.arch.fence_proxy("async.shared", space="cta")
 
             sched_pipeline.consumer_release(sched_consumer_state)
             sched_consumer_state.advance()

--- a/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_dense_blockscaled_static_persistent_impl.py
+++ b/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_dense_blockscaled_static_persistent_impl.py
@@ -1490,10 +1490,7 @@ class PersistentDenseBlockScaledGemmKernelImpl:
                         tRS_sC[(None, None, None, c_buffer)],
                     )
                     # Fence and barrier to make sure shared memory store is visible to TMA store
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
-                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
                     self.epilog_sync_barrier.arrive_and_wait()
 
                     #

--- a/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_static_persistent_efc_impl.py
+++ b/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_static_persistent_efc_impl.py
@@ -961,10 +961,7 @@ class PersistentDenseGemmEFCKernelImpl:
                         c_pipeline_consumer_state.index
                     )
 
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
-                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
                     c_pipeline.consumer_release(c_pipeline_consumer_state)
 
                     # Advance pipeline states
@@ -995,10 +992,7 @@ class PersistentDenseGemmEFCKernelImpl:
                     self.efc.kernel.store_written_tensors_to_smem(d_buffer)
 
                     # Fence and barrier to make sure shared memory store is visible to TMA store
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
-                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
                     epilog_sync_barrier.arrive_and_wait()
 
                     #

--- a/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_static_persistent_impl.py
+++ b/python/cutlass_api/cutlass_api/providers/cutedsl/gemm/implementations/sm100_static_persistent_impl.py
@@ -1073,10 +1073,7 @@ class PersistentDenseGemmKernelImpl:
                 c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
                 cute.copy(tiled_copy_r2s, tRS_rC, tRS_sC[(None, None, None, c_buffer)])
                 # Fence and barrier to make sure shared memory store is visible to TMA store
-                cute.arch.fence_proxy(
-                    cute.arch.ProxyKind.async_shared,
-                    space=cute.arch.SharedSpace.shared_cta,
-                )
+                cute.arch.fence_proxy("async.shared", space="cta")
                 epilog_sync_barrier.arrive_and_wait()
 
                 #


### PR DESCRIPTION
Update fence_proxy API to string-based arguments in cutlass_api GEMM impls

Replace deprecated cute.arch.ProxyKind/SharedSpace enum usage with the new string-based fence_proxy API: fence_proxy("async.shared", space="cta").

Credit goes to Cursor Coding agent. 

Background
Issue: https://github.com/pytorch/pytorch/issues/188477 
Related PyTorch PR: https://github.com/pytorch/pytorch/pull/188633 

Note: this is a temporary solution to unblock PyTorch by fixing the failed tests. The longer term is to move away from "cutlass_api" branch usage  and migrate PyTorch with it to e.g. cutlass operators. 