### PR TITLE
[CuTe DSL] Raise a clear error when jit source is stale instead of silently misbehaving, issue #3395

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
@@ -789,8 +789,65 @@ class DSLPreprocessor(ast.NodeTransformer):
             # Under REPL mode, there is no way to get source of a function object, error out
             raise DSLRuntimeError(
                 f"Failed to parse function {func_name}",
-                suggestion="DSL does not support REPL mode, save the function to a file instead.",
+                suggestion=(
+                    "DSL does not support REPL mode, save the function to a file instead. "
+                    "If the source file was modified after the module was imported (e.g. the "
+                    "package was upgraded in place), restart the process or reload the module."
+                ),
             )
+
+        # Step 1.1 Guard against stale source. Preprocessing is lazy (it runs on the
+        # first call), and the source is re-read from disk here. If the file changed
+        # after the module was imported, co_firstlineno points at the wrong block and
+        # the extracted source belongs to a different statement or function. Without
+        # this check that either silently skips preprocessing (the function later
+        # fails with a confusing dynamic-value-to-bool error on its first dynamic
+        # `if`), or dies replacing __code__ ("requires a code object with N free
+        # vars"), or -- worst -- silently transforms a *different same-named* function
+        # and swaps its code into this one.
+        # (Lambdas have no retrievable `def` block and are skipped by the decorator
+        # check below anyway, so they are exempt from this guard.)
+        parsed = tree.body[0] if tree.body else None
+        if func_name != "<lambda>":
+            stale_reason = None
+            if not isinstance(parsed, ast.FunctionDef) or parsed.name != func_name:
+                found = getattr(
+                    parsed, "name", type(parsed).__name__ if parsed is not None else "<empty>"
+                )
+                stale_reason = f"defines `{found}` instead"
+            else:
+                # Same name: cross-check the declared parameters against the code
+                # object we hold; a stale line number can land on a same-named
+                # function of another class or scope with a different signature.
+                arg_spec = parsed.args
+                declared_params = [p.arg for p in arg_spec.posonlyargs + arg_spec.args + arg_spec.kwonlyargs]
+                if arg_spec.vararg is not None:
+                    declared_params.append(arg_spec.vararg.arg)
+                if arg_spec.kwarg is not None:
+                    declared_params.append(arg_spec.kwarg.arg)
+                code = function_pointer.__code__
+                n_params = (
+                    code.co_argcount
+                    + code.co_kwonlyargcount
+                    + bool(code.co_flags & inspect.CO_VARARGS)
+                    + bool(code.co_flags & inspect.CO_VARKEYWORDS)
+                )
+                if (
+                    len(arg_spec.posonlyargs) + len(arg_spec.args) != code.co_argcount
+                    or len(arg_spec.kwonlyargs) != code.co_kwonlyargcount
+                    or declared_params != list(code.co_varnames[:n_params])
+                ):
+                    stale_reason = "declares a different signature"
+            if stale_reason is not None:
+                raise DSLRuntimeError(
+                    f"Source extracted for function `{func_name}` ({file_name}:{start_line}) "
+                    f"{stale_reason} -- the source file appears to have been modified "
+                    "after the module was imported.",
+                    suggestion=(
+                        "Restart the process (or re-import/reload the module) so the "
+                        "in-memory code and the on-disk source agree."
+                    ),
+                )
 
         # Step 1.2 Check the decorator
         if not self.check_decorator(tree.body[0]):


### PR DESCRIPTION
## Problem of https://github.com/NVIDIA/cutlass/issues/3395

`@cute.jit` AST preprocessing is lazy: it runs at the *first call/compile* of each function, and at that point it re-reads the function source **from disk** via `inspect.getsourcelines`, slicing the current file at the in-memory code object's `co_firstlineno` (`base_dsl/ast_preprocessor.py::transform_function`).

If the source file was modified after the module was imported — typically a package upgraded **in place** while a long-lived process (serving worker, orchestrator, notebook kernel) still holds the old modules — the extracted slice is misaligned, and there is no consistency check. What happens next depends on what text sits at the stale line number:

1. **Slice has no DSL decorator**: `check_decorator` returns False, `transform_function` silently returns `[]`, `run_preprocessor` returns `None`, and `_preprocess_and_replace_code` silently skips the code replacement. The kernel then runs as plain Python with no control-flow staging, and its first dynamic `if` raises the confusing `error[PHASE_DYNAMIC_TO_STATIC_BOOL]: Cannot use a Runtime value (Staged value) value where a Python value (Meta value) boolean is required` ("Unable to convert dynamic `Boolean` value to bool" in older wording). Class methods hit this path.
2. **Top-level functions**: the (empty) transformed module is exec'd, the name resolves back to the original jit wrapper from the module globals, and code replacement dies with `ValueError: f() requires a code object with 0 free vars, not 3`.
3. **Worst case — silent wrong-code swap**: if the stale offset lands on a *different same-named* decorated function (e.g. `__call__` methods of sibling classes in one file), the preprocessor transforms *that* function, `exec` binds it under the bare name, and the original function's `__code__` is replaced with the wrong function's body — **no error at all**.

None of these point at the actual cause. Found while debugging Dao-AILab/flash-attention#2716, where attribution took ~20 experiment rounds across two engineers. Repros are GPU-independent and hit `nvidia-cutlass-dsl` 4.6.1 and 4.6.0.dev0 alike, on CPython 3.10 and 3.12.

## Fix

Guard `transform_function` right after parsing the extracted slice:

1. If the slice is not a `FunctionDef` named `func_name`, raise a `DSLRuntimeError` naming the mismatch and the likely cause, with a restart/reload suggestion:

   ```
   DSLRuntimeError: Source extracted for function `load_KV`
   (flash_fwd_sm100.py:3028) defines `load_Q_non_tma` instead -- the source file
   appears to have been modified after the module was imported.
   suggestion: Restart the process (or re-import/reload the module) so the
   in-memory code and the on-disk source agree.
   ```

   `<lambda>` is exempt (no retrievable `def` block; already skipped by the decorator check).
2. If the name matches, cross-check the declared parameter list against the code object (`co_varnames` / `co_argcount` / `co_kwonlyargcount` / vararg / kwarg flags) — a stale offset can land on a same-named method of another class with a different signature.
3. Extend the parse-failure suggestion (previously REPL-only) to also mention in-place source modification.

No behavior change for consistent sources; single-file change, +58/−1.

## Validation

- **Minimal repros** (no GPU; CPython 3.10 + 3.12; dsl 4.6.1 + 4.6.0.dev0): top-level function, class-method, and same-named-function variants — every previously-cryptic failure above now raises the clear stale-source error; untouched files compile exactly as before.
- **Real-workload regression**: flash-attention SM100 forward kernels on B200 — bf16 / fp8-e4m3 / fp8-e5m2 compiles plus a repeated warm call, results bit-identical with and without this patch.
- **Stale-file scenarios on the same kernels** (import → replace `flash_fwd_sm100.py` in place → first trace): previously `Unable to convert dynamic Boolean value to bool at compile time`, now the clear error quoted above.

## Known residual (for discussion)

A same-name **and** same-signature swap (mode 3 with twin methods) is not detectable from the slice alone. We prototyped recompiling the slice and comparing code objects, but CPython emits different bytecode for identical source depending on compile context (class body vs wrapped block — the method-call specialization bits in `LOAD_GLOBAL`/`LOAD_ATTR` opargs differ), so bytecode equality is not a sound invariant; it false-positived on real kernels and was dropped. The complete fix would capture the source (or a hash of it) eagerly at decoration time — happy to explore that in a follow-up if maintainers prefer. `f = cute.jit(g)` (non-`@` usage) silently skips preprocessing today and is unchanged by this PR.