### PR TITLE
Fix SM89 FP8 blockwise scale indexing under threadblock swizzling

### DIFF
--- a/include/cutlass/gemm/kernel/gemm_universal_blockwise.h
+++ b/include/cutlass/gemm/kernel/gemm_universal_blockwise.h
@@ -268,7 +268,8 @@ struct GemmUniversalBlockwise {
     if (!kSplitKSerial || gemm_k_iterations > 0) {
       // Compute threadblock-scoped matrix multiply-add
       mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators,
-          params.scale_A, params.scale_B);
+          params.scale_A, params.scale_B, threadblock_tile_offset.m(),
+          threadblock_tile_offset.n());
     }
 
     //

--- a/include/cutlass/gemm/threadblock/mma_multistage_blockwise.h
+++ b/include/cutlass/gemm/threadblock/mma_multistage_blockwise.h
@@ -406,23 +406,21 @@ public:
       ///< initial value of accumulator
       FragmentC const &src_accum,
       cutlass::TensorRef<ElementScale, LayoutScale> scaleA,
-      cutlass::TensorRef<ElementScale, LayoutScale> scaleB) {
-    // Each scale element corresponds to a 128x128 tile along (M, K) for A and
-    // (N, K) for B. Grid dimension  X enumerates threadblock tiles along M and
-    // grid dimension Y along N when GemmIdentityThreadblockSwizzle is used with
-    // the default N = 1 (tile = 1). Therefore,
-    //   blockIdx.x -> tile index along the M dimension
-    //   blockIdx.y -> tile index along the N dimension.
+      cutlass::TensorRef<ElementScale, LayoutScale> scaleB,
+      ///< logical threadblock tile index along M after swizzling
+      int threadblock_tile_m,
+      ///< logical threadblock tile index along N after swizzling
+      int threadblock_tile_n) {
 
     constexpr int kScaleBlock = 128;
     // Row-wise block index for A (and output C/D) – one per 128 rows.
-    int block_m_idx = (blockIdx.x * Shape::kM) / kScaleBlock;
+    int block_m_idx = (threadblock_tile_m * Shape::kM) / kScaleBlock;
 
     // Column-wise block index for B – one per 128 columns.  Note that each
     // threadblock processes Shape::kN columns, which may be < 128 (64 in this
     // kernel).  We therefore map two consecutive threadblock tiles onto the
     // same 128-wide scale block when Shape::kN < kScaleBlock.
-    int block_n_idx = (blockIdx.y * Shape::kN) / kScaleBlock;
+    int block_n_idx = (threadblock_tile_n * Shape::kN) / kScaleBlock;
 
     // Prologue (start fetching iterations of global fragments into shared
     // memory)

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -574,6 +574,12 @@ cutlass_test_unit_gemm_device_add_executable(
 )
 
 cutlass_test_unit_gemm_device_add_executable(
+  cutlass_test_unit_gemm_device_tensorop_sm89_blockwise
+
+  gemm_f8t_f8n_bf16t_tensor_op_f32_blockwise_sm89.cu
+)
+
+cutlass_test_unit_gemm_device_add_executable(
   cutlass_test_unit_gemm_device_grouped
 
   BATCH_SOURCES ON

--- a/test/unit/gemm/device/gemm_f8t_f8n_bf16t_tensor_op_f32_blockwise_sm89.cu
+++ b/test/unit/gemm/device/gemm_f8t_f8n_bf16t_tensor_op_f32_blockwise_sm89.cu
@@ -1,0 +1,197 @@
+/***************************************************************************************************
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+/*! \file
+    \brief Tests SM89 FP8 blockwise GEMM with threadblock swizzling.
+*/
+
+#include "../../common/cutlass_unit_test.h"
+
+#include "cutlass/arch/arch.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/device/gemm_blockwise.h"
+#include "cutlass/gemm/threadblock/threadblock_swizzle.h"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/util/host_tensor.h"
+#include "cutlass/util/reference/host/tensor_fill.h"
+
+#if defined(CUTLASS_ARCH_MMA_F32_SM89_SUPPORTED)
+
+namespace {
+
+using ElementA = cutlass::float_e4m3_t;
+using ElementB = cutlass::float_e4m3_t;
+using ElementOutput = cutlass::bfloat16_t;
+using ElementAccumulator = float;
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::ColumnMajor;
+using LayoutC = cutlass::layout::RowMajor;
+using LayoutScale = cutlass::layout::RowMajor;
+
+int const kM = 256;
+int const kN = 256;
+int const kK = 128;
+int const kScaleBlock = 128;
+
+using EpilogueOutputOp = cutlass::epilogue::thread::LinearCombination<
+    ElementOutput, 8, ElementAccumulator, ElementAccumulator>;
+
+template <typename ThreadblockSwizzle>
+using Gemm = cutlass::gemm::device::GemmBlockwise<
+    ElementA, LayoutA, ElementB, LayoutB, ElementOutput, LayoutC,
+    ElementAccumulator, cutlass::arch::OpClassTensorOp, cutlass::arch::Sm89,
+    cutlass::gemm::GemmShape<64, 128, 128>,
+    cutlass::gemm::GemmShape<64, 64, 128>,
+    cutlass::gemm::GemmShape<16, 8, 32>, float, LayoutScale, kScaleBlock,
+    EpilogueOutputOp, ThreadblockSwizzle, 3, 16, 16, false,
+    cutlass::arch::OpMultiplyAdd>;
+
+template <typename ThreadblockSwizzle>
+::testing::AssertionResult run_blockwise_gemm() {
+  using Operator = Gemm<ThreadblockSwizzle>;
+
+  cutlass::HostTensor<ElementA, LayoutA> tensor_a({kM, kK});
+  cutlass::HostTensor<ElementB, LayoutB> tensor_b({kK, kN});
+  cutlass::HostTensor<ElementOutput, LayoutC> tensor_c({kM, kN});
+  cutlass::HostTensor<ElementOutput, LayoutC> tensor_d({kM, kN});
+  cutlass::HostTensor<float, LayoutScale> scale_a({kM / kScaleBlock, 1});
+  cutlass::HostTensor<float, LayoutScale> scale_b({kN / kScaleBlock, 1});
+
+  cutlass::reference::host::TensorFill(tensor_a.host_view(), ElementA(1));
+  cutlass::reference::host::TensorFill(tensor_b.host_view(), ElementB(1));
+  cutlass::reference::host::TensorFill(tensor_c.host_view(), ElementOutput(0));
+  cutlass::reference::host::TensorFill(tensor_d.host_view(), ElementOutput(0));
+
+  // Powers-of-two scales keep the expected BF16 outputs exactly representable.
+  scale_a.host_view().at({0, 0}) = 1.0f;
+  scale_a.host_view().at({1, 0}) = 4.0f;
+  scale_b.host_view().at({0, 0}) = 2.0f;
+  scale_b.host_view().at({1, 0}) = 8.0f;
+
+  tensor_a.sync_device();
+  tensor_b.sync_device();
+  tensor_c.sync_device();
+  tensor_d.sync_device();
+  scale_a.sync_device();
+  scale_b.sync_device();
+
+  typename Operator::TensorRefScale scale_a_ref(
+      scale_a.device_data(), LayoutScale(1));
+  typename Operator::TensorRefScale scale_b_ref(
+      scale_b.device_data(), LayoutScale(1));
+  typename Operator::Arguments arguments(
+      {kM, kN, kK}, {tensor_a.device_data(), kK},
+      {tensor_b.device_data(), kK}, {tensor_c.device_data(), kN},
+      {tensor_d.device_data(), kN}, scale_a_ref, scale_b_ref,
+      typename Operator::EpilogueOutputOp::Params(1.0f, 0.0f));
+
+  cutlass::Status status = Operator::can_implement(arguments);
+  if (status != cutlass::Status::kSuccess) {
+    return ::testing::AssertionFailure()
+           << "can_implement failed with status " << int(status);
+  }
+
+  Operator gemm;
+  status = gemm.initialize(arguments, nullptr);
+  if (status != cutlass::Status::kSuccess) {
+    return ::testing::AssertionFailure()
+           << "initialize failed with status " << int(status);
+  }
+
+  status = gemm();
+  if (status != cutlass::Status::kSuccess) {
+    return ::testing::AssertionFailure()
+           << "launch failed with status " << int(status);
+  }
+
+  cudaError_t cuda_status = cudaDeviceSynchronize();
+  if (cuda_status != cudaSuccess) {
+    return ::testing::AssertionFailure()
+           << "synchronize failed: " << cudaGetErrorString(cuda_status);
+  }
+
+  tensor_d.sync_host();
+
+  uint64_t mismatches = 0;
+  int first_m = -1;
+  int first_n = -1;
+  float first_expected = 0;
+  float first_observed = 0;
+  float const scale_a_values[] = {1.0f, 4.0f};
+  float const scale_b_values[] = {2.0f, 8.0f};
+
+  for (int m = 0; m < kM; ++m) {
+    for (int n = 0; n < kN; ++n) {
+      float expected = float(kK) * scale_a_values[m / kScaleBlock] *
+                       scale_b_values[n / kScaleBlock];
+      float observed = float(tensor_d.host_view().at({m, n}));
+      if (observed != expected) {
+        if (!mismatches) {
+          first_m = m;
+          first_n = n;
+          first_expected = expected;
+          first_observed = observed;
+        }
+        ++mismatches;
+      }
+    }
+  }
+
+  if (mismatches) {
+    return ::testing::AssertionFailure()
+           << mismatches << " mismatches; first at (" << first_m << ", "
+           << first_n << "): expected " << first_expected << ", observed "
+           << first_observed;
+  }
+
+  return ::testing::AssertionSuccess();
+}
+
+}  // namespace
+
+TEST(SM89_Device_GemmBlockwise_fe4m3t_fe4m3n_bf16t_tensor_op_f32,
+     identity_1_256x256x128_64x128x128) {
+  using Swizzle =
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<1>;
+  EXPECT_TRUE(run_blockwise_gemm<Swizzle>());
+}
+
+// Identity<2> exercises a nontrivial physical-to-logical CTA mapping.
+TEST(SM89_Device_GemmBlockwise_fe4m3t_fe4m3n_bf16t_tensor_op_f32,
+     identity_2_256x256x128_64x128x128) {
+  using Swizzle =
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<2>;
+  EXPECT_TRUE(run_blockwise_gemm<Swizzle>());
+}
+
+#endif  // CUTLASS_ARCH_MMA_F32_SM89_SUPPORTED


### PR DESCRIPTION
## Problem

`MmaMultistageBlockwise` derives the `ScaleA` and `ScaleB` row indices from the raw CUDA block coordinates, `blockIdx.x` and `blockIdx.y`.

With `GemmIdentityThreadblockSwizzle<N>` and `N > 1`, the physical launch coordinates do not necessarily match the logical GEMM tile coordinates returned by the swizzle and used by the operand iterators and epilogue. The blockwise mainloop can therefore select scale rows that do not correspond to the M and N tiles being processed. This produces incorrect output and can read beyond exact-size scale tensors.

## Fix

Pass the post-swizzle logical M and N tile coordinates from `GemmUniversalBlockwise` to `MmaMultistageBlockwise`, and use those coordinates when calculating the blockwise scale row indices instead of reading `blockIdx` directly.

Add an SM89 FP8 blockwise regression test covering:

- `GemmIdentityThreadblockSwizzle<1>` as a positive control.
- `GemmIdentityThreadblockSwizzle<2>` as the swizzled case that exposes the incorrect indexing.

The regression uses a `256x256x128` problem with a `64x128x128` threadblock shape, creating multiple logical tiles along both M and N. A and B are filled with ones, while each 128-row M scale block and 128-column N scale block uses a distinct power-of-two value, so the expected result can be computed directly for every output element.

The scale tensors are allocated at their exact required size, and the full output matrix is compared exactly. This makes an incorrect scale-row selection observable and prevents it from being hidden by unused padding.

## Validation

Tested on an NVIDIA GeForce RTX 4060 Laptop GPU (Ada, SM89) with CUDA 12.8 under WSL2 Ubuntu 24.04.

- New SM89 blockwise unit-test target: 2/2 tests passed.
- Before the fix, the `Identity<2>` case produced 49,152 output mismatches.
- After the fix, the same case matched the expected output exactly.
- Compute Sanitizer memcheck on the fixed `Identity<2>` case reported 0 errors.
- Additional local checks passed with `Identity<4>`, multiple non-split K scale blocks, and the public ColumnMajor adapter.
- Example 94 SM89 FP8 blockwise verification passed.
- Existing adjacent SM89 unit tests: 34/34 passed.
- `git diff --check` passed.