### PR TITLE
Fix CuTe tuple protocol compatibility across CCCL versions

### DIFF
--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -111,22 +111,26 @@
 #endif
 
 #if defined(__CUDACC_RTC__)
-// Use CCCL's public tuple entry point so std tuple protocol declarations
-// follow the layout provided by the active CCCL version.
-#  include <cuda/std/tuple>
-
-// Older libcu++ releases do not provide the host std tuple primary templates
-// through a top-level tuple protocol header. Keep the legacy forward
-// declarations only for those layouts. Newer CCCL releases provide them via
-// either structured_bindings.h or the split tuple_size/tuple_element headers.
+// Load the tuple protocol from the layout provided by the active CCCL version.
+// Older CUDA toolkits may not provide the public <cuda/std/tuple> entry point,
+// while newer releases may remove the legacy detail/libcxx include path.
 #  if defined(__has_include)
-#    if !__has_include(<cuda/std/__tuple_dir/structured_bindings.h>) && \
-        !__has_include(<cuda/std/detail/libcxx/include/__tuple_dir/structured_bindings.h>) && \
-        (!__has_include(<cuda/std/__tuple_dir/tuple_size.h>) || \
-         !__has_include(<cuda/std/__tuple_dir/tuple_element.h>))
+#    if __has_include(<cuda/std/tuple>)
+#      include <cuda/std/tuple>
+#    elif __has_include(<cuda/std/__tuple_dir/structured_bindings.h>)
+#      include <cuda/std/__tuple_dir/structured_bindings.h>
+#    elif __has_include(<cuda/std/detail/libcxx/include/__tuple_dir/structured_bindings.h>)
+#      include <cuda/std/detail/libcxx/include/__tuple_dir/structured_bindings.h>
+#    elif __has_include(<cuda/std/__tuple_dir/tuple_size.h>) && \
+          __has_include(<cuda/std/__tuple_dir/tuple_element.h>)
+#      include <cuda/std/__tuple_dir/tuple_size.h>
+#      include <cuda/std/__tuple_dir/tuple_element.h>
+#    else
 #      define CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS
 #    endif
-#  elif (__CUDACC_VER_MAJOR__ < 13)
+#  elif (__CUDACC_VER_MAJOR__ >= 13)
+#    include <cuda/std/tuple>
+#  else
 #    define CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS
 #  endif
 #endif

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -121,6 +121,7 @@
 // either structured_bindings.h or the split tuple_size/tuple_element headers.
 #  if defined(__has_include)
 #    if !__has_include(<cuda/std/__tuple_dir/structured_bindings.h>) && \
+        !__has_include(<cuda/std/detail/libcxx/include/__tuple_dir/structured_bindings.h>) && \
         (!__has_include(<cuda/std/__tuple_dir/tuple_size.h>) || \
          !__has_include(<cuda/std/__tuple_dir/tuple_element.h>))
 #      define CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -110,17 +110,23 @@
 #  define CUTE_STL_NAMESPACE std
 #endif
 
-#if !defined(CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE)
+#if defined(__CUDACC_RTC__)
+// Use CCCL's public tuple entry point so std tuple protocol declarations
+// follow the layout provided by the active CCCL version.
+#  include <cuda/std/tuple>
+
+// Older libcu++ releases do not provide the host std tuple primary templates
+// through a top-level tuple protocol header. Keep the legacy forward
+// declarations only for those layouts. Newer CCCL releases provide them via
+// either structured_bindings.h or the split tuple_size/tuple_element headers.
 #  if defined(__has_include)
-#    if __has_include(<cuda/std/__tuple_dir/structured_bindings.h>)
-#      define CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE 1
-#    else
-#      define CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE 0
+#    if !__has_include(<cuda/std/__tuple_dir/structured_bindings.h>) && \
+        (!__has_include(<cuda/std/__tuple_dir/tuple_size.h>) || \
+         !__has_include(<cuda/std/__tuple_dir/tuple_element.h>))
+#      define CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS
 #    endif
-#  elif (__CUDACC_VER_MAJOR__ >= 13)
-#    define CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE 1
-#  else
-#    define CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE 0
+#  elif (__CUDACC_VER_MAJOR__ < 13)
+#    define CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS
 #  endif
 #endif
 

--- a/include/cute/container/array.hpp
+++ b/include/cute/container/array.hpp
@@ -447,18 +447,12 @@ struct tuple_element<I, cute::array<T,N>>
 namespace std
 {
 
-#if CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE
+#if defined(CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS)
+template <class _Tp>
+struct tuple_size;
 
-#include <cuda/std/__tuple_dir/structured_bindings.h>
-
-#else
-#if defined(__CUDACC_RTC__)
-  template <class _Tp>
-  struct tuple_size;
-
-  template <size_t _Ip, class _Tp>
-  struct tuple_element;
-#endif
+template <size_t _Ip, class _Tp>
+struct tuple_element;
 #endif
 
 template <class T, size_t N>

--- a/include/cute/container/array_subbyte.hpp
+++ b/include/cute/container/array_subbyte.hpp
@@ -617,18 +617,12 @@ struct tuple_element<I, cute::array_subbyte<T,N>>
 namespace std
 {
 
-#if CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE
+#if defined(CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS)
+template <class _Tp>
+struct tuple_size;
 
-#include <cuda/std/__tuple_dir/structured_bindings.h>
-
-#else
-#if defined(__CUDACC_RTC__)
-  template <class _Tp>
-  struct tuple_size;
-
-  template <size_t _Ip, class _Tp>
-  struct tuple_element;
-#endif
+template <size_t _Ip, class _Tp>
+struct tuple_element;
 #endif
 
 template <class T, size_t N>

--- a/include/cute/container/tuple.hpp
+++ b/include/cute/container/tuple.hpp
@@ -701,18 +701,12 @@ struct tuple_element<I, cute::tuple<T...>>
 namespace std
 {
 
-#if CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE
+#if defined(CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS)
+template <class _Tp>
+struct tuple_size;
 
-#include <cuda/std/__tuple_dir/structured_bindings.h>
-
-#else
-#if defined(__CUDACC_RTC__)
-  template <class _Tp>
-  struct tuple_size;
-
-  template <size_t _Ip, class _Tp>
-  struct tuple_element;
-#endif
+template <size_t _Ip, class _Tp>
+struct tuple_element;
 #endif
 
 template <class... T>

--- a/include/cute/container/type_list.hpp
+++ b/include/cute/container/type_list.hpp
@@ -103,18 +103,12 @@ struct tuple_element<I, cute::type_list<T...>>
 namespace std
 {
 
-#if CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE
+#if defined(CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS)
+template <class _Tp>
+struct tuple_size;
 
-#include <cuda/std/__tuple_dir/structured_bindings.h>
-
-#else
-#if defined(__CUDACC_RTC__)
-  template <class _Tp>
-  struct tuple_size;
-
-  template <size_t _Ip, class _Tp>
-  struct tuple_element;
-#endif
+template <size_t _Ip, class _Tp>
+struct tuple_element;
 #endif
 
 template <class... T>

--- a/include/cute/numeric/arithmetic_tuple.hpp
+++ b/include/cute/numeric/arithmetic_tuple.hpp
@@ -513,18 +513,12 @@ struct tuple_element<I, cute::ArithmeticTuple<T...>>
 namespace std
 {
 
-#if CUTE_CUDA_STD_STRUCTURED_BINDINGS_HEADER_AVAILABLE
+#if defined(CUTE_CUDA_STD_NEEDS_TUPLE_PRIMARY_DECLARATIONS)
+template <class _Tp>
+struct tuple_size;
 
-#include <cuda/std/__tuple_dir/structured_bindings.h>
-
-#else
-#if defined(__CUDACC_RTC__)
-  template <class _Tp>
-  struct tuple_size;
-
-  template <size_t _Ip, class _Tp>
-  struct tuple_element;
-#endif
+template <size_t _Ip, class _Tp>
+struct tuple_element;
 #endif
 
 template <class... T>

--- a/include/cute/numeric/integer_sequence.hpp
+++ b/include/cute/numeric/integer_sequence.hpp
@@ -37,10 +37,28 @@
 namespace cute
 {
 
-using CUTE_STL_NAMESPACE::integer_sequence;
-using CUTE_STL_NAMESPACE::make_integer_sequence;
+template <class T, T... Ints>
+struct integer_sequence
+{
+  using value_type = T;
+
+  CUTE_HOST_DEVICE static constexpr size_t
+  size() noexcept
+  {
+    return sizeof...(Ints);
+  }
+};
 
 namespace detail {
+
+template <class Sequence>
+struct as_cute_integer_sequence;
+
+template <class T, T... Ints>
+struct as_cute_integer_sequence<CUTE_STL_NAMESPACE::integer_sequence<T, Ints...>>
+{
+  using type = integer_sequence<T, Ints...>;
+};
 
 template <class T, class S, T Begin>
 struct range_impl;
@@ -59,6 +77,10 @@ struct reverse_impl<integer_sequence<T, N...>> {
 };
 
 } // end namespace detail
+
+template <class T, T N>
+using make_integer_sequence = typename detail::as_cute_integer_sequence<
+    CUTE_STL_NAMESPACE::make_integer_sequence<T, N>>::type;
 
 template <class T, T Begin, T End>
 using make_integer_range = typename detail::range_impl<
@@ -150,7 +172,7 @@ template <class T>
 using to_seq_t = typename to_seq<T>::type;
 
 //
-// Specialize cute::tuple-traits for std::integer_sequence
+// Specialize cute::tuple-traits for cute::integer_sequence
 //
 
 template <class T, T... Ints>

--- a/test/unit/cute/core/tuple.cpp
+++ b/test/unit/cute/core/tuple.cpp
@@ -41,6 +41,51 @@
 #include <cute/algorithm/tuple_algorithms.hpp>
 #include <cute/tensor.hpp>
 
+TEST(CuTe_core, IntegerSequenceTransformApply)
+{
+  using seq0 = cute::int_sequence<1, 2, 3>;
+  using seq1 = cute::int_sequence<4, 5, 6>;
+  using seq2 = cute::int_sequence<7, 8, 9>;
+
+  static_assert(!cute::is_same_v<
+      seq0,
+      CUTE_STL_NAMESPACE::integer_sequence<int, 1, 2, 3>>);
+
+  auto pairwise = cute::transform_apply(
+      seq0{}, seq1{},
+      [](auto x, auto y) { return x + y; },
+      [](auto... values) { return cute::make_tuple(values...); });
+  EXPECT_EQ(cute::get<0>(pairwise), 5);
+  EXPECT_EQ(cute::get<1>(pairwise), 7);
+  EXPECT_EQ(cute::get<2>(pairwise), 9);
+  static_assert(cute::is_constant_v<5, decltype(cute::get<0>(pairwise))>);
+  static_assert(cute::is_constant_v<7, decltype(cute::get<1>(pairwise))>);
+  static_assert(cute::is_constant_v<9, decltype(cute::get<2>(pairwise))>);
+
+  auto three_way = cute::transform_apply(
+      seq0{}, seq1{}, seq2{},
+      [](auto x, auto y, auto z) { return x + y + z; },
+      [](auto... values) { return cute::make_tuple(values...); });
+  EXPECT_EQ(cute::get<0>(three_way), 12);
+  EXPECT_EQ(cute::get<1>(three_way), 15);
+  EXPECT_EQ(cute::get<2>(three_way), 18);
+  static_assert(cute::is_constant_v<12, decltype(cute::get<0>(three_way))>);
+  static_assert(cute::is_constant_v<15, decltype(cute::get<1>(three_way))>);
+  static_assert(cute::is_constant_v<18, decltype(cute::get<2>(three_way))>);
+
+  auto sum = cute::fold(
+      seq0{}, cute::_0{},
+      [](auto accumulated, auto value) { return accumulated + value; });
+  EXPECT_EQ(sum, 6);
+  static_assert(cute::is_constant_v<6, decltype(sum)>);
+
+  auto sum_without_identity = cute::fold_first(
+      seq0{},
+      [](auto accumulated, auto value) { return accumulated + value; });
+  EXPECT_EQ(sum_without_identity, 6);
+  static_assert(cute::is_constant_v<6, decltype(sum_without_identity)>);
+}
+
 TEST(CuTe_core, Tuple)
 {
   using namespace cute;
@@ -354,7 +399,7 @@ test_packed_type_alias([[maybe_unused]] ExpectedPackedType packed, std::tuple<Ar
     tuple<Args...> sl = cute::apply(unpacked, [](auto... a){ return cute::make_tuple(a...); });
     EXPECT_EQ(std::get<index>(unpacked), cute::get<index>(sl));
   };
-  cute::for_each(std::make_index_sequence<sizeof...(Args)>(), test_element);
+  cute::for_each(cute::make_index_sequence<sizeof...(Args)>(), test_element);
 }
 
 void test_packed_type_aliases() {


### PR DESCRIPTION
## Summary

Recent CCCL versions no longer provide the private `cuda/std/__tuple_dir/structured_bindings.h` aggregation header, while older CCCL layouts do not always expose the tuple protocol primary declarations through the newer split headers. CuTe's NVRTC path needs to support both layouts.

Newer CCCL versions also provide `cuda::std::get` for `integer_sequence`. When CuTe aliases that type directly, its associated namespace brings the newer overload into unqualified lookup and conflicts with CuTe's tuple protocol.

## Changes

- Use the public `cuda/std/tuple` entry point for NVRTC compilation.
- Detect the available CCCL header layout and retain fallback tuple primary declarations only when neither the legacy nor split headers are available.
- Remove direct dependencies on the private structured-bindings header from CuTe tuple-like containers.
- Define a CuTe-owned `integer_sequence` and adapt the configured STL `make_integer_sequence` result into it.
- Keep tuple algorithms on their original unqualified `get` path; ordinary tuple-like ADL remains unchanged, while CuTe integer sequences no longer associate with the CCCL namespace.
- Add focused regression coverage for two- and three-input transforms and fold operations on integer sequences, including a type-ownership assertion.

## Compatibility

- Preserves older CUDA/CCCL support by continuing to use the configured STL namespace to generate integer packs.
- Uses CCCL-provided tuple declarations when supported and retains the existing fallback only for older layouts.
- Avoids requiring newer library APIs or compiler-specific forwarding helpers.

## Testing

- Added focused CuTe tuple regression cases in `test/unit/cute/core/tuple.cpp`.
- `git diff --check` passes; full CUDA validation is pending on the updated commit.