### PR TITLE
fix: restrict i8-to-bf16 arch gate to Hopper+ and guard s2t copy to leader CTA

### DIFF
--- a/include/cutlass/gemm/collective/sm100_blockscaled_mma_mixed_tma_cpasync_warpspecialized.hpp
+++ b/include/cutlass/gemm/collective/sm100_blockscaled_mma_mixed_tma_cpasync_warpspecialized.hpp
@@ -1026,7 +1026,7 @@ struct CollectiveMma<
       int read_stage_tma = mainloop_pipe_tma_consumer_state.index();
       int read_stage_cpasync = mainloop_pipe_cpasync_consumer_state.index();
 
-      if (cute::elect_one_sync()) {
+      if (is_mma_leader_cta && cute::elect_one_sync()) {
         copy(tiled_copy_s2t_SFA, thr_tCsSFA_s2t(_,_,_,_,read_stage_tma), thr_tCtSFA_s2t);
         copy(tiled_copy_s2t_SFB, thr_tCsSFB_s2t(_,_,_,_,read_stage_tma), thr_tCtSFB_s2t);
       }

--- a/media/docs/cpp/fundamental_types.md
+++ b/media/docs/cpp/fundamental_types.md
@@ -344,17 +344,6 @@ multiply_add<Array<half_t, kN>> mad_op;
 d = mad_op(a, b, c);   // efficient multiply-add for Array of half-precision elements
 ```
 
-## Numeric Conversion
-
-Operators are define to convert between numeric types in `numeric_conversion.h`. Conversion operators are defined in
-terms of individual numeric elements and on arrays which enable the possibility of efficient hardware
-support on current and future NVIDIA GPUs.
-
-**Example:** Converting between 32-b and 8-b integers.
-```c++
-
-```
-
 ### Copyright
 
 Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/python/CuTeDSL/cutlass/cute/arch/numeric_conversion.py
+++ b/python/CuTeDSL/cutlass/cute/arch/numeric_conversion.py
@@ -365,8 +365,6 @@ def sext_unpacked_i4_i8_intrinsic(
 
 # Expose supported architectures via the intrinsic symbol
 cvt_i8_bf16_intrinsic.supported_archs = (  # type: ignore[attr-defined]
-    *Arch.AmpereArchs(),
-    *Arch.AdaArchs(),
     *Arch.HopperArchs(),
     *Arch.BlackwellArchs(),
 )


### PR DESCRIPTION
Fixes #3354 and #3331.

- cvt_i8_bf16_intrinsic listed Ampere/Ada in supported_archs but lowers to sm_90+ PTX. Removed so the itofp fallback is reached.
- The s2t copy of scale factors was gated only by elect_one_sync(), allowing both SMs to race. Added is_mma_leader_cta check.