### PR TITLE
[CuTeDSL] Gate Blackwell example tuning by CUDA backend

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell/kernel/attention/mamba2_ssd/mamba2_ssd.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/attention/mamba2_ssd/mamba2_ssd.py
@@ -58,6 +58,17 @@ from cute.blackwell.kernel.attention.mamba2_ssd.mamba2_ssd_tile_scheduler import
 )
 
 
+def _get_warp_register_counts() -> Tuple[int, int]:
+    """Return register counts tuned for each CUDA backend.
+
+    CUDA 12.9 benefits from the 48/88 uniform/epilogue split, while CUDA 13.1
+    and newer use the 32/104 split.
+    """
+    if cutlass.target_version(min_version="13.1"):
+        return 32, 104
+    return 48, 88
+
+
 class SSDKernel:
     def __init__(
         self,
@@ -142,10 +153,12 @@ class SSDKernel:
         )
 
         # Number of registers used by each warp
-        self.num_regs_uniform_warps = 32
+        (
+            self.num_regs_uniform_warps,
+            self.num_regs_epilogue_warps,
+        ) = _get_warp_register_counts()
         self.num_regs_pre_inter_warps = 168
         self.num_regs_pre_intra_warps = 208
-        self.num_regs_epilogue_warps = 104
 
         # Shared storage
         self.shared_storage = None

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/blockwise_gemm/contiguous_grouped_gemm.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/blockwise_gemm/contiguous_grouped_gemm.py
@@ -195,6 +195,7 @@ class BlockwiseContiguousGroupedGemmKernel:
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
+        self.use_newer_backend_codegen = cutlass.target_version(min_version="13.1")
         # K dimension is deferred in _setup_attributes
         self.mma_tiler = (*mma_tiler_mn, 1)
 
@@ -1664,11 +1665,30 @@ class BlockwiseContiguousGroupedGemmKernel:
                         tTR_rSFA_subtile = tTR_rSFA[(None, None, None, subtile_idx)]
                         tTR_rSFB_subtile = tTR_rSFB[(None, None, None, subtile_idx)]
 
-                        scale = cute.make_rmem_tensor(tTR_rSFA_subtile.shape, self.acc_dtype)
-                        for fma_idx in cutlass.range_constexpr(cute.size(scale)):
-                            scale[fma_idx] = tTR_rSFA_subtile[fma_idx] * tTR_rSFB_subtile[fma_idx]
-                        for fma_idx in cutlass.range_constexpr(cute.size(tTR_rAcc_subtile)):
-                            tTR_rAcc_subtile[fma_idx] = tTR_rAcc[fma_idx] * scale[fma_idx] + tTR_rAcc_subtile[fma_idx]
+                        if cutlass.const_expr(self.use_newer_backend_codegen):
+                            acc_vec = tTR_rAcc.load()
+                            final_vec = tTR_rAcc_subtile.load()
+                            scale_a = tTR_rSFA_subtile.load()
+                            scale_b = tTR_rSFB_subtile.load()
+                            scale = scale_a * scale_b
+                            final_vec = acc_vec * scale + final_vec
+                            tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+                        else:
+                            scale = cute.make_rmem_tensor(
+                                tTR_rSFA_subtile.shape, self.acc_dtype
+                            )
+                            for fma_idx in cutlass.range_constexpr(cute.size(scale)):
+                                scale[fma_idx] = (
+                                    tTR_rSFA_subtile[fma_idx]
+                                    * tTR_rSFB_subtile[fma_idx]
+                                )
+                            for fma_idx in cutlass.range_constexpr(
+                                cute.size(tTR_rAcc_subtile)
+                            ):
+                                tTR_rAcc_subtile[fma_idx] = (
+                                    tTR_rAcc[fma_idx] * scale[fma_idx]
+                                    + tTR_rAcc_subtile[fma_idx]
+                                )
 
                     #
                     # Async arrive accumulator buffer empty
@@ -2820,6 +2840,9 @@ def run(
         gidx_mapping,
         max_active_clusters,
         current_stream,
+        options=(
+            "--opt-level 2" if gemm.use_newer_backend_codegen else "--opt-level 3"
+        ),
     )
 
     # Execution

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/blockwise_gemm/masked_grouped_gemm.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/blockwise_gemm/masked_grouped_gemm.py
@@ -194,6 +194,7 @@ class BlockwiseMaskedGroupedGemmKernel:
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
+        self.use_newer_backend_codegen = cutlass.target_version(min_version="13.1")
         # K dimension is deferred in _setup_attributes
         self.mma_tiler = (*mma_tiler_mn, 1)
 
@@ -1669,11 +1670,30 @@ class BlockwiseMaskedGroupedGemmKernel:
                         tTR_rSFA_subtile = tTR_rSFA[(None, None, None, subtile_idx)]
                         tTR_rSFB_subtile = tTR_rSFB[(None, None, None, subtile_idx)]
 
-                        scale = cute.make_rmem_tensor(tTR_rSFA_subtile.shape, self.acc_dtype)
-                        for fma_idx in cutlass.range_constexpr(cute.size(scale)):
-                            scale[fma_idx] = tTR_rSFA_subtile[fma_idx] * tTR_rSFB_subtile[fma_idx]
-                        for fma_idx in cutlass.range_constexpr(cute.size(tTR_rAcc_subtile)):
-                            tTR_rAcc_subtile[fma_idx] = tTR_rAcc[fma_idx] * scale[fma_idx] + tTR_rAcc_subtile[fma_idx]
+                        if cutlass.const_expr(self.use_newer_backend_codegen):
+                            acc_vec = tTR_rAcc.load()
+                            final_vec = tTR_rAcc_subtile.load()
+                            scale_a = tTR_rSFA_subtile.load()
+                            scale_b = tTR_rSFB_subtile.load()
+                            scale = scale_a * scale_b
+                            final_vec = acc_vec * scale + final_vec
+                            tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+                        else:
+                            scale = cute.make_rmem_tensor(
+                                tTR_rSFA_subtile.shape, self.acc_dtype
+                            )
+                            for fma_idx in cutlass.range_constexpr(cute.size(scale)):
+                                scale[fma_idx] = (
+                                    tTR_rSFA_subtile[fma_idx]
+                                    * tTR_rSFB_subtile[fma_idx]
+                                )
+                            for fma_idx in cutlass.range_constexpr(
+                                cute.size(tTR_rAcc_subtile)
+                            ):
+                                tTR_rAcc_subtile[fma_idx] = (
+                                    tTR_rAcc[fma_idx] * scale[fma_idx]
+                                    + tTR_rAcc_subtile[fma_idx]
+                                )
 
                     #
                     # Async arrive accumulator buffer empty
@@ -2804,6 +2824,7 @@ def run(
         gidx_mapping,
         max_active_clusters,
         current_stream,
+        options="--opt-level 2" if gemm.use_newer_backend_codegen else "",
     )
 
     # Execution


### PR DESCRIPTION
## Summary

This is a follow-up to #3344. The register-friendly paths needed by CUDA 12.9 should not replace the better code generation used by CUDA 13.1 and newer.

- select the Mamba2 SSD `48/88` uniform/epilogue register split before CUDA 13.1 and retain `32/104` on newer backends
- retain per-element grouped-GEMM accumulation on older backends, while restoring vector accumulation on CUDA 13.1 and newer
- select contiguous O3/O2 and masked default/O2 compiler options with the same backend predicate
- keep masked grouped GEMM's role-local warp-uniform loop bounds on both backends

## Performance

The B200 tests used CUTLASS DSL 4.6 with CUDA 12.9 and CUDA 13.3.

For SSD `gbehcdln=(2,4,2,40,32,64,128,128)` with BF16 I/O and FP32 accumulation, CUDA 12.9 improved by 8.03%, 5.82%, and 6.40% for none/scalar/vector D fusion relative to the `32/104` split. CUDA 13.3 retains the `32/104` path and produces the same binaries as its control.

For grouped GEMM `mnkl=(2048,2112,7168,2)`, FP8 inputs, BF16 output, FP32 scales, 2CTA, a `128x128` MMA tile, and a `2x2` cluster, the backend gate preserves the validated CUDA 12.9 scalar path. On CUDA 13.3 it avoids the observed scalar-path regressions: contiguous returned from 103.60 us to about 97.2 us, and masked returned from 250.60 us to about 222.95 us.

## Validation

- Python byte compilation
- Ruff formatting and targeted lint checks
- B200 correctness for SSD none/scalar/vector and contiguous/masked grouped GEMM on CUDA 12.9 and CUDA 13.3
- fresh-process cold-L2 performance runs with 10 warmups and 10 measured iterations
- contiguous PTX and cubin remained byte-identical on both backends after consolidating the version predicate
