### PR TITLE
[CuTeDSL] Make autotuning more user friendly & new docs

### DIFF
--- a/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
@@ -393,10 +393,20 @@ Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is n
     compiled_gemm(*args)
 
 ``reports`` holds one timing table per case (each configuration's measured time, fastest first) so user can use this to decide what's their favorite configuration, 
-and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations. 
+and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations
 
 The heuristic behind this is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good
-among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). 
+among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). It will return the top 5
+most widely accepted configurations like this:
+
+.. code-block:: text
+
+    recommended configs:
+        {'cluster_shape_mn': (2, 1), 'max_active_clusters': 76, 'mma_tiler_mn': (128, 128), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 2/2 cases
+        {'cluster_shape_mn': (2, 1), 'max_active_clusters': 76, 'mma_tiler_mn': (256, 256), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 2/2 cases
+        {'cluster_shape_mn': (2, 2), 'max_active_clusters': 36, 'mma_tiler_mn': (256, 128), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 1/2 cases
+        {'cluster_shape_mn': (2, 1), 'max_active_clusters': 76, 'mma_tiler_mn': (256, 128), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 1/2 cases
+        {'cluster_shape_mn': (2, 2), 'max_active_clusters': 36, 'mma_tiler_mn': (256, 128), 'use_2cta_instrs': True, 'use_tma_store': False}: accepted in 1/2 cases
 
 Note: about ``workspace_count``, this is the parameter that is crucial to ensure the benchmarking is accurate in terms of memory bandwidth.
 This means ``autotune_suite`` will allocate a workspace of size ``workspace_count`` copies of input arguments using ``make_arguments`` you pass, 

--- a/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
@@ -148,3 +148,231 @@ approximation doesn't negatively impact performance for your specific use case.
 
 By following the methods above, you can customize your own auto-tuner to find the optimal GEMM kernel configuration 
 for specific matrix dimensions and data types, significantly improving computational performance for models.
+
+Autotuning JIT kernels with CuTeDSL functions
+---------------------------------------------
+
+The manual ``autotune_gemm`` loop above demonstrates the general principle behind tuning CuTeDSL kernels. 
+CuTeDSL provides a higher-level interface for this process which relies on the same underlying mechanism, 
+which is the ``autotune_jit`` decorator from ``cutlass.cute.testing``. It performs the same "compile every
+configuration, benchmark, keep the best" strategy but it does so automatically,
+with handling the search space sweep lazily when function is called, performing the cold-L2 benchmarking 
+and caching compiled kernel automatically for you.
+
+We still use the persistent GEMM kernel as an example. We first need to define the ``@cute.jit`` function.
+It should accepts the turnable parameters as ``Constexpr`` keyword arguments.
+The non-autotuned version should look like this:
+
+.. code-block:: python
+
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.cute.testing as testing
+    from dense_gemm_persistent import PersistentDenseGemmKernel
+
+    @cute.jit
+    def gemm(
+        a, b, c, stream, m, n, k,
+        use_2cta_instrs: cutlass.Constexpr = True,
+        use_tma_store: cutlass.Constexpr = True,
+        mma_tiler_mn: cutlass.Constexpr = (256, 256),
+        cluster_shape_mn: cutlass.Constexpr = (2, 1),
+        max_active_clusters: cutlass.Constexpr = 0,
+    ):
+        kernel = PersistentDenseGemmKernel(
+            cutlass.Float32,  # acc_dtype
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            use_tma_store,
+        )
+        kernel(a, b, c, max_active_clusters, stream)
+
+Since ``cluster_shape_mn`` is a tunable parameter and it's unknown when we do the grid sweep and search the optimal configuration, 
+``autotune_jit`` needs to know how to compute ``max_active_clusters`` on the host side based on the current  ``cluster_shape_mn`` value when tuning.
+Therefore, to allow this function to be autotuned with ``max_active_clusters`` being a parameter, we need to define an 
+auxiliary function on the host side to derive the ``max_active_clusters`` parameter from the swept ``cluster_shape_mn`` value when tuning.
+
+
+.. code-block:: python
+
+    # max_active_clusters is derived from the swept cluster_shape_mn. It is
+    # computed on the host, because HardwareInfo cannot run inside @cute.jit.
+    def derive_max_active_clusters(cluster_shape_mn):
+        return cutlass.utils.HardwareInfo().get_max_active_clusters(
+            cluster_shape_mn[0] * cluster_shape_mn[1]
+        )
+
+
+The search space is a dictionary mapping each tunable parameter to its candidate
+values; every combination is tried. Add more candidates to a list to widen the
+sweep:
+
+.. code-block:: python
+
+    search_space = {
+        "use_2cta_instrs": [True],
+        "use_tma_store": [False, True],
+        "mma_tiler_mn": [(128, 128), (256, 128), (256, 256)],
+        "cluster_shape_mn": [(2, 1), (2, 2)],
+    }
+
+Then we can decorate the CuTeDSL function with ``autotune_jit`` to sweep this search space and find the best configuration.
+The first call to the decorated function for a given m, n, k problem size sweeps the search space, benchmarks each configuration and caches the best compiled kernel; 
+and subsequent calls whose ``update_on_change`` values (here ``m, n, k``) are unchanged reuse it without re-tuning. 
+
+For parameters in ``param_dict``, they are removed from the decorated function's signature so when calling the decorated function you do not need to pass them, and they are automatically tuned.
+And parameters in ``derived_params`` work similarly; you don't pass them and their value will be derived from the current values of the other parameters in ``param_dict`` using the function you provides, 
+whose signature must match the parameters in ``param_dict`` that it depends on with the same name. So for example, ``derive_max_active_clusters`` above takes ``cluster_shape_mn`` as an argument, 
+and it will use the current value of ``cluster_shape_mn`` for each configuration during the sweep to derive the value of ``max_active_clusters`` argument.
+For parameters in ``update_on_change``, they are used as the key to cache compiled kernels, so when any of them changes the decorated function will re-tune and cache a new best kernel for that combination. 
+When calling the decorated function, you still need to pass them as normal arguments.
+
+.. code-block:: python
+
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.cute.testing as testing
+    from dense_gemm_persistent import PersistentDenseGemmKernel
+
+    @testing.autotune_jit(
+        params_dict=search_space,
+        update_on_change=["m", "n", "k"],
+        derived_params={"max_active_clusters": derive_max_active_clusters},
+        warmup_iterations=5,
+        iterations=100,
+    )
+    @cute.jit
+    def autotuned_gemm(
+        a, b, c, stream, m, n, k,
+        use_2cta_instrs: cutlass.Constexpr = True,
+        use_tma_store: cutlass.Constexpr = True,
+        mma_tiler_mn: cutlass.Constexpr = (256, 256),
+        cluster_shape_mn: cutlass.Constexpr = (2, 1),
+        max_active_clusters: cutlass.Constexpr = 0,
+    ):
+        kernel = PersistentDenseGemmKernel(
+            cutlass.Float32,  # acc_dtype
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            use_tma_store,
+        )
+        kernel(a, b, c, max_active_clusters, stream)
+
+    autotuned_gemm(a, b, c, stream, m, n, k)  # first call for this (m, n, k) autotunes
+    autotuned_gemm(a, b, c, stream, m, n, k)  # subsequent calls reuse the cached best kernel
+
+Autotuning JIT kernels with classes
+-----------------------------------
+
+Many CuTe DSL kernels are written as classes: the tunable configuration is passed
+to the constructor, and a ``@cute.jit`` ``__call__`` method takes only the dynamic
+runtime arguments (which is the structure of ``PersistentDenseGemmKernel`` used
+above). ``autotune_jit`` can decorate such a class directly, without writing an
+adapter. It turns the class into a *partial* class: the tunable constructor
+parameters are removed (which are auto-tuned), so you can use the decorated class like a
+normal class -- you just do not pass the tunable parameters when instantiating.
+
+Take a small elementwise-add kernel as an example, where ``elementwise_add`` is a
+``@cute.jit`` function implementing the vectorized addition operation:
+
+.. code-block:: python
+
+    @testing.autotune_jit(
+        params_dict={"COPY_BITS": [32, 64, 128], "THREADS_M": [4, 8]},
+        update_on_change=["M", "N"],
+        warmup_iterations=10,
+        iterations=50,
+    )
+    class ElementwiseAddKernel:
+        def __init__(self, COPY_BITS=128, THREADS_M=4):
+            self.COPY_BITS = COPY_BITS
+            self.THREADS_M = THREADS_M
+
+        @cute.jit
+        def __call__(self, mA, mB, mC, M, N):
+            elementwise_add(
+                mA, mB, mC, M, N,
+                copy_bits=self.COPY_BITS,
+                threads_m=self.THREADS_M,
+            )
+
+    autotuned_add = ElementwiseAddKernel()   # instantiate (no tunable params)
+    autotuned_add(a, b, c, M, N)             # first call for this (M, N) autotunes
+    autotuned_add(a, b, c, M, N)             # subsequent calls reuse the cached best kernel
+
+
+- ``params_dict`` takes the tuneable parameters that are passed to the class constructor (``COPY_BITS``,
+  ``THREADS_M``). These are constexprs that instantiate the kernel, and are fixed at the runtime.
+  When user create an instance of the decorated class, they do not need to pass these parameters, and they will be auto-tuned.
+  These tuneable parameters are removed from the decorated class's constructor signature.
+  For non-tuneable parameters, user should still pass them when creating the instance as usual.
+- ``update_on_change`` names the ``__call__`` arguments to key the cache on
+  (``M``, ``N``). When any of these change, the decorated class will re-tune and cache a new best kernel for that combination.
+- Because the tunable parameters are separated into the constructor, the ``@cute.jit`` ``__call__`` takes only the dynamic arguments. 
+  Therefore, unlike the decorated CuTeDSL function where it takes both the dynamic and tunable parameters in the signature,
+  the separation here is clearer: the constructor parameters defines the kernel configuration which are used to compile the kernel.
+  Then, ``__call__`` takes the dynamic arguments that may change per execution.
+
+
+Choosing one configuration for many shapes
+-------------------------------------------
+
+The JIT path tunes each problem size on its first call. When you instead need a single configuration baked into an ahead-of-time (AOT) build, 
+or you simply don't want to compile kernels too often when input shapes change frequently, you can use ``autotune_suite`` to find one that performs well
+across the shapes your application sees. ``autotune_suite`` allows you to grid-search the same space over a list of representative problem sizes.
+For each case it builds fresh inputs with ``make_arguments`` whose parameters , compiles and benchmarks every
+configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations. 
+You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes. 
+
+.. code-block:: python
+
+    import cuda.bindings.driver as cuda
+
+    torch_stream = torch.cuda.Stream()
+    stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    def make_arguments(m, n, k):
+        # Batched GEMM with a hardcoded batch size l = 1. The kernel takes
+        # rank-3 tensors, so we build torch tensors with the shape and major
+        # ordering it expects and pass them directly -- CuTe DSL accepts torch
+        # tensors via DLPack (a plain 2D torch tensor would be the wrong rank):
+        #   A: (m, k, l) m-major, B: (n, k, l) k-major, C: (m, n, l) m-major
+        l = 1
+        a = torch.randn(l, k, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        b = torch.randn(l, n, k, dtype=torch.float16, device="cuda").permute(1, 2, 0)
+        c = torch.zeros(l, n, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        return a, b, c, stream, m, n, k
+
+    with torch.cuda.stream(torch_stream):
+        reports, recommended = testing.autotune_suite(
+            gemm,
+            make_arguments,
+            cases=[
+                (2048, 2048, 4096),  # representative (m, n, k) problem sizes
+                (4096, 4096, 2048),
+            ],
+            params_dict=search_space,
+            derived_params={"max_active_clusters": derive_max_active_clusters},
+            accept_percentile=50,  # keep each case's fastest half of the configs
+            stream=stream,
+        )
+
+    # recommended is ranked by how many cases accepted each config within the
+    # percentile; pick the top one and compile it ahead of time.
+    best_config = recommended[0]["config"]
+    args = make_arguments(2048, 2048, 4096)
+    compiled_gemm = cute.compile(gemm, *args, **best_config)
+    compiled_gemm(*args)
+
+``reports`` holds one timing table per case (each configuration's measured time,
+fastest first), and ``recommended`` ranks configurations by how many cases
+accepted them within ``accept_percentile``. Use ``reports[i]["best_config"]`` when
+a separate kernel per problem size is acceptable, or ``recommended[0]["config"]``
+when a single configuration must serve all shapes.
+
+For stable, reproducible measurements, lock the GPU's SM and memory frequencies
+with ``nvidia-smi`` before running the sweep; the number of warmup iterations,
+timed iterations and cold-L2 workspaces are controlled by ``autotune_suite``'s
+``warmup_iterations``, ``iterations`` and ``workspace_count`` parameters.

--- a/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
@@ -305,9 +305,10 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
         iterations=50,
     )
     class ElementwiseAddKernel:
-        def __init__(self, COPY_BITS=128, THREADS_M=4):
+        THREADS_M = 4 # default value; can be overridden by autotune_jit
+
+        def __init__(self, COPY_BITS=128):
             self.COPY_BITS = COPY_BITS
-            self.THREADS_M = THREADS_M
 
         @cute.jit
         def __call__(self, mA, mB, mC, M, N):

--- a/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
@@ -156,11 +156,11 @@ The manual ``autotune_gemm`` loop above demonstrates the general principle behin
 CuTeDSL provides a higher-level interface for this process which relies on the same underlying mechanism, 
 which is the ``autotune_jit`` decorator from ``cutlass.cute.testing``. It performs the same "compile every
 configuration, benchmark, keep the best" strategy but it does so automatically,
-with handling the search space sweep lazily when function is called, performing the cold-L2 benchmarking 
-and caching compiled kernel automatically for you.
+handling the search-space sweep lazily when the function is called, performing the cold-L2 benchmarking,
+and caching the compiled kernel automatically for you.
 
 We still use the persistent GEMM kernel as an example. We first need to define the ``@cute.jit`` function.
-It should accepts the turnable parameters as ``Constexpr`` keyword arguments.
+It should accept the tunable parameters as ``Constexpr`` keyword arguments.
 
 The non-autotuned version should look like this:
 
@@ -280,7 +280,7 @@ When calling the decorated function, you still need to pass them as normal argum
 
     autotuned_gemm(a, b, c, stream, M, N, K)  # first call for this (M, N, K) autotunes
     autotuned_gemm(a, b, c, stream, M, N, K)  # subsequent calls reuse the cached best kernel
-    print(f"Best config for autotuned_gemm: {autotuned_gemm._best_config}")
+    print(f"Best config for autotuned_gemm: {autotuned_gemm._best_config[(M, N, K)]}")
 
 Autotuning JIT kernels with classes
 -----------------------------------
@@ -320,12 +320,12 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
     autotuned_add = ElementwiseAddKernel()   # instantiate (no tunable params)
     autotuned_add(a, b, c, M, N)             # first call for this (M, N) autotunes
     autotuned_add(a, b, c, M, N)             # subsequent calls reuse the cached best kernel
-    print(f"Best config for autotuned_add: {autotuned_add._best_config}")
+    print(f"Best config for autotuned_add: {autotuned_add._best_config[(M, N)]}")
 
 
 - ``params_dict`` takes the tuneable parameters that are passed to the class constructor (``COPY_BITS``,
-  ``THREADS_M``). These are constexprs that instantiate the kernel, and are fixed at the runtime.
-  When user create an instance of the decorated class, they do not need to pass these parameters, and they will be auto-tuned.
+  ``THREADS_M``). These are constexprs used to instantiate the kernel, and are baked in at compile time.
+  When you create an instance of the decorated class, you do not need to pass these parameters; they will be auto-tuned.
   These tuneable parameters are removed from the decorated class's constructor signature.
   For non-tuneable parameters, user should still pass them when creating the instance as usual.
   And ``derived_params`` and ``prune_configs`` work the same way as in the function case.
@@ -333,7 +333,7 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
   (``M``, ``N``). When any of these change, the decorated class will re-tune and cache a new best kernel for that combination.
 - Because the tunable parameters are separated into the constructor, the ``@cute.jit`` ``__call__`` takes only the dynamic arguments. 
   Therefore, unlike the decorated CuTeDSL function where it takes both the dynamic and tunable parameters in the signature,
-  the separation here is clearer: the constructor parameters defines the kernel configuration which are used to compile the kernel.
+  the separation here is clearer: the constructor parameters define the kernel configuration used to compile the kernel.
   Then, ``__call__`` takes the dynamic arguments that may change per execution.
 
 
@@ -343,8 +343,8 @@ Choosing one configuration for many shapes
 The JIT path tunes each problem size on its first call. When you instead need a single configuration baked into an ahead-of-time (AOT) build, 
 or you simply don't want to compile kernels too often when input shapes change frequently, you can use ``autotune_suite`` to find one that performs well
 across the shapes your application sees. ``autotune_suite`` allows you to grid-search the same space over a list of representative problem sizes.
-For each case it builds fresh inputs with ``make_arguments`` whose parameters , compiles and benchmarks every
-configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations. 
+For each case it builds fresh inputs with ``make_arguments``, compiles and benchmarks every
+configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations.
 
 You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes.
 
@@ -395,21 +395,21 @@ Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is n
 ``reports`` holds one timing table per case (each configuration's measured time, fastest first) so user can use this to decide what's their favorite configuration, 
 and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations. 
 
-The heruistic behind is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good 
+The heuristic behind this is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good
 among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). 
 
 Note: about ``workspace_count``, this is the parameter that is crucial to ensure the benchmarking is accurate in terms of memory bandwidth.
 This means ``autotune_suite`` will allocate a workspace of size ``workspace_count`` copies of input arguments using ``make_arguments`` you pass, 
 and it will cycle through these workspaces ``warmup_iterations`` + ``iterations`` times.
 To let the benchmark correctly reflect the achieved memory bandwidth, we would like to make sure our kernel is reading from HBM instead of L2 cache during the benchmarking. 
-Therefore, we need to make sure the workspace is large enough so that its size exceeds the L2 cache size, so when we finish one lap around the workspace ring buffer and get back To
+Therefore, we need to make sure the workspace is large enough so that its size exceeds the L2 cache size, so when we finish one lap around the workspace ring buffer and get back to
 the first workspace, the data is no longer in L2 cache and we are reading from HBM again.
 
 For example, suppose our input tensors use 2MB of memory, and the L2 cache size is 10MB. If we set ``workspace_count`` to 6, then the total workspace size is 12MB, 
 which **exceeds** the L2 cache size. In this case, when we are at iteration 7, the L2 cache would hold the 5 copies of inputs from workspace 2 to 6, and 
 iteration 7 uses workspace 1, which is no longer in L2 cache and is read from HBM. 
-In addition, a workspace whose size is equal to the L2 cache size is not sufficient, because in this case ``workspace_count`` is 5, which means at the 6th iteration we are back to workspace 1, 
-but it's is still in L2 cache because L2 cache is large enough to hold all 5 copies of the input tensors. Therefore, we would be reading from L2 cache instead of HBM, which is not what we want.
+In addition, a total workspace size equal to the L2 cache size is not sufficient, because in this case ``workspace_count`` is 5, which means at the 6th iteration we are back to workspace 1,
+but it is still in L2 cache because L2 cache is large enough to hold all 5 copies of the input tensors. Therefore, we would be reading from L2 cache instead of HBM, which is not what we want.
 The rule of thumb is that we need ``(workspace_count - 1) * size_of_input_data >= L2_cache_size`` to guarantee that when we finish one round and get back to the first workspace, its data is no longer in L2 cache.
 
 In conclusion, you should always set ``workspace_count`` to a proper value that ensures that the current benchmark run always reads from HBM due to its input being evicted from L2 cache, 

--- a/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/autotuning_gemm.rst
@@ -129,15 +129,15 @@ We could cache the tuning results in a input-to-kernel dictionary (e.g., ``input
 When processing inputs with matching ``config_key`` values, the cached kernel can be reused directly without re-tuning. 
 The ``config_key`` is related with the input tensor's characteristics, such as the shape, data type, etc. 
 The setup of ``config_key`` is very flexible, users can customize it based on their own application.
-For instance, if the data type is fixed in users' application, we could use the input tensor's shape as the key, i.e., ``(m, n, k)``. 
-To further reduce tuning overhead, we could consider using a simplified key like ``config_key = (power_of_2(m), power_of_2(n), power_of_2(k))``, 
-where ``m``, ``n``, and ``k`` are rounded up to the nearest power of 2. This simplification can significantly reduce the number 
+For instance, if the data type is fixed in users' application, we could use the input tensor's shape as the key, i.e., ``(M, N, K)``. 
+To further reduce tuning overhead, we could consider using a simplified key like ``config_key = (power_of_2(M), power_of_2(N), power_of_2(K))``, 
+where ``M``, ``N``, and ``K`` are rounded up to the nearest power of 2. This simplification can significantly reduce the number 
 of unique keys while still maintaining good performance in most cases. However, it's important to validate that this 
 approximation doesn't negatively impact performance for your specific use case. 
 
 .. code-block:: python
 
-    config_key = (m, n, k)
+    config_key = (M, N, K)
     if config_key in input_kernel_dict:
         compiled_gemm = input_kernel_dict[config_key]
     else:
@@ -161,6 +161,7 @@ and caching compiled kernel automatically for you.
 
 We still use the persistent GEMM kernel as an example. We first need to define the ``@cute.jit`` function.
 It should accepts the turnable parameters as ``Constexpr`` keyword arguments.
+
 The non-autotuned version should look like this:
 
 .. code-block:: python
@@ -171,8 +172,8 @@ The non-autotuned version should look like this:
     from dense_gemm_persistent import PersistentDenseGemmKernel
 
     @cute.jit
-    def gemm(
-        a, b, c, stream, m, n, k,
+    def non_autotuned_gemm(
+        a, b, c, stream, M, N, K,
         use_2cta_instrs: cutlass.Constexpr = True,
         use_tma_store: cutlass.Constexpr = True,
         mma_tiler_mn: cutlass.Constexpr = (256, 256),
@@ -217,9 +218,25 @@ sweep:
         "cluster_shape_mn": [(2, 1), (2, 2)],
     }
 
+The configurations we will search are the Cartesian product of all these lists, so there are 12 total configurations in this example.
+If you have a large search space, you can prune it by removing configurations that are known to be invalid or suboptimal using ``prune_configs``.
+``prune_configs`` is a predicate function whose parameters are a subset of the tunable parameters (the keys of ``params_dict`` with the same name).
+It returns ``True`` to keep a configuration or ``False`` to skip it. For example, to
+reject one specific configuration -- the largest tile paired with the largest
+cluster -- from the sweep:
+
+.. code-block:: python
+
+    def prune_config(mma_tiler_mn, cluster_shape_mn):
+        # only these two parameters are inspected; return False to drop this config
+        return not (mma_tiler_mn == (256, 256) and cluster_shape_mn == (2, 2))
+
+This drops 2 of the 12 configurations (``(256, 256)`` with ``(2, 2)`` for either
+``use_tma_store`` value), leaving 10 to benchmark.
+
 Then we can decorate the CuTeDSL function with ``autotune_jit`` to sweep this search space and find the best configuration.
-The first call to the decorated function for a given m, n, k problem size sweeps the search space, benchmarks each configuration and caches the best compiled kernel; 
-and subsequent calls whose ``update_on_change`` values (here ``m, n, k``) are unchanged reuse it without re-tuning. 
+The first call to the decorated function for a given M, N, K problem size sweeps the search space, benchmarks each configuration and caches the best compiled kernel; 
+and subsequent calls whose ``update_on_change`` values (here ``M, N, K``) are unchanged reuse it without re-tuning. 
 
 For parameters in ``param_dict``, they are removed from the decorated function's signature so when calling the decorated function you do not need to pass them, and they are automatically tuned.
 And parameters in ``derived_params`` work similarly; you don't pass them and their value will be derived from the current values of the other parameters in ``param_dict`` using the function you provides, 
@@ -237,14 +254,15 @@ When calling the decorated function, you still need to pass them as normal argum
 
     @testing.autotune_jit(
         params_dict=search_space,
-        update_on_change=["m", "n", "k"],
+        update_on_change=["M", "N", "K"],
         derived_params={"max_active_clusters": derive_max_active_clusters},
+        prune_configs=prune_config,
         warmup_iterations=5,
         iterations=100,
     )
     @cute.jit
     def autotuned_gemm(
-        a, b, c, stream, m, n, k,
+        a, b, c, stream, M, N, K,
         use_2cta_instrs: cutlass.Constexpr = True,
         use_tma_store: cutlass.Constexpr = True,
         mma_tiler_mn: cutlass.Constexpr = (256, 256),
@@ -260,8 +278,9 @@ When calling the decorated function, you still need to pass them as normal argum
         )
         kernel(a, b, c, max_active_clusters, stream)
 
-    autotuned_gemm(a, b, c, stream, m, n, k)  # first call for this (m, n, k) autotunes
-    autotuned_gemm(a, b, c, stream, m, n, k)  # subsequent calls reuse the cached best kernel
+    autotuned_gemm(a, b, c, stream, M, N, K)  # first call for this (M, N, K) autotunes
+    autotuned_gemm(a, b, c, stream, M, N, K)  # subsequent calls reuse the cached best kernel
+    print(f"Best config for autotuned_gemm: {autotuned_gemm._best_config}")
 
 Autotuning JIT kernels with classes
 -----------------------------------
@@ -301,6 +320,7 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
     autotuned_add = ElementwiseAddKernel()   # instantiate (no tunable params)
     autotuned_add(a, b, c, M, N)             # first call for this (M, N) autotunes
     autotuned_add(a, b, c, M, N)             # subsequent calls reuse the cached best kernel
+    print(f"Best config for autotuned_add: {autotuned_add._best_config}")
 
 
 - ``params_dict`` takes the tuneable parameters that are passed to the class constructor (``COPY_BITS``,
@@ -308,6 +328,7 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
   When user create an instance of the decorated class, they do not need to pass these parameters, and they will be auto-tuned.
   These tuneable parameters are removed from the decorated class's constructor signature.
   For non-tuneable parameters, user should still pass them when creating the instance as usual.
+  And ``derived_params`` and ``prune_configs`` work the same way as in the function case.
 - ``update_on_change`` names the ``__call__`` arguments to key the cache on
   (``M``, ``N``). When any of these change, the decorated class will re-tune and cache a new best kernel for that combination.
 - Because the tunable parameters are separated into the constructor, the ``@cute.jit`` ``__call__`` takes only the dynamic arguments. 
@@ -324,55 +345,72 @@ or you simply don't want to compile kernels too often when input shapes change f
 across the shapes your application sees. ``autotune_suite`` allows you to grid-search the same space over a list of representative problem sizes.
 For each case it builds fresh inputs with ``make_arguments`` whose parameters , compiles and benchmarks every
 configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations. 
-You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes. 
+
+You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes.
+
+Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is not decorated by ``@testing.autotune_jit``.
 
 .. code-block:: python
 
+    import torch
     import cuda.bindings.driver as cuda
+    from cutlass import cute
+    from cutlass.cute.testing import autotune_suite
 
     torch_stream = torch.cuda.Stream()
     stream = cuda.CUstream(torch_stream.cuda_stream)
 
-    def make_arguments(m, n, k):
-        # Batched GEMM with a hardcoded batch size l = 1. The kernel takes
-        # rank-3 tensors, so we build torch tensors with the shape and major
-        # ordering it expects and pass them directly -- CuTe DSL accepts torch
-        # tensors via DLPack (a plain 2D torch tensor would be the wrong rank):
-        #   A: (m, k, l) m-major, B: (n, k, l) k-major, C: (m, n, l) m-major
-        l = 1
-        a = torch.randn(l, k, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
-        b = torch.randn(l, n, k, dtype=torch.float16, device="cuda").permute(1, 2, 0)
-        c = torch.zeros(l, n, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
-        return a, b, c, stream, m, n, k
+    def make_arguments(M, N, K):
+        # Batched GEMM with a hardcoded batch size L = 1.
+        #   A: (M, K, L) M-major, B: (N, K, L) K-major, C: (M, N, L) M-major
+        L = 1
+        a = torch.randn(L, K, M, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        b = torch.randn(L, N, K, dtype=torch.float16, device="cuda").permute(1, 2, 0)
+        c = torch.zeros(L, N, M, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        return a, b, c, stream, M, N, K
 
     with torch.cuda.stream(torch_stream):
         reports, recommended = testing.autotune_suite(
-            gemm,
+            non_autotuned_gemm,
             make_arguments,
             cases=[
-                (2048, 2048, 4096),  # representative (m, n, k) problem sizes
+                (2048, 2048, 4096),  # representative (M, N, K) problem sizes
                 (4096, 4096, 2048),
             ],
             params_dict=search_space,
+            prune_configs=prune_config,
             derived_params={"max_active_clusters": derive_max_active_clusters},
             accept_percentile=50,  # keep each case's fastest half of the configs
+            print_summary=True,
             stream=stream,
         )
 
     # recommended is ranked by how many cases accepted each config within the
-    # percentile; pick the top one and compile it ahead of time.
+    # percentile you've given; here we just pick the top one and compile it ahead of time.
     best_config = recommended[0]["config"]
     args = make_arguments(2048, 2048, 4096)
-    compiled_gemm = cute.compile(gemm, *args, **best_config)
+    compiled_gemm = cute.compile(non_autotuned_gemm, *args, **best_config)
     compiled_gemm(*args)
 
-``reports`` holds one timing table per case (each configuration's measured time,
-fastest first), and ``recommended`` ranks configurations by how many cases
-accepted them within ``accept_percentile``. Use ``reports[i]["best_config"]`` when
-a separate kernel per problem size is acceptable, or ``recommended[0]["config"]``
-when a single configuration must serve all shapes.
+``reports`` holds one timing table per case (each configuration's measured time, fastest first) so user can use this to decide what's their favorite configuration, 
+and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations. 
 
-For stable, reproducible measurements, lock the GPU's SM and memory frequencies
-with ``nvidia-smi`` before running the sweep; the number of warmup iterations,
-timed iterations and cold-L2 workspaces are controlled by ``autotune_suite``'s
-``warmup_iterations``, ``iterations`` and ``workspace_count`` parameters.
+The heruistic behind is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good 
+among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). 
+
+Note: about ``workspace_count``, this is the parameter that is crucial to ensure the benchmarking is accurate in terms of memory bandwidth.
+This means ``autotune_suite`` will allocate a workspace of size ``workspace_count`` copies of input arguments using ``make_arguments`` you pass, 
+and it will cycle through these workspaces ``warmup_iterations`` + ``iterations`` times.
+To let the benchmark correctly reflect the achieved memory bandwidth, we would like to make sure our kernel is reading from HBM instead of L2 cache during the benchmarking. 
+Therefore, we need to make sure the workspace is large enough so that its size exceeds the L2 cache size, so when we finish one lap around the workspace ring buffer and get back To
+the first workspace, the data is no longer in L2 cache and we are reading from HBM again.
+
+For example, suppose our input tensors use 2MB of memory, and the L2 cache size is 10MB. If we set ``workspace_count`` to 6, then the total workspace size is 12MB, 
+which **exceeds** the L2 cache size. In this case, when we are at iteration 7, the L2 cache would hold the 5 copies of inputs from workspace 2 to 6, and 
+iteration 7 uses workspace 1, which is no longer in L2 cache and is read from HBM. 
+In addition, a workspace whose size is equal to the L2 cache size is not sufficient, because in this case ``workspace_count`` is 5, which means at the 6th iteration we are back to workspace 1, 
+but it's is still in L2 cache because L2 cache is large enough to hold all 5 copies of the input tensors. Therefore, we would be reading from L2 cache instead of HBM, which is not what we want.
+The rule of thumb is that we need ``(workspace_count - 1) * size_of_input_data >= L2_cache_size`` to guarantee that when we finish one round and get back to the first workspace, its data is no longer in L2 cache.
+
+In conclusion, you should always set ``workspace_count`` to a proper value that ensures that the current benchmark run always reads from HBM due to its input being evicted from L2 cache, 
+or just set it to a large enough value that is guaranteed to **exceed** the L2 cache size.

--- a/media/docs/pythonDSL/guides/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/guides/autotuning_gemm.rst
@@ -393,10 +393,20 @@ Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is n
     compiled_gemm(*args)
 
 ``reports`` holds one timing table per case (each configuration's measured time, fastest first) so user can use this to decide what's their favorite configuration, 
-and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations. 
+and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations
 
 The heuristic behind this is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good
-among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). 
+among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). It will return the top 5
+most widely accepted configurations like this:
+
+.. code-block:: text
+
+    recommended configs:
+        {'cluster_shape_mn': (2, 1), 'max_active_clusters': 76, 'mma_tiler_mn': (128, 128), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 2/2 cases
+        {'cluster_shape_mn': (2, 1), 'max_active_clusters': 76, 'mma_tiler_mn': (256, 256), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 2/2 cases
+        {'cluster_shape_mn': (2, 2), 'max_active_clusters': 36, 'mma_tiler_mn': (256, 128), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 1/2 cases
+        {'cluster_shape_mn': (2, 1), 'max_active_clusters': 76, 'mma_tiler_mn': (256, 128), 'use_2cta_instrs': True, 'use_tma_store': True}: accepted in 1/2 cases
+        {'cluster_shape_mn': (2, 2), 'max_active_clusters': 36, 'mma_tiler_mn': (256, 128), 'use_2cta_instrs': True, 'use_tma_store': False}: accepted in 1/2 cases
 
 Note: about ``workspace_count``, this is the parameter that is crucial to ensure the benchmarking is accurate in terms of memory bandwidth.
 This means ``autotune_suite`` will allocate a workspace of size ``workspace_count`` copies of input arguments using ``make_arguments`` you pass, 

--- a/media/docs/pythonDSL/guides/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/guides/autotuning_gemm.rst
@@ -148,3 +148,231 @@ approximation doesn't negatively impact performance for your specific use case.
 
 By following the methods above, you can customize your own auto-tuner to find the optimal GEMM kernel configuration 
 for specific matrix dimensions and data types, significantly improving computational performance for models.
+
+Autotuning JIT kernels with CuTeDSL functions
+---------------------------------------------
+
+The manual ``autotune_gemm`` loop above demonstrates the general principle behind tuning CuTeDSL kernels. 
+CuTeDSL provides a higher-level interface for this process which relies on the same underlying mechanism, 
+which is the ``autotune_jit`` decorator from ``cutlass.cute.testing``. It performs the same "compile every
+configuration, benchmark, keep the best" strategy but it does so automatically,
+with handling the search space sweep lazily when function is called, performing the cold-L2 benchmarking 
+and caching compiled kernel automatically for you.
+
+We still use the persistent GEMM kernel as an example. We first need to define the ``@cute.jit`` function.
+It should accepts the turnable parameters as ``Constexpr`` keyword arguments.
+The non-autotuned version should look like this:
+
+.. code-block:: python
+
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.cute.testing as testing
+    from dense_gemm_persistent import PersistentDenseGemmKernel
+
+    @cute.jit
+    def gemm(
+        a, b, c, stream, m, n, k,
+        use_2cta_instrs: cutlass.Constexpr = True,
+        use_tma_store: cutlass.Constexpr = True,
+        mma_tiler_mn: cutlass.Constexpr = (256, 256),
+        cluster_shape_mn: cutlass.Constexpr = (2, 1),
+        max_active_clusters: cutlass.Constexpr = 0,
+    ):
+        kernel = PersistentDenseGemmKernel(
+            cutlass.Float32,  # acc_dtype
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            use_tma_store,
+        )
+        kernel(a, b, c, max_active_clusters, stream)
+
+Since ``cluster_shape_mn`` is a tunable parameter and it's unknown when we do the grid sweep and search the optimal configuration, 
+``autotune_jit`` needs to know how to compute ``max_active_clusters`` on the host side based on the current  ``cluster_shape_mn`` value when tuning.
+Therefore, to allow this function to be autotuned with ``max_active_clusters`` being a parameter, we need to define an 
+auxiliary function on the host side to derive the ``max_active_clusters`` parameter from the swept ``cluster_shape_mn`` value when tuning.
+
+
+.. code-block:: python
+
+    # max_active_clusters is derived from the swept cluster_shape_mn. It is
+    # computed on the host, because HardwareInfo cannot run inside @cute.jit.
+    def derive_max_active_clusters(cluster_shape_mn):
+        return cutlass.utils.HardwareInfo().get_max_active_clusters(
+            cluster_shape_mn[0] * cluster_shape_mn[1]
+        )
+
+
+The search space is a dictionary mapping each tunable parameter to its candidate
+values; every combination is tried. Add more candidates to a list to widen the
+sweep:
+
+.. code-block:: python
+
+    search_space = {
+        "use_2cta_instrs": [True],
+        "use_tma_store": [False, True],
+        "mma_tiler_mn": [(128, 128), (256, 128), (256, 256)],
+        "cluster_shape_mn": [(2, 1), (2, 2)],
+    }
+
+Then we can decorate the CuTeDSL function with ``autotune_jit`` to sweep this search space and find the best configuration.
+The first call to the decorated function for a given m, n, k problem size sweeps the search space, benchmarks each configuration and caches the best compiled kernel; 
+and subsequent calls whose ``update_on_change`` values (here ``m, n, k``) are unchanged reuse it without re-tuning. 
+
+For parameters in ``param_dict``, they are removed from the decorated function's signature so when calling the decorated function you do not need to pass them, and they are automatically tuned.
+And parameters in ``derived_params`` work similarly; you don't pass them and their value will be derived from the current values of the other parameters in ``param_dict`` using the function you provides, 
+whose signature must match the parameters in ``param_dict`` that it depends on with the same name. So for example, ``derive_max_active_clusters`` above takes ``cluster_shape_mn`` as an argument, 
+and it will use the current value of ``cluster_shape_mn`` for each configuration during the sweep to derive the value of ``max_active_clusters`` argument.
+For parameters in ``update_on_change``, they are used as the key to cache compiled kernels, so when any of them changes the decorated function will re-tune and cache a new best kernel for that combination. 
+When calling the decorated function, you still need to pass them as normal arguments.
+
+.. code-block:: python
+
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.cute.testing as testing
+    from dense_gemm_persistent import PersistentDenseGemmKernel
+
+    @testing.autotune_jit(
+        params_dict=search_space,
+        update_on_change=["m", "n", "k"],
+        derived_params={"max_active_clusters": derive_max_active_clusters},
+        warmup_iterations=5,
+        iterations=100,
+    )
+    @cute.jit
+    def autotuned_gemm(
+        a, b, c, stream, m, n, k,
+        use_2cta_instrs: cutlass.Constexpr = True,
+        use_tma_store: cutlass.Constexpr = True,
+        mma_tiler_mn: cutlass.Constexpr = (256, 256),
+        cluster_shape_mn: cutlass.Constexpr = (2, 1),
+        max_active_clusters: cutlass.Constexpr = 0,
+    ):
+        kernel = PersistentDenseGemmKernel(
+            cutlass.Float32,  # acc_dtype
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            use_tma_store,
+        )
+        kernel(a, b, c, max_active_clusters, stream)
+
+    autotuned_gemm(a, b, c, stream, m, n, k)  # first call for this (m, n, k) autotunes
+    autotuned_gemm(a, b, c, stream, m, n, k)  # subsequent calls reuse the cached best kernel
+
+Autotuning JIT kernels with classes
+-----------------------------------
+
+Many CuTe DSL kernels are written as classes: the tunable configuration is passed
+to the constructor, and a ``@cute.jit`` ``__call__`` method takes only the dynamic
+runtime arguments (which is the structure of ``PersistentDenseGemmKernel`` used
+above). ``autotune_jit`` can decorate such a class directly, without writing an
+adapter. It turns the class into a *partial* class: the tunable constructor
+parameters are removed (which are auto-tuned), so you can use the decorated class like a
+normal class -- you just do not pass the tunable parameters when instantiating.
+
+Take a small elementwise-add kernel as an example, where ``elementwise_add`` is a
+``@cute.jit`` function implementing the vectorized addition operation:
+
+.. code-block:: python
+
+    @testing.autotune_jit(
+        params_dict={"COPY_BITS": [32, 64, 128], "THREADS_M": [4, 8]},
+        update_on_change=["M", "N"],
+        warmup_iterations=10,
+        iterations=50,
+    )
+    class ElementwiseAddKernel:
+        def __init__(self, COPY_BITS=128, THREADS_M=4):
+            self.COPY_BITS = COPY_BITS
+            self.THREADS_M = THREADS_M
+
+        @cute.jit
+        def __call__(self, mA, mB, mC, M, N):
+            elementwise_add(
+                mA, mB, mC, M, N,
+                copy_bits=self.COPY_BITS,
+                threads_m=self.THREADS_M,
+            )
+
+    autotuned_add = ElementwiseAddKernel()   # instantiate (no tunable params)
+    autotuned_add(a, b, c, M, N)             # first call for this (M, N) autotunes
+    autotuned_add(a, b, c, M, N)             # subsequent calls reuse the cached best kernel
+
+
+- ``params_dict`` takes the tuneable parameters that are passed to the class constructor (``COPY_BITS``,
+  ``THREADS_M``). These are constexprs that instantiate the kernel, and are fixed at the runtime.
+  When user create an instance of the decorated class, they do not need to pass these parameters, and they will be auto-tuned.
+  These tuneable parameters are removed from the decorated class's constructor signature.
+  For non-tuneable parameters, user should still pass them when creating the instance as usual.
+- ``update_on_change`` names the ``__call__`` arguments to key the cache on
+  (``M``, ``N``). When any of these change, the decorated class will re-tune and cache a new best kernel for that combination.
+- Because the tunable parameters are separated into the constructor, the ``@cute.jit`` ``__call__`` takes only the dynamic arguments. 
+  Therefore, unlike the decorated CuTeDSL function where it takes both the dynamic and tunable parameters in the signature,
+  the separation here is clearer: the constructor parameters defines the kernel configuration which are used to compile the kernel.
+  Then, ``__call__`` takes the dynamic arguments that may change per execution.
+
+
+Choosing one configuration for many shapes
+-------------------------------------------
+
+The JIT path tunes each problem size on its first call. When you instead need a single configuration baked into an ahead-of-time (AOT) build, 
+or you simply don't want to compile kernels too often when input shapes change frequently, you can use ``autotune_suite`` to find one that performs well
+across the shapes your application sees. ``autotune_suite`` allows you to grid-search the same space over a list of representative problem sizes.
+For each case it builds fresh inputs with ``make_arguments`` whose parameters , compiles and benchmarks every
+configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations. 
+You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes. 
+
+.. code-block:: python
+
+    import cuda.bindings.driver as cuda
+
+    torch_stream = torch.cuda.Stream()
+    stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    def make_arguments(m, n, k):
+        # Batched GEMM with a hardcoded batch size l = 1. The kernel takes
+        # rank-3 tensors, so we build torch tensors with the shape and major
+        # ordering it expects and pass them directly -- CuTe DSL accepts torch
+        # tensors via DLPack (a plain 2D torch tensor would be the wrong rank):
+        #   A: (m, k, l) m-major, B: (n, k, l) k-major, C: (m, n, l) m-major
+        l = 1
+        a = torch.randn(l, k, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        b = torch.randn(l, n, k, dtype=torch.float16, device="cuda").permute(1, 2, 0)
+        c = torch.zeros(l, n, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        return a, b, c, stream, m, n, k
+
+    with torch.cuda.stream(torch_stream):
+        reports, recommended = testing.autotune_suite(
+            gemm,
+            make_arguments,
+            cases=[
+                (2048, 2048, 4096),  # representative (m, n, k) problem sizes
+                (4096, 4096, 2048),
+            ],
+            params_dict=search_space,
+            derived_params={"max_active_clusters": derive_max_active_clusters},
+            accept_percentile=50,  # keep each case's fastest half of the configs
+            stream=stream,
+        )
+
+    # recommended is ranked by how many cases accepted each config within the
+    # percentile; pick the top one and compile it ahead of time.
+    best_config = recommended[0]["config"]
+    args = make_arguments(2048, 2048, 4096)
+    compiled_gemm = cute.compile(gemm, *args, **best_config)
+    compiled_gemm(*args)
+
+``reports`` holds one timing table per case (each configuration's measured time,
+fastest first), and ``recommended`` ranks configurations by how many cases
+accepted them within ``accept_percentile``. Use ``reports[i]["best_config"]`` when
+a separate kernel per problem size is acceptable, or ``recommended[0]["config"]``
+when a single configuration must serve all shapes.
+
+For stable, reproducible measurements, lock the GPU's SM and memory frequencies
+with ``nvidia-smi`` before running the sweep; the number of warmup iterations,
+timed iterations and cold-L2 workspaces are controlled by ``autotune_suite``'s
+``warmup_iterations``, ``iterations`` and ``workspace_count`` parameters.

--- a/media/docs/pythonDSL/guides/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/guides/autotuning_gemm.rst
@@ -305,9 +305,10 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
         iterations=50,
     )
     class ElementwiseAddKernel:
-        def __init__(self, COPY_BITS=128, THREADS_M=4):
+        THREADS_M = 4 # default value; can be overridden by autotune_jit
+
+        def __init__(self, COPY_BITS=128):
             self.COPY_BITS = COPY_BITS
-            self.THREADS_M = THREADS_M
 
         @cute.jit
         def __call__(self, mA, mB, mC, M, N):

--- a/media/docs/pythonDSL/guides/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/guides/autotuning_gemm.rst
@@ -156,11 +156,11 @@ The manual ``autotune_gemm`` loop above demonstrates the general principle behin
 CuTeDSL provides a higher-level interface for this process which relies on the same underlying mechanism, 
 which is the ``autotune_jit`` decorator from ``cutlass.cute.testing``. It performs the same "compile every
 configuration, benchmark, keep the best" strategy but it does so automatically,
-with handling the search space sweep lazily when function is called, performing the cold-L2 benchmarking 
-and caching compiled kernel automatically for you.
+handling the search-space sweep lazily when the function is called, performing the cold-L2 benchmarking,
+and caching the compiled kernel automatically for you.
 
 We still use the persistent GEMM kernel as an example. We first need to define the ``@cute.jit`` function.
-It should accepts the turnable parameters as ``Constexpr`` keyword arguments.
+It should accept the tunable parameters as ``Constexpr`` keyword arguments.
 
 The non-autotuned version should look like this:
 
@@ -280,7 +280,7 @@ When calling the decorated function, you still need to pass them as normal argum
 
     autotuned_gemm(a, b, c, stream, M, N, K)  # first call for this (M, N, K) autotunes
     autotuned_gemm(a, b, c, stream, M, N, K)  # subsequent calls reuse the cached best kernel
-    print(f"Best config for autotuned_gemm: {autotuned_gemm._best_config}")
+    print(f"Best config for autotuned_gemm: {autotuned_gemm._best_config[(M, N, K)]}")
 
 Autotuning JIT kernels with classes
 -----------------------------------
@@ -320,12 +320,12 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
     autotuned_add = ElementwiseAddKernel()   # instantiate (no tunable params)
     autotuned_add(a, b, c, M, N)             # first call for this (M, N) autotunes
     autotuned_add(a, b, c, M, N)             # subsequent calls reuse the cached best kernel
-    print(f"Best config for autotuned_add: {autotuned_add._best_config}")
+    print(f"Best config for autotuned_add: {autotuned_add._best_config[(M, N)]}")
 
 
 - ``params_dict`` takes the tuneable parameters that are passed to the class constructor (``COPY_BITS``,
-  ``THREADS_M``). These are constexprs that instantiate the kernel, and are fixed at the runtime.
-  When user create an instance of the decorated class, they do not need to pass these parameters, and they will be auto-tuned.
+  ``THREADS_M``). These are constexprs used to instantiate the kernel, and are baked in at compile time.
+  When you create an instance of the decorated class, you do not need to pass these parameters; they will be auto-tuned.
   These tuneable parameters are removed from the decorated class's constructor signature.
   For non-tuneable parameters, user should still pass them when creating the instance as usual.
   And ``derived_params`` and ``prune_configs`` work the same way as in the function case.
@@ -333,7 +333,7 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
   (``M``, ``N``). When any of these change, the decorated class will re-tune and cache a new best kernel for that combination.
 - Because the tunable parameters are separated into the constructor, the ``@cute.jit`` ``__call__`` takes only the dynamic arguments. 
   Therefore, unlike the decorated CuTeDSL function where it takes both the dynamic and tunable parameters in the signature,
-  the separation here is clearer: the constructor parameters defines the kernel configuration which are used to compile the kernel.
+  the separation here is clearer: the constructor parameters define the kernel configuration used to compile the kernel.
   Then, ``__call__`` takes the dynamic arguments that may change per execution.
 
 
@@ -343,8 +343,8 @@ Choosing one configuration for many shapes
 The JIT path tunes each problem size on its first call. When you instead need a single configuration baked into an ahead-of-time (AOT) build, 
 or you simply don't want to compile kernels too often when input shapes change frequently, you can use ``autotune_suite`` to find one that performs well
 across the shapes your application sees. ``autotune_suite`` allows you to grid-search the same space over a list of representative problem sizes.
-For each case it builds fresh inputs with ``make_arguments`` whose parameters , compiles and benchmarks every
-configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations. 
+For each case it builds fresh inputs with ``make_arguments``, compiles and benchmarks every
+configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations.
 
 You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes.
 
@@ -395,21 +395,21 @@ Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is n
 ``reports`` holds one timing table per case (each configuration's measured time, fastest first) so user can use this to decide what's their favorite configuration, 
 and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations. 
 
-The heruistic behind is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good 
+The heuristic behind this is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good
 among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). 
 
 Note: about ``workspace_count``, this is the parameter that is crucial to ensure the benchmarking is accurate in terms of memory bandwidth.
 This means ``autotune_suite`` will allocate a workspace of size ``workspace_count`` copies of input arguments using ``make_arguments`` you pass, 
 and it will cycle through these workspaces ``warmup_iterations`` + ``iterations`` times.
 To let the benchmark correctly reflect the achieved memory bandwidth, we would like to make sure our kernel is reading from HBM instead of L2 cache during the benchmarking. 
-Therefore, we need to make sure the workspace is large enough so that its size exceeds the L2 cache size, so when we finish one lap around the workspace ring buffer and get back To
+Therefore, we need to make sure the workspace is large enough so that its size exceeds the L2 cache size, so when we finish one lap around the workspace ring buffer and get back to
 the first workspace, the data is no longer in L2 cache and we are reading from HBM again.
 
 For example, suppose our input tensors use 2MB of memory, and the L2 cache size is 10MB. If we set ``workspace_count`` to 6, then the total workspace size is 12MB, 
 which **exceeds** the L2 cache size. In this case, when we are at iteration 7, the L2 cache would hold the 5 copies of inputs from workspace 2 to 6, and 
 iteration 7 uses workspace 1, which is no longer in L2 cache and is read from HBM. 
-In addition, a workspace whose size is equal to the L2 cache size is not sufficient, because in this case ``workspace_count`` is 5, which means at the 6th iteration we are back to workspace 1, 
-but it's is still in L2 cache because L2 cache is large enough to hold all 5 copies of the input tensors. Therefore, we would be reading from L2 cache instead of HBM, which is not what we want.
+In addition, a total workspace size equal to the L2 cache size is not sufficient, because in this case ``workspace_count`` is 5, which means at the 6th iteration we are back to workspace 1,
+but it is still in L2 cache because L2 cache is large enough to hold all 5 copies of the input tensors. Therefore, we would be reading from L2 cache instead of HBM, which is not what we want.
 The rule of thumb is that we need ``(workspace_count - 1) * size_of_input_data >= L2_cache_size`` to guarantee that when we finish one round and get back to the first workspace, its data is no longer in L2 cache.
 
 In conclusion, you should always set ``workspace_count`` to a proper value that ensures that the current benchmark run always reads from HBM due to its input being evicted from L2 cache, 

--- a/media/docs/pythonDSL/guides/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/guides/autotuning_gemm.rst
@@ -129,15 +129,15 @@ We could cache the tuning results in a input-to-kernel dictionary (e.g., ``input
 When processing inputs with matching ``config_key`` values, the cached kernel can be reused directly without re-tuning. 
 The ``config_key`` is related with the input tensor's characteristics, such as the shape, data type, etc. 
 The setup of ``config_key`` is very flexible, users can customize it based on their own application.
-For instance, if the data type is fixed in users' application, we could use the input tensor's shape as the key, i.e., ``(m, n, k)``. 
-To further reduce tuning overhead, we could consider using a simplified key like ``config_key = (power_of_2(m), power_of_2(n), power_of_2(k))``, 
-where ``m``, ``n``, and ``k`` are rounded up to the nearest power of 2. This simplification can significantly reduce the number 
+For instance, if the data type is fixed in users' application, we could use the input tensor's shape as the key, i.e., ``(M, N, K)``. 
+To further reduce tuning overhead, we could consider using a simplified key like ``config_key = (power_of_2(M), power_of_2(N), power_of_2(K))``, 
+where ``M``, ``N``, and ``K`` are rounded up to the nearest power of 2. This simplification can significantly reduce the number 
 of unique keys while still maintaining good performance in most cases. However, it's important to validate that this 
 approximation doesn't negatively impact performance for your specific use case. 
 
 .. code-block:: python
 
-    config_key = (m, n, k)
+    config_key = (M, N, K)
     if config_key in input_kernel_dict:
         compiled_gemm = input_kernel_dict[config_key]
     else:
@@ -161,6 +161,7 @@ and caching compiled kernel automatically for you.
 
 We still use the persistent GEMM kernel as an example. We first need to define the ``@cute.jit`` function.
 It should accepts the turnable parameters as ``Constexpr`` keyword arguments.
+
 The non-autotuned version should look like this:
 
 .. code-block:: python
@@ -171,8 +172,8 @@ The non-autotuned version should look like this:
     from dense_gemm_persistent import PersistentDenseGemmKernel
 
     @cute.jit
-    def gemm(
-        a, b, c, stream, m, n, k,
+    def non_autotuned_gemm(
+        a, b, c, stream, M, N, K,
         use_2cta_instrs: cutlass.Constexpr = True,
         use_tma_store: cutlass.Constexpr = True,
         mma_tiler_mn: cutlass.Constexpr = (256, 256),
@@ -217,9 +218,25 @@ sweep:
         "cluster_shape_mn": [(2, 1), (2, 2)],
     }
 
+The configurations we will search are the Cartesian product of all these lists, so there are 12 total configurations in this example.
+If you have a large search space, you can prune it by removing configurations that are known to be invalid or suboptimal using ``prune_configs``.
+``prune_configs`` is a predicate function whose parameters are a subset of the tunable parameters (the keys of ``params_dict`` with the same name).
+It returns ``True`` to keep a configuration or ``False`` to skip it. For example, to
+reject one specific configuration -- the largest tile paired with the largest
+cluster -- from the sweep:
+
+.. code-block:: python
+
+    def prune_config(mma_tiler_mn, cluster_shape_mn):
+        # only these two parameters are inspected; return False to drop this config
+        return not (mma_tiler_mn == (256, 256) and cluster_shape_mn == (2, 2))
+
+This drops 2 of the 12 configurations (``(256, 256)`` with ``(2, 2)`` for either
+``use_tma_store`` value), leaving 10 to benchmark.
+
 Then we can decorate the CuTeDSL function with ``autotune_jit`` to sweep this search space and find the best configuration.
-The first call to the decorated function for a given m, n, k problem size sweeps the search space, benchmarks each configuration and caches the best compiled kernel; 
-and subsequent calls whose ``update_on_change`` values (here ``m, n, k``) are unchanged reuse it without re-tuning. 
+The first call to the decorated function for a given M, N, K problem size sweeps the search space, benchmarks each configuration and caches the best compiled kernel; 
+and subsequent calls whose ``update_on_change`` values (here ``M, N, K``) are unchanged reuse it without re-tuning. 
 
 For parameters in ``param_dict``, they are removed from the decorated function's signature so when calling the decorated function you do not need to pass them, and they are automatically tuned.
 And parameters in ``derived_params`` work similarly; you don't pass them and their value will be derived from the current values of the other parameters in ``param_dict`` using the function you provides, 
@@ -237,14 +254,15 @@ When calling the decorated function, you still need to pass them as normal argum
 
     @testing.autotune_jit(
         params_dict=search_space,
-        update_on_change=["m", "n", "k"],
+        update_on_change=["M", "N", "K"],
         derived_params={"max_active_clusters": derive_max_active_clusters},
+        prune_configs=prune_config,
         warmup_iterations=5,
         iterations=100,
     )
     @cute.jit
     def autotuned_gemm(
-        a, b, c, stream, m, n, k,
+        a, b, c, stream, M, N, K,
         use_2cta_instrs: cutlass.Constexpr = True,
         use_tma_store: cutlass.Constexpr = True,
         mma_tiler_mn: cutlass.Constexpr = (256, 256),
@@ -260,8 +278,9 @@ When calling the decorated function, you still need to pass them as normal argum
         )
         kernel(a, b, c, max_active_clusters, stream)
 
-    autotuned_gemm(a, b, c, stream, m, n, k)  # first call for this (m, n, k) autotunes
-    autotuned_gemm(a, b, c, stream, m, n, k)  # subsequent calls reuse the cached best kernel
+    autotuned_gemm(a, b, c, stream, M, N, K)  # first call for this (M, N, K) autotunes
+    autotuned_gemm(a, b, c, stream, M, N, K)  # subsequent calls reuse the cached best kernel
+    print(f"Best config for autotuned_gemm: {autotuned_gemm._best_config}")
 
 Autotuning JIT kernels with classes
 -----------------------------------
@@ -301,6 +320,7 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
     autotuned_add = ElementwiseAddKernel()   # instantiate (no tunable params)
     autotuned_add(a, b, c, M, N)             # first call for this (M, N) autotunes
     autotuned_add(a, b, c, M, N)             # subsequent calls reuse the cached best kernel
+    print(f"Best config for autotuned_add: {autotuned_add._best_config}")
 
 
 - ``params_dict`` takes the tuneable parameters that are passed to the class constructor (``COPY_BITS``,
@@ -308,6 +328,7 @@ Take a small elementwise-add kernel as an example, where ``elementwise_add`` is 
   When user create an instance of the decorated class, they do not need to pass these parameters, and they will be auto-tuned.
   These tuneable parameters are removed from the decorated class's constructor signature.
   For non-tuneable parameters, user should still pass them when creating the instance as usual.
+  And ``derived_params`` and ``prune_configs`` work the same way as in the function case.
 - ``update_on_change`` names the ``__call__`` arguments to key the cache on
   (``M``, ``N``). When any of these change, the decorated class will re-tune and cache a new best kernel for that combination.
 - Because the tunable parameters are separated into the constructor, the ``@cute.jit`` ``__call__`` takes only the dynamic arguments. 
@@ -324,55 +345,72 @@ or you simply don't want to compile kernels too often when input shapes change f
 across the shapes your application sees. ``autotune_suite`` allows you to grid-search the same space over a list of representative problem sizes.
 For each case it builds fresh inputs with ``make_arguments`` whose parameters , compiles and benchmarks every
 configuration (cycling through cold-L2 workspaces), and returns per-case timings plus a ranked list of recommended configurations. 
-You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes. 
+
+You may then pick a configuration that you think is best and compile it ahead of time for use with all shapes.
+
+Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is not decorated by ``@testing.autotune_jit``.
 
 .. code-block:: python
 
+    import torch
     import cuda.bindings.driver as cuda
+    from cutlass import cute
+    from cutlass.cute.testing import autotune_suite
 
     torch_stream = torch.cuda.Stream()
     stream = cuda.CUstream(torch_stream.cuda_stream)
 
-    def make_arguments(m, n, k):
-        # Batched GEMM with a hardcoded batch size l = 1. The kernel takes
-        # rank-3 tensors, so we build torch tensors with the shape and major
-        # ordering it expects and pass them directly -- CuTe DSL accepts torch
-        # tensors via DLPack (a plain 2D torch tensor would be the wrong rank):
-        #   A: (m, k, l) m-major, B: (n, k, l) k-major, C: (m, n, l) m-major
-        l = 1
-        a = torch.randn(l, k, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
-        b = torch.randn(l, n, k, dtype=torch.float16, device="cuda").permute(1, 2, 0)
-        c = torch.zeros(l, n, m, dtype=torch.float16, device="cuda").permute(2, 1, 0)
-        return a, b, c, stream, m, n, k
+    def make_arguments(M, N, K):
+        # Batched GEMM with a hardcoded batch size L = 1.
+        #   A: (M, K, L) M-major, B: (N, K, L) K-major, C: (M, N, L) M-major
+        L = 1
+        a = torch.randn(L, K, M, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        b = torch.randn(L, N, K, dtype=torch.float16, device="cuda").permute(1, 2, 0)
+        c = torch.zeros(L, N, M, dtype=torch.float16, device="cuda").permute(2, 1, 0)
+        return a, b, c, stream, M, N, K
 
     with torch.cuda.stream(torch_stream):
         reports, recommended = testing.autotune_suite(
-            gemm,
+            non_autotuned_gemm,
             make_arguments,
             cases=[
-                (2048, 2048, 4096),  # representative (m, n, k) problem sizes
+                (2048, 2048, 4096),  # representative (M, N, K) problem sizes
                 (4096, 4096, 2048),
             ],
             params_dict=search_space,
+            prune_configs=prune_config,
             derived_params={"max_active_clusters": derive_max_active_clusters},
             accept_percentile=50,  # keep each case's fastest half of the configs
+            print_summary=True,
             stream=stream,
         )
 
     # recommended is ranked by how many cases accepted each config within the
-    # percentile; pick the top one and compile it ahead of time.
+    # percentile you've given; here we just pick the top one and compile it ahead of time.
     best_config = recommended[0]["config"]
     args = make_arguments(2048, 2048, 4096)
-    compiled_gemm = cute.compile(gemm, *args, **best_config)
+    compiled_gemm = cute.compile(non_autotuned_gemm, *args, **best_config)
     compiled_gemm(*args)
 
-``reports`` holds one timing table per case (each configuration's measured time,
-fastest first), and ``recommended`` ranks configurations by how many cases
-accepted them within ``accept_percentile``. Use ``reports[i]["best_config"]`` when
-a separate kernel per problem size is acceptable, or ``recommended[0]["config"]``
-when a single configuration must serve all shapes.
+``reports`` holds one timing table per case (each configuration's measured time, fastest first) so user can use this to decide what's their favorite configuration, 
+and ``recommended`` ranks configurations by how many cases accepted them within each input case's top ``accept_percentile`` configurations. 
 
-For stable, reproducible measurements, lock the GPU's SM and memory frequencies
-with ``nvidia-smi`` before running the sweep; the number of warmup iterations,
-timed iterations and cold-L2 workspaces are controlled by ``autotune_suite``'s
-``warmup_iterations``, ``iterations`` and ``workspace_count`` parameters.
+The heruistic behind is simple. You don't want a configuration that is the fastest for one case but slow for others, and a configuration that is consistently good 
+among all these representative cases is more likely to be the preferred choice in general (even if it's never the best for any of those cases). 
+
+Note: about ``workspace_count``, this is the parameter that is crucial to ensure the benchmarking is accurate in terms of memory bandwidth.
+This means ``autotune_suite`` will allocate a workspace of size ``workspace_count`` copies of input arguments using ``make_arguments`` you pass, 
+and it will cycle through these workspaces ``warmup_iterations`` + ``iterations`` times.
+To let the benchmark correctly reflect the achieved memory bandwidth, we would like to make sure our kernel is reading from HBM instead of L2 cache during the benchmarking. 
+Therefore, we need to make sure the workspace is large enough so that its size exceeds the L2 cache size, so when we finish one lap around the workspace ring buffer and get back To
+the first workspace, the data is no longer in L2 cache and we are reading from HBM again.
+
+For example, suppose our input tensors use 2MB of memory, and the L2 cache size is 10MB. If we set ``workspace_count`` to 6, then the total workspace size is 12MB, 
+which **exceeds** the L2 cache size. In this case, when we are at iteration 7, the L2 cache would hold the 5 copies of inputs from workspace 2 to 6, and 
+iteration 7 uses workspace 1, which is no longer in L2 cache and is read from HBM. 
+In addition, a workspace whose size is equal to the L2 cache size is not sufficient, because in this case ``workspace_count`` is 5, which means at the 6th iteration we are back to workspace 1, 
+but it's is still in L2 cache because L2 cache is large enough to hold all 5 copies of the input tensors. Therefore, we would be reading from L2 cache instead of HBM, which is not what we want.
+The rule of thumb is that we need ``(workspace_count - 1) * size_of_input_data >= L2_cache_size`` to guarantee that when we finish one round and get back to the first workspace, its data is no longer in L2 cache.
+
+In conclusion, you should always set ``workspace_count`` to a proper value that ensures that the current benchmark run always reads from HBM due to its input being evicted from L2 cache, 
+or just set it to a large enough value that is guaranteed to **exceed** the L2 cache size.

--- a/media/docs/pythonDSL/guides/autotuning_gemm.rst
+++ b/media/docs/pythonDSL/guides/autotuning_gemm.rst
@@ -351,6 +351,19 @@ You may then pick a configuration that you think is best and compile it ahead of
 
 Note: autotune_suite expects a non-autotuned CuTeDSL function or class that is not decorated by ``@testing.autotune_jit``.
 
+If some argument's size depends on the configuration, such as a reduction workspace, we will pass the values from
+``params_dict`` and ``derived_params`` to ``make_arguments`` as keyword arguments if their parameter names match.
+
+For example, if the workspace size depends on ``mma_tiler_mn``, you can write
+
+.. code-block:: python
+
+    def make_arguments(M, N, K, mma_tiler_mn):
+        ...  # size a workspace from mma_tiler_mn
+
+And we will call this function with the values of ``M``, ``N``, ``K`` from the current case,
+and ``mma_tiler_mn`` from the current configuration being benchmarked.
+
 .. code-block:: python
 
     import torch

--- a/python/CuTeDSL/cutlass/cute/testing.py
+++ b/python/CuTeDSL/cutlass/cute/testing.py
@@ -924,9 +924,29 @@ class autotune_jit:
                         derived = outer._compute_derived(
                             self._derived_params, current_config
                         )
-                        kernel = self._original_kernel_cls(
-                            **{**self._fixed_kwargs, **current_config, **derived}
-                        )
+                        config_with_derived = {
+                            **self._fixed_kwargs, **current_config, **derived
+                        }
+                        kernel_cls = self._original_kernel_cls
+                        init_params = inspect.signature(kernel_cls.__init__).parameters
+                        # Config set through __init__ vs. as class attributes.
+                        init_configs = {
+                            k: v for k, v in config_with_derived.items()
+                            if k in init_params
+                        }
+                        attr_configs = {
+                            k: v for k, v in config_with_derived.items()
+                            if k not in init_params
+                        }
+                        kernel = kernel_cls(**init_configs)
+                        # Override class attributes
+                        for k, v in attr_configs.items():
+                            if not hasattr(kernel, k):
+                                raise AttributeError(
+                                    f"Kernel class {kernel_cls.__name__} has no "
+                                    f"attribute {k} to override"
+                                )
+                            setattr(kernel, k, v)
                         compiled_func = compile(kernel, *args, **kwargs)
                         cur_time = _benchmark_for_autotune(
                             compiled_func,
@@ -937,7 +957,9 @@ class autotune_jit:
                             print_verbose=False,
                             **kwargs,
                         )
-                    except NotImplementedError:
+                    except AttributeError:
+                        # Raise exception when keys in params_dict are not recognized as either
+                        # constructor parameters or class attributes of the kernel class.
                         raise
                     except Exception as e:
                         outer.log().info(f"   Configuration skipped: {e}")
@@ -1176,9 +1198,23 @@ def autotune_suite(
                         **{k: v for k, v in config.items() if k in fn_params}
                     )
                 if inspect.isclass(func_or_cls):
-                    # Instantiate the kernel class with the current config and derived params,
+                    config_with_derived = {**config, **derived}
+                    init_params = inspect.signature(func_or_cls.__init__).parameters
+                    # Attributes to override that are initialized in __init__ method
+                    init_configs = {k: v for k, v in config_with_derived.items() if k in init_params}
+                    # Attributes to override that set along with the class definition
+                    attr_configs = {k: v for k, v in config_with_derived.items() if k not in init_params}
+                    # Instantiate the kernel class with the config and derived params,
                     # then compile it with the dynamic args.
-                    compiled = cute.compile(func_or_cls(**config, **derived), *args)
+                    kernel_obj = func_or_cls(**init_configs)
+                    # Override class attributes
+                    for k, v in attr_configs.items():
+                        if not hasattr(kernel_obj, k):
+                            raise AttributeError(
+                                f"Kernel class {func_or_cls.__name__} has no attribute {k} to override"
+                            )
+                        setattr(kernel_obj, k, v)
+                    compiled = cute.compile(kernel_obj, *args)
                 else:
                     compiled = cute.compile(func_or_cls, *args, **config, **derived)
                 compiled(*args)
@@ -1193,7 +1229,9 @@ def autotune_suite(
                     iterations=iterations,
                     stream=stream,
                 )
-            except NotImplementedError:
+            except AttributeError:
+                # Raise exception when keys in params_dict are not recognized as either
+                # constructor parameters or class attributes of the kernel class.
                 raise
             except Exception as e:
                 if print_summary:

--- a/python/CuTeDSL/cutlass/cute/testing.py
+++ b/python/CuTeDSL/cutlass/cute/testing.py
@@ -648,6 +648,7 @@ class autotune_jit:
         warmup_iterations: int,
         iterations: int,
         autotune_update_params: list[str],
+        prune_configs: Optional[Callable[..., bool]] = None,
     ) -> Callable[..., Any]:
         """Create a wrapper function that performs auto-tuning
 
@@ -713,6 +714,12 @@ class autotune_jit:
                 for config_values in product(*values):
                     # Build current configuration
                     current_config = dict(zip(keys, config_values))
+                    # Skip configs rejected by the user's prune_configs predicate.
+                    if prune_configs is not None and not prune_configs(
+                        **{k: v for k, v in current_config.items()
+                           if k in inspect.signature(prune_configs).parameters}
+                    ):
+                        continue
                     cls.log().info(f"Tuning configuration: {current_config}")
 
                     try:
@@ -823,6 +830,7 @@ class autotune_jit:
         warmup_iterations: int,
         iterations: int,
         autotune_update_params: list[str],
+        prune_configs: Optional[Callable[..., bool]] = None,
     ) -> type:
         """Turn a kernel class into an auto-tuning class.
 
@@ -902,17 +910,24 @@ class autotune_jit:
 
                 for config_values in product(*values):
                     current_config = dict(zip(keys, config_values))
+                    # Skip configs rejected by the user's prune_configs predicate.
+                    if prune_configs is not None and not prune_configs(
+                        **{k: v for k, v in current_config.items()
+                           if k in inspect.signature(prune_configs).parameters}
+                    ):
+                        continue
                     outer.log().info(f"Tuning configuration: {current_config}")
                     try:
-                        # Instantiate the original class with the fixed kwargs
-                        # plus the current (tuned) configuration.
-                        kernel = self._original_kernel_cls(
-                            **{**self._fixed_kwargs, **current_config}
-                        )
+                        # Instantiate the original class with the fixed kwargs,
+                        # the current (tuned) configuration and the derived
+                        # params
                         derived = outer._compute_derived(
                             self._derived_params, current_config
                         )
-                        compiled_func = compile(kernel, *args, **kwargs, **derived)
+                        kernel = self._original_kernel_cls(
+                            **{**self._fixed_kwargs, **current_config, **derived}
+                        )
+                        compiled_func = compile(kernel, *args, **kwargs)
                         cur_time = _benchmark_for_autotune(
                             compiled_func,
                             *args,
@@ -960,6 +975,7 @@ class autotune_jit:
         warmup_iterations: int = 10,
         iterations: int = 100,
         derived_params: Optional[Dict[str, Callable[..., Any]]] = None,
+        prune_configs: Optional[Callable[..., bool]] = None,
     ) -> None:
         """Initialize the autotune_jit decorator.
 
@@ -976,6 +992,10 @@ class autotune_jit:
         :type iterations: int, optional
         :param derived_params: a dict to derive the values of parameters from other parameters passed in params_dict.
         :type derived_params: Dict[str, Callable], optional
+        :param prune_configs: Optional predicate whose parameters are a subset of the tunable parameters 
+             (``params_dict``'s keys); return ``True`` to keep a configuration or ``False`` to skip it,
+             defaults to None, which will accept all configurations.
+        :type prune_configs: Callable[..., bool], optional
         """
         # Initialize logger
         self._initialize_logger()
@@ -984,6 +1004,7 @@ class autotune_jit:
         self.params_dict = params_dict or {}
         self.update_on_change = update_on_change or list()
         self.derived_params = derived_params or {}
+        self.prune_configs = prune_configs
 
         # Save iterations
         self.warmup_iterations = warmup_iterations
@@ -1004,11 +1025,13 @@ class autotune_jit:
         # decorators merge their params instead of nesting tuners.
         if inspect.isclass(func):
             decorated_func = self._create_class_tuning_wrapper(
-                func, self.warmup_iterations, self.iterations, self.update_on_change
+                func, self.warmup_iterations, self.iterations,
+                self.update_on_change, self.prune_configs,
             )
         else:
             decorated_func = self._create_tuning_wrapper(
-                func, self.warmup_iterations, self.iterations, self.update_on_change
+                func, self.warmup_iterations, self.iterations,
+                self.update_on_change, self.prune_configs,
             )
 
         # Use the wrapper if it exists, otherwise use the original function
@@ -1032,16 +1055,17 @@ def autotune_suite(
     make_arguments: Callable[..., tuple],
     cases: List[Any],
     params_dict: Dict[str, List[Any]],
+    prune_configs: Optional[Callable[..., bool]] = None,
     derived_params: Optional[Dict[str, Callable[..., Any]]] = None,
-    accept_percentile: Optional[float] = None,
+    accept_percentile: Optional[float] = 50.0,
     print_summary: bool = False,
     warmup_iterations: int = 10,
     iterations: int = 100,
     workspace_count: int = 10,
     stream: Optional[Any] = None,
 ) -> Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]]]:
-    """Benchmark every configuration of a kernel over a series of input cases and 
-    report the per-configuration timings for each case along with best configuration recommendations.
+    """Benchmark every configuration of a kernel across a set of input cases and
+    report per-case timings plus a ranked configuration recommendation.
 
     Example:
 
@@ -1056,75 +1080,52 @@ def autotune_suite(
             lambda M, N: make_tensors(M, N) + (M, N),
             cases=[(4096, 4096), (8192, 2048)],
             params_dict={"copy_bits": [64, 128]},
-            accept_percentile=50,  # keep each case's fastest half of the configs
+            accept_percentile=50,
         )
-        best = recommended[0]["config"]  # accepted in the most cases
+        best = recommended[0]["config"]        # accepted in the most cases
         aot = cute.compile(my_kernel, *args, **best)
 
-    :param func_or_cls: A ``cute.jit`` function whose tunable (``params_dict``)
-        and derived (``derived_params``) parameters must all follow the dynamic
-        ones in its signature. Those are supplied by keyword at compile time,
-        so any that appears before a dynamic (positional) argument collides
-        with the positional fill; keep every dynamic argument first, then the
-        tunable and derived parameters. A ``Constexpr`` parameter without a
-        default must be supplied through ``params_dict``, ``derived_params`` or
-        ``make_arguments``; one with a default falls back to it. Alternatively a
-        kernel class whose constructor
-        takes the tunable parameters and whose ``@cute.jit`` ``__call__`` takes
-        the dynamic arguments (followed by any derived ones); each configuration
-        is instantiated as ``func_or_cls(**config)``.
+    :param func_or_cls: A ``cute.jit`` function, or a kernel class whose
+        constructor takes the tunable / derived params and whose ``@cute.jit``
+        ``__call__`` takes only the dynamic arguments. For a function, the
+        tunable and derived params are keyword arguments, so they must follow
+        all dynamic (positional) arguments in the signature.
     :type func_or_cls: Callable
-    :param make_arguments: Builds the non-tunable (dynamic) positional arguments for one case. 
-        It must match the signature of ``__call__`` method of ``func_or_cls`` in the same order minus the tunable parameters 
-        (which are indicated by ``params_dict``) since they are omitted when the function is called at runtime.
+    :param make_arguments: Builds the dynamic positional arguments for one case,
+        i.e. the call arguments minus the tunable/derived params.
     :type make_arguments: Callable
-    :param cases: Input cases to sweep. Its items are passed to ``make_arguments`` to generate the inputs for each case.
+    :param cases: Input cases; each item is passed to ``make_arguments``.
     :type cases: List
-    :param params_dict: Parameter names and candidate values to sweep
+    :param params_dict: Parameter names and candidate values to sweep.
     :type params_dict: Dict[str, List[Any]]
-    :param derived_params: Optional map from a keyword-argument name to a
-        function that computes it from the current configuration. For each
-        config, the function is called on the host with the ``params_dict``
-        values whose names match its parameters, and its return value is passed
-        as that keyword argument at compile time (alongside ``config``). Use
-        this for configuration-derived compile-time arguments that cannot be
-        produced by ``make_arguments`` (which is config-blind) nor computed
-        inside a ``@cute.jit`` function -- e.g. a Blackwell persistent GEMM's
-        ``max_active_clusters``, which depends on the swept ``cluster_shape_mn``
-        and must be obtained from ``HardwareInfo`` on the host. Like the tunable
-        parameters, each derived parameter is passed by keyword, so it must come
-        after every dynamic argument in the signature; if the kernel expects it
-        interleaved with dynamic arguments (as the persistent GEMM's
-        ``max_active_clusters`` sits before ``stream`` in ``__call__``), wrap the
-        kernel in a thin ``@cute.jit`` adapter that takes the derived parameter
-        last and positions it correctly for the real call, defaults to None
+    :param prune_configs: Optional predicate whose parameters are a subset of
+        ``params_dict``'s keys; return ``False`` to skip a config, defaults to None.
+    :type prune_configs: Callable[..., bool], optional
+    :param derived_params: Optional map from a name to a function to compute it
+        from the current config (whose parameters come from ``params_dict``'s keys and the value
+        is the current configuration it benchmarks), defaults to None.
     :type derived_params: Dict[str, Callable], optional
-    :param accept_percentile: If set (0 < p <= 100), each case's ``timings`` keeps
-        only its fastest ``p`` percent of configurations (at least one); slower
-        configurations are discarded from the report. ``None`` keeps every
-        configuration, defaults to None
+    :param accept_percentile: If set (0 < p <= 100), each case keeps only its
+        fastest ``p`` percent of configs; if None, ``recommended`` is None.. Default to 50.0 
+        (configurations better than average are accepted).
     :type accept_percentile: float, optional
-    :param print_summary: Print the per-case timing tables and, when
-        ``accept_percentile`` is set, the recommended configs, defaults to True
+    :param print_summary: Print the per-case timing tables and recommendation, defaults to False.
     :type print_summary: bool, optional
-    :param warmup_iterations: Warmup iterations per benchmark, defaults to 10
+    :param warmup_iterations: Warmup iterations per benchmark, defaults to 10.
     :type warmup_iterations: int, optional
-    :param iterations: Benchmark iterations per configuration, defaults to 100
+    :param iterations: Benchmark iterations per config, defaults to 100.
     :type iterations: int, optional
-    :param workspace_count: Number of workspaces cycled through while
-        benchmarking to keep the L2 cache cold, defaults to 10
+    :param workspace_count: Workspaces cycled through to keep the L2 cache cold, defaults to 10.
     :type workspace_count: int, optional
-    :param stream: CUDA stream the kernel launches in; must be the same stream
-        ``make_arguments`` puts in its argument tuple. Defaults to the default
-        CUDA stream
+    :param stream: CUDA stream the kernel launches in; must match the one
+        ``make_arguments`` returns. Defaults to the default stream.
     :type stream: CUstream, optional
-    :return: ``(case_reports, recommended)``. ``case_reports`` holds one report
-        per case, in ``cases`` order: a dict with ``case``, ``best_config`` and
-        ``timings`` (sorted fastest first, truncated by ``accept_percentile``).
-        ``recommended`` holds up to 5 configurations ranked by how many cases
-        accepted them within ``accept_percentile``, each as
-        ``{"config": dict, "count": int}``; it is None when
-        ``accept_percentile`` is None
+    :return: ``(case_reports, recommended)``. ``case_reports`` has one dict per
+        case with ``case``, ``best_config`` and ``timings`` (fastest first). Each
+        reported config includes the derived params, so it is directly usable
+        with ``cute.compile``. ``recommended`` ranks up to 5 configs by how many
+        cases accepted them, each ``{"config": dict, "count": int}``, or None
+        when ``accept_percentile`` is None.
     :rtype: Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]]]
     """
     from cutlass import cute
@@ -1157,6 +1158,12 @@ def autotune_suite(
         timings = []
         for config_values in product(*params_dict.values()):
             config = dict(zip(keys, config_values))
+            # Skip configs rejected by the user's prune_configs predicate.
+            if prune_configs is not None and not prune_configs(
+                **{k: v for k, v in config.items()
+                   if k in inspect.signature(prune_configs).parameters}
+            ):
+                continue
             try:
                 args = case_arguments()
                 # Compute configuration-derived compile-time arguments on the
@@ -1169,9 +1176,9 @@ def autotune_suite(
                         **{k: v for k, v in config.items() if k in fn_params}
                     )
                 if inspect.isclass(func_or_cls):
-                    # class-style kernel: constexpr config goes to the constructor and the @cute.jit __call__ takes
-                    # only the dynamic arguments.
-                    compiled = cute.compile(func_or_cls(**config), *args, **derived)
+                    # Instantiate the kernel class with the current config and derived params,
+                    # then compile it with the dynamic args.
+                    compiled = cute.compile(func_or_cls(**config, **derived), *args)
                 else:
                     compiled = cute.compile(func_or_cls, *args, **config, **derived)
                 compiled(*args)
@@ -1192,7 +1199,8 @@ def autotune_suite(
                 if print_summary:
                     print(f"case {case}: skipping config {config}: {e}")
                 continue
-            timings.append({"config": config, "time_us": time_us})
+            # Include the derived params in the reported config so the returned best_config is directly usable
+            timings.append({"config": {**config, **derived}, "time_us": time_us})
 
         timings.sort(key=lambda entry: entry["time_us"])
         if accept_percentile is not None:

--- a/python/CuTeDSL/cutlass/cute/testing.py
+++ b/python/CuTeDSL/cutlass/cute/testing.py
@@ -633,7 +633,7 @@ class autotune_jit:
 
         Each derive function is called with the ``config`` values whose names
         match its parameters, and its return value becomes the keyword argument
-        of the same name (see ``benchmark_suite``'s ``derived_params``).
+        of the same name (see ``autotune_suite``'s ``derived_params``).
         """
         derived = {}
         for name, fn in (derived_params or {}).items():
@@ -823,92 +823,95 @@ class autotune_jit:
         warmup_iterations: int,
         iterations: int,
         autotune_update_params: list[str],
-    ) -> Callable[..., Any]:
-        """Create an auto-tuning wrapper for a kernel class that performs auto-tuning.
+    ) -> type:
+        """Turn a kernel class into an auto-tuning class.
 
-        The search space (``kernel_cls._autotune_params``) and the
-        derived-parameter functions (``kernel_cls._derived_params``) are read
-        from attributes on ``kernel_cls`` at call time -- they are populated by
-        ``__call__`` after this wrapper is built, so stacked decorators can
-        accumulate into them.
+        The tunable constructor parameters (those in ``params_dict``) are removed
+        from construction -- they are auto-tuned instead -- so the returned class
+        is used like a normal class, just without passing the tunable params.
 
         Args:
             kernel_cls: The kernel class to be wrapped.
             warmup_iterations: Number of warmup iterations for benchmarking.
             iterations: Number of benchmark iterations for benchmarking.
-            autotune_update_params: List of parameter names that trigger re-tuning when changed.
+            autotune_update_params: Names of the runtime arguments that key the cache.
 
         Returns:
-            Decorated wrapper function
+            A class whose instances are auto-tuning callables.
         """
         from cutlass.cute import compile
         from cutlass.testing import _benchmark_for_autotune
 
-        if not hasattr(kernel_cls, "_autotune_params"):
-            kernel_cls._original_kernel_cls = kernel_cls  # type: ignore[attr-defined]
-            kernel_cls._autotune_params = {}  # type: ignore[attr-defined]
-            kernel_cls._autotune_update_params = autotune_update_params  # type: ignore[attr-defined]
-            kernel_cls._best_kernel = dict()  # type: ignore[attr-defined]
-            kernel_cls._best_config = dict()  # type: ignore[attr-defined]
-            kernel_cls._timings = dict()  # type: ignore[attr-defined]
-            kernel_cls._derived_params = {}  # type: ignore[attr-defined]
+        # Already wrapped (e.g. stacked decorators): the merge happens in __call__.
+        if hasattr(kernel_cls, "_autotune_params"):
+            return kernel_cls
 
-            # Create wrapper function I auto-tuning
-            @functools.wraps(kernel_cls.__call__)
-            def tuning_wrapper(*args: Any, **kwargs: Any) -> Any:
-                # ``update_on_change`` names refer to the dynamic arguments the wrapper is called with, 
-                # which live in ``__call__``'s signature.
-                # The constructor only takes the tunable params as constexpr but not the runtime arguments
-                # that trigger re-tuning.
+        outer = cls  # the autotune_jit class, for logging and _compute_derived
+
+        class AutoTunedKernel:
+            _original_kernel_cls = kernel_cls
+            _autotune_params: Dict[str, List[Any]] = {}
+            _autotune_update_params = autotune_update_params
+            _derived_params: Dict[str, Callable[..., Any]] = {}
+
+            def __init__(self, **fixed_kwargs: Any) -> None:
+                # Constructor arguments that are NOT tuned (e.g. dtypes) may be
+                # fixed here; the tunable parameters come from params_dict instead.
+                self._fixed_kwargs = fixed_kwargs
+                # Per-instance tuning cache.
+                self._best_kernel: Dict[Any, Any] = {}
+                self._best_config: Dict[Any, Any] = {}
+                self._timings: Dict[Any, Any] = {}
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                # update_on_change names the dynamic __call__ arguments to key on.
                 call_parameters = [
                     name
-                    for name in inspect.signature(kernel_cls.__call__).parameters
+                    for name in inspect.signature(
+                        self._original_kernel_cls.__call__
+                    ).parameters
                     if name != "self"
                 ]
                 tuning_key: Any = list()
-                for param_name in kernel_cls._autotune_update_params:  # type: ignore[attr-defined]
-                    if param_name in kwargs.keys():
+                for param_name in self._autotune_update_params:
+                    if param_name in kwargs:
+                        # The parameter to update autotuning is passed as a keyword argument
                         tuning_key.append(kwargs[param_name])
                     else:
                         index = call_parameters.index(param_name)
                         if index < len(args):
+                            # The parameter to update autotuning is passed as a positional argument
                             tuning_key.append(args[index])
                 tuning_key = tuple(tuning_key)
-                if tuning_key in kernel_cls._best_kernel:
-                    cls.log().info(
-                        f"Using cached best configuration: {kernel_cls._best_config[tuning_key]}"
-                    )
-                    return kernel_cls._best_kernel[tuning_key](*args, **kwargs)
 
-                # Get all parameter configurations
-                params_dict = kernel_cls._autotune_params  # type: ignore[attr-defined]
+                if tuning_key in self._best_kernel:
+                    outer.log().info(
+                        f"Using cached best configuration: {self._best_config[tuning_key]}"
+                    )
+                    return self._best_kernel[tuning_key](*args, **kwargs)
+
+                params_dict = self._autotune_params
                 keys = list(params_dict.keys())
                 values = list(params_dict.values())
 
                 min_time = float("inf")
-
                 best_kernel = None
                 best_config = None
                 config_timings: List[Dict[str, Any]] = []
-                # Record start time
                 start = time()
 
-                # Iterate through all possible configuration combinations
                 for config_values in product(*values):
-                    # Build current configuration
                     current_config = dict(zip(keys, config_values))
-                    cls.log().info(f"Tuning configuration: {current_config}")
-
+                    outer.log().info(f"Tuning configuration: {current_config}")
                     try:
-                        # Create an instance of the kernel class with the current configuration,
-                        # using current configuration to replace default parameters
-                        kernel = kernel_cls(**current_config)
-                        # Compute derived parameters using the function user provides
-                        derived = cls._compute_derived(
-                            kernel_cls._derived_params, current_config  # type: ignore[attr-defined]
+                        # Instantiate the original class with the fixed kwargs
+                        # plus the current (tuned) configuration.
+                        kernel = self._original_kernel_cls(
+                            **{**self._fixed_kwargs, **current_config}
                         )
-                        # Call the kernel object; configuration-derived compile
-                        # arguments are computed on the host and passed by keyword.
+                        derived = outer._compute_derived(
+                            self._derived_params, current_config
+                        )
                         compiled_func = compile(kernel, *args, **kwargs, **derived)
                         cur_time = _benchmark_for_autotune(
                             compiled_func,
@@ -919,13 +922,13 @@ class autotune_jit:
                             print_verbose=False,
                             **kwargs,
                         )
-                    except NotImplementedError as e:
-                        raise e
+                    except NotImplementedError:
+                        raise
                     except Exception as e:
-                        cls.log().info(f"   Configuration skipped: {e}")
+                        outer.log().info(f"   Configuration skipped: {e}")
                         continue
 
-                    cls.log().info(f"   Execution time: {cur_time} us")
+                    outer.log().info(f"   Execution time: {cur_time} us")
                     config_timings.append(
                         {"config": dict(current_config), "time_us": cur_time}
                     )
@@ -937,30 +940,18 @@ class autotune_jit:
                 if best_kernel is None:
                     raise ValueError("No best kernel found")
 
-                cls.log().info(
+                outer.log().info(
                     f"Best configuration: {best_config}, execution time: {min_time} us"
                 )
-                cls.log().info(f"Total tuning time: {time() - start} s")
-                kernel_cls._best_kernel[tuning_key] = best_kernel
-                kernel_cls._best_config[tuning_key] = best_config
-                kernel_cls._timings[tuning_key] = config_timings
+                outer.log().info(f"Total tuning time: {time() - start} s")
+                self._best_kernel[tuning_key] = best_kernel
+                self._best_config[tuning_key] = best_config
+                self._timings[tuning_key] = config_timings
                 return best_kernel(*args, **kwargs)
-            
-            # Append autotune wrapper to not conflict with the jit kernel names
-            tuning_wrapper.__name__ = kernel_cls.__name__ + "_autotune_wrapper"
-            tuning_wrapper.__qualname__ = kernel_cls.__qualname__ + "_autotune_wrapper"
 
-            # Expose the tuning state on the wrapper too
-            tuning_wrapper._autotune_params = kernel_cls._autotune_params  # type: ignore[attr-defined]
-            tuning_wrapper._autotune_update_params = kernel_cls._autotune_update_params  # type: ignore[attr-defined]
-            tuning_wrapper._best_kernel = kernel_cls._best_kernel  # type: ignore[attr-defined]
-            tuning_wrapper._best_config = kernel_cls._best_config  # type: ignore[attr-defined]
-            tuning_wrapper._timings = kernel_cls._timings  # type: ignore[attr-defined]
-            tuning_wrapper._derived_params = kernel_cls._derived_params  # type: ignore[attr-defined]
-
-            return tuning_wrapper
-
-        return kernel_cls  # If already has a wrapper, return the original class
+        AutoTunedKernel.__name__ = kernel_cls.__name__
+        AutoTunedKernel.__qualname__ = kernel_cls.__qualname__
+        return AutoTunedKernel
 
     def __init__(
         self,
@@ -1036,7 +1027,7 @@ class autotune_jit:
 
         return result_func
 
-def benchmark_suite(
+def autotune_suite(
     func_or_cls: Callable[..., Any],
     make_arguments: Callable[..., tuple],
     cases: List[Any],
@@ -1060,7 +1051,7 @@ def benchmark_suite(
         def my_kernel(a, b, c, M, N, copy_bits: cutlass.Constexpr = 128):
             ...
 
-        reports, recommended = benchmark_suite(
+        reports, recommended = autotune_suite(
             my_kernel,
             lambda M, N: make_tensors(M, N) + (M, N),
             cases=[(4096, 4096), (8192, 2048)],
@@ -1084,7 +1075,7 @@ def benchmark_suite(
         is instantiated as ``func_or_cls(**config)``.
     :type func_or_cls: Callable
     :param make_arguments: Builds the non-tunable (dynamic) positional arguments for one case. 
-        It must match the signature of ``func_or_cls`` in the same order except for the tunable parameters 
+        It must match the signature of ``__call__`` method of ``func_or_cls`` in the same order minus the tunable parameters 
         (which are indicated by ``params_dict``) since they are omitted when the function is called at runtime.
     :type make_arguments: Callable
     :param cases: Input cases to sweep. Its items are passed to ``make_arguments`` to generate the inputs for each case.
@@ -1139,6 +1130,14 @@ def benchmark_suite(
     from cutlass import cute
     from cutlass import testing
 
+    # An autotune_jit-decorated function/class carries _autotune_params; it is not
+    # a plain cute.jit function or kernel class and cannot be compiled directly.
+    if hasattr(func_or_cls, "_autotune_params"):
+        raise TypeError(
+            "autotune_suite expects an undecorated cute.jit function or kernel "
+            "class, but got an autotune_jit-decorated one. Pass the original "
+            "(undecorated) function/class and its search space via params_dict."
+        )
     if accept_percentile is not None and not 0 < accept_percentile <= 100:
         raise ValueError(
             f"accept_percentile must be in (0, 100] or None to accept all configs, got {accept_percentile}"

--- a/python/CuTeDSL/cutlass/cute/testing.py
+++ b/python/CuTeDSL/cutlass/cute/testing.py
@@ -13,10 +13,11 @@
 import functools
 import inspect
 import logging
+import math
 import os
 from itertools import product
 from time import time
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from cutlass.cutlass_dsl import Constexpr, CuTeDSL, T, dsl_user_op, const_expr
 
@@ -553,8 +554,12 @@ def convert(src: Tensor, dst: Tensor) -> None:
 class autotune_jit:
     """Auto-tuning tool supporting both dictionary and parameterized decorator styles.
     The autotune_jit class can be used as a decorator or a function.
-    When used as a decorator, it will automatically tune the function based on the parameters.
+    When used as a decorator, it will automatically tune the function or class based on the parameters.
+    When decorating a class, the class must have the structure where the tunable parameters are passed to the constructor,
+    and the @cute.jit __call__ method takes only the dynamic arguments.
+
     When used as a function, it will return a decorator that can be used to decorate a function.
+
     For example:
     .. code-block:: python
 
@@ -563,6 +568,17 @@ class autotune_jit:
         def user_function(param1=1, param2=2, param3=3):
             # contents of the function
             pass
+
+        @autotune_jit(params_dict={'param1': [1, 2, 3], 'param2': [4, 5, 6]}, update_on_change=['param3'])
+        class UserKernel:
+            def __init__(self, param1=1, param2=2, param3=3):
+                # constructor contents
+                pass
+
+            @cute.jit
+            def __call__(self, *args, **kwargs):
+                # contents of the __call__ method
+                pass
 
     The function will be automatically tuned over all combinations of param1 and param2 whenever param3 changes .
     For non-specified parameters, the default value in user_function will be used (e.g., `param3` in `user_function`).
@@ -574,6 +590,10 @@ class autotune_jit:
     - Only supports functions that are decorated with cute.jit
     - If the function which is decorated with cute.jit is call method of a class, and the class has internal state that
       is used as constexpr arguments in the function, the autotuner will not be able to find the best configuration.
+    - The tunable (``params_dict``) and derived (``derived_params``) parameters are supplied by keyword during tuning,
+      so for a decorated function they must all follow the positional runtime arguments in its signature -- otherwise they will
+      collide with the positional parameter.
+      A ``Constexpr`` parameter without a default value must be either swept, derived, or passed at the call site.
 
     Note: The autotuner has the same semantics as cute.compile. If the function is compiled, but global variables are changed,
     the autotuner will not recompile the kernel.
@@ -605,6 +625,22 @@ class autotune_jit:
         assert cls._logger is not None, "logger is not initialized"
         return cls._logger
 
+    @staticmethod
+    def _compute_derived(
+        derived_params: Dict[str, Callable[..., Any]], config: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Compute configuration-derived compile-time arguments on the host.
+
+        Each derive function is called with the ``config`` values whose names
+        match its parameters, and its return value becomes the keyword argument
+        of the same name (see ``benchmark_suite``'s ``derived_params``).
+        """
+        derived = {}
+        for name, fn in (derived_params or {}).items():
+            fn_params = inspect.signature(fn).parameters
+            derived[name] = fn(**{k: v for k, v in config.items() if k in fn_params})
+        return derived
+
     @classmethod
     def _create_tuning_wrapper(
         cls,
@@ -615,8 +651,16 @@ class autotune_jit:
     ) -> Callable[..., Any]:
         """Create a wrapper function that performs auto-tuning
 
+        The search space (``func._autotune_params``) and the derived-parameter
+        functions (``func._derived_params``) are read from attributes on ``func``
+        at call time -- they are populated by ``__call__`` after this wrapper is
+        built, so stacked decorators can accumulate into them.
+
         Args:
             func: Original function
+            warmup_iterations: Number of warmup iterations for benchmarking.
+            iterations: Number of benchmark iterations for benchmarking.
+            autotune_update_params: List of parameter names that trigger re-tuning when changed.
 
         Returns:
             Decorated wrapper function
@@ -631,6 +675,8 @@ class autotune_jit:
             func._autotune_update_params = autotune_update_params  # type: ignore[attr-defined]
             func._best_kernel = dict()  # type: ignore[attr-defined]
             func._best_config = dict()  # type: ignore[attr-defined]
+            func._timings = dict()  # type: ignore[attr-defined]
+            func._derived_params = {}  # type: ignore[attr-defined]
 
             # Create wrapper function for auto-tuning
             @functools.wraps(func)
@@ -659,6 +705,7 @@ class autotune_jit:
                 min_time = float("inf")
 
                 best_kernel = None
+                config_timings: List[Dict[str, Any]] = []
                 # Record start time
                 start = time()
 
@@ -669,10 +716,14 @@ class autotune_jit:
                     cls.log().info(f"Tuning configuration: {current_config}")
 
                     try:
+                        # Compute derived parameters using the function user provides
+                        derived = cls._compute_derived(
+                            func._derived_params, current_config  # type: ignore[attr-defined]
+                        )
                         # Call the original function, using current configuration to replace default parameters
                         # For example, if current_config contains "cluster_shape_mn": (2, 1)
                         # It will override func's default parameter value
-                        merged_kwargs = {**kwargs, **current_config}
+                        merged_kwargs = {**kwargs, **current_config, **derived}
                         compiled_func = compile(
                             func._original_func,  # type: ignore[attr-defined]
                             *args,
@@ -685,7 +736,13 @@ class autotune_jit:
                         for arg in compiled_func.execution_args.get_constexpr_args():
                             if arg["argument_name"] in merged_kwargs:
                                 del merged_kwargs[arg["argument_name"]]
-                            elif arg["argument_index"] is not None:
+                            elif (
+                                arg["argument_index"] is not None
+                                and arg["argument_index"] < len(args)
+                            ):
+                                # Only strip arguments that were passed positionally. A constexpr that is not passed positionally
+                                # (and isn't a kwarg, handled above) should use its default value defined in the function signature,
+                                # in which case we shouldn't strip it.
                                 indexes_to_remove.append(arg["argument_index"])
                             if arg["argument_name"] not in func._autotune_update_params:  # type: ignore[attr-defined]
                                 # Handle the case where the programmer avoided autotuning over constexpr values, and
@@ -711,6 +768,10 @@ class autotune_jit:
                         )
 
                         cls.log().info(f"   Execution time: {cur_time} us")
+
+                        config_timings.append(
+                            {"config": dict(current_config), "time_us": cur_time}
+                        )
 
                         # Update best results
                         if cur_time < min_time:
@@ -744,6 +805,7 @@ class autotune_jit:
                 cls.log().info(f"Total tuning time: {tuning_time} s")
                 func._best_kernel[tuning_key] = best_kernel  # type: ignore[attr-defined]
                 func._best_config[tuning_key] = best_config  # type: ignore[attr-defined]
+                func._timings[tuning_key] = config_timings  # type: ignore[attr-defined]
                 return best_kernel(*args, **kwargs)
 
             # Append autotune wrapper to not conflict with the jit kernel names
@@ -754,14 +816,164 @@ class autotune_jit:
 
         return func  # If already has a wrapper, return the original function
 
+    @classmethod
+    def _create_class_tuning_wrapper(
+        cls,
+        kernel_cls: type,
+        warmup_iterations: int,
+        iterations: int,
+        autotune_update_params: list[str],
+    ) -> Callable[..., Any]:
+        """Create an auto-tuning wrapper for a kernel class that performs auto-tuning.
+
+        The search space (``kernel_cls._autotune_params``) and the
+        derived-parameter functions (``kernel_cls._derived_params``) are read
+        from attributes on ``kernel_cls`` at call time -- they are populated by
+        ``__call__`` after this wrapper is built, so stacked decorators can
+        accumulate into them.
+
+        Args:
+            kernel_cls: The kernel class to be wrapped.
+            warmup_iterations: Number of warmup iterations for benchmarking.
+            iterations: Number of benchmark iterations for benchmarking.
+            autotune_update_params: List of parameter names that trigger re-tuning when changed.
+
+        Returns:
+            Decorated wrapper function
+        """
+        from cutlass.cute import compile
+        from cutlass.testing import _benchmark_for_autotune
+
+        if not hasattr(kernel_cls, "_autotune_params"):
+            kernel_cls._original_kernel_cls = kernel_cls  # type: ignore[attr-defined]
+            kernel_cls._autotune_params = {}  # type: ignore[attr-defined]
+            kernel_cls._autotune_update_params = autotune_update_params  # type: ignore[attr-defined]
+            kernel_cls._best_kernel = dict()  # type: ignore[attr-defined]
+            kernel_cls._best_config = dict()  # type: ignore[attr-defined]
+            kernel_cls._timings = dict()  # type: ignore[attr-defined]
+            kernel_cls._derived_params = {}  # type: ignore[attr-defined]
+
+            # Create wrapper function I auto-tuning
+            @functools.wraps(kernel_cls.__call__)
+            def tuning_wrapper(*args: Any, **kwargs: Any) -> Any:
+                # ``update_on_change`` names refer to the dynamic arguments the wrapper is called with, 
+                # which live in ``__call__``'s signature.
+                # The constructor only takes the tunable params as constexpr but not the runtime arguments
+                # that trigger re-tuning.
+                call_parameters = [
+                    name
+                    for name in inspect.signature(kernel_cls.__call__).parameters
+                    if name != "self"
+                ]
+                tuning_key: Any = list()
+                for param_name in kernel_cls._autotune_update_params:  # type: ignore[attr-defined]
+                    if param_name in kwargs.keys():
+                        tuning_key.append(kwargs[param_name])
+                    else:
+                        index = call_parameters.index(param_name)
+                        if index < len(args):
+                            tuning_key.append(args[index])
+                tuning_key = tuple(tuning_key)
+                if tuning_key in kernel_cls._best_kernel:
+                    cls.log().info(
+                        f"Using cached best configuration: {kernel_cls._best_config[tuning_key]}"
+                    )
+                    return kernel_cls._best_kernel[tuning_key](*args, **kwargs)
+
+                # Get all parameter configurations
+                params_dict = kernel_cls._autotune_params  # type: ignore[attr-defined]
+                keys = list(params_dict.keys())
+                values = list(params_dict.values())
+
+                min_time = float("inf")
+
+                best_kernel = None
+                best_config = None
+                config_timings: List[Dict[str, Any]] = []
+                # Record start time
+                start = time()
+
+                # Iterate through all possible configuration combinations
+                for config_values in product(*values):
+                    # Build current configuration
+                    current_config = dict(zip(keys, config_values))
+                    cls.log().info(f"Tuning configuration: {current_config}")
+
+                    try:
+                        # Create an instance of the kernel class with the current configuration,
+                        # using current configuration to replace default parameters
+                        kernel = kernel_cls(**current_config)
+                        # Compute derived parameters using the function user provides
+                        derived = cls._compute_derived(
+                            kernel_cls._derived_params, current_config  # type: ignore[attr-defined]
+                        )
+                        # Call the kernel object; configuration-derived compile
+                        # arguments are computed on the host and passed by keyword.
+                        compiled_func = compile(kernel, *args, **kwargs, **derived)
+                        cur_time = _benchmark_for_autotune(
+                            compiled_func,
+                            *args,
+                            warmup_iterations=warmup_iterations,
+                            iterations=iterations,
+                            use_cold_l2=True,
+                            print_verbose=False,
+                            **kwargs,
+                        )
+                    except NotImplementedError as e:
+                        raise e
+                    except Exception as e:
+                        cls.log().info(f"   Configuration skipped: {e}")
+                        continue
+
+                    cls.log().info(f"   Execution time: {cur_time} us")
+                    config_timings.append(
+                        {"config": dict(current_config), "time_us": cur_time}
+                    )
+                    if cur_time < min_time:
+                        min_time = cur_time
+                        best_kernel = compiled_func
+                        best_config = current_config
+
+                if best_kernel is None:
+                    raise ValueError("No best kernel found")
+
+                cls.log().info(
+                    f"Best configuration: {best_config}, execution time: {min_time} us"
+                )
+                cls.log().info(f"Total tuning time: {time() - start} s")
+                kernel_cls._best_kernel[tuning_key] = best_kernel
+                kernel_cls._best_config[tuning_key] = best_config
+                kernel_cls._timings[tuning_key] = config_timings
+                return best_kernel(*args, **kwargs)
+            
+            # Append autotune wrapper to not conflict with the jit kernel names
+            tuning_wrapper.__name__ = kernel_cls.__name__ + "_autotune_wrapper"
+            tuning_wrapper.__qualname__ = kernel_cls.__qualname__ + "_autotune_wrapper"
+
+            # Expose the tuning state on the wrapper too
+            tuning_wrapper._autotune_params = kernel_cls._autotune_params  # type: ignore[attr-defined]
+            tuning_wrapper._autotune_update_params = kernel_cls._autotune_update_params  # type: ignore[attr-defined]
+            tuning_wrapper._best_kernel = kernel_cls._best_kernel  # type: ignore[attr-defined]
+            tuning_wrapper._best_config = kernel_cls._best_config  # type: ignore[attr-defined]
+            tuning_wrapper._timings = kernel_cls._timings  # type: ignore[attr-defined]
+            tuning_wrapper._derived_params = kernel_cls._derived_params  # type: ignore[attr-defined]
+
+            return tuning_wrapper
+
+        return kernel_cls  # If already has a wrapper, return the original class
+
     def __init__(
         self,
         params_dict: Optional[Dict[str, List[Any]]] = None,
         update_on_change: Optional[List[str]] = None,
         warmup_iterations: int = 10,
         iterations: int = 100,
+        derived_params: Optional[Dict[str, Callable[..., Any]]] = None,
     ) -> None:
         """Initialize the autotune_jit decorator.
+
+        Note: The parameters in ``params_dict`` and ``derived_params`` must all follow the dynamic arguments (positional) in
+        the function signature of the decorated function or class.
 
         :param params_dict: Dictionary containing parameter names and their possible values
         :type params_dict: Dict[str, List[Any]], optional
@@ -771,6 +983,8 @@ class autotune_jit:
         :type warmup_iterations: int, optional
         :param iterations: Number of benchmark iterations, defaults to 100
         :type iterations: int, optional
+        :param derived_params: a dict to derive the values of parameters from other parameters passed in params_dict.
+        :type derived_params: Dict[str, Callable], optional
         """
         # Initialize logger
         self._initialize_logger()
@@ -778,6 +992,7 @@ class autotune_jit:
         # Save parameter dictionary
         self.params_dict = params_dict or {}
         self.update_on_change = update_on_change or list()
+        self.derived_params = derived_params or {}
 
         # Save iterations
         self.warmup_iterations = warmup_iterations
@@ -786,15 +1001,24 @@ class autotune_jit:
     def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
         """Called when class instance is used as a decorator.
 
-        :param func: Function to be decorated
+        :param func: Function (``@cute.jit``) or kernel class to be decorated.
+            A class should take the tunable parameters in its constructor and
+            define a ``@cute.jit`` ``__call__`` with only dynamic arguments.
         :type func: Callable
         :return: Decorated function
         :rtype: Callable
         """
-        # Create wrapper function
-        decorated_func = self._create_tuning_wrapper(
-            func, self.warmup_iterations, self.iterations, self.update_on_change
-        )
+        # Create wrapper function; an already-wrapped func (carrying
+        # _autotune_params) is returned unchanged by either path so stacked
+        # decorators merge their params instead of nesting tuners.
+        if inspect.isclass(func):
+            decorated_func = self._create_class_tuning_wrapper(
+                func, self.warmup_iterations, self.iterations, self.update_on_change
+            )
+        else:
+            decorated_func = self._create_tuning_wrapper(
+                func, self.warmup_iterations, self.iterations, self.update_on_change
+            )
 
         # Use the wrapper if it exists, otherwise use the original function
         result_func = (
@@ -805,7 +1029,210 @@ class autotune_jit:
         for param_name, param_values in self.params_dict.items():
             result_func._autotune_params[param_name] = param_values
 
+        # Merge derived-parameter functions the same way (stacked decorators
+        # accumulate them into the shared dict the sweep reads).
+        for name, fn in self.derived_params.items():
+            result_func._derived_params[name] = fn
+
         return result_func
+
+def benchmark_suite(
+    func_or_cls: Callable[..., Any],
+    make_arguments: Callable[..., tuple],
+    cases: List[Any],
+    params_dict: Dict[str, List[Any]],
+    derived_params: Optional[Dict[str, Callable[..., Any]]] = None,
+    accept_percentile: Optional[float] = None,
+    print_summary: bool = False,
+    warmup_iterations: int = 10,
+    iterations: int = 100,
+    workspace_count: int = 10,
+    stream: Optional[Any] = None,
+) -> Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]]]:
+    """Benchmark every configuration of a kernel over a series of input cases and 
+    report the per-configuration timings for each case along with best configuration recommendations.
+
+    Example:
+
+    .. code-block:: python
+
+        @cute.jit
+        def my_kernel(a, b, c, M, N, copy_bits: cutlass.Constexpr = 128):
+            ...
+
+        reports, recommended = benchmark_suite(
+            my_kernel,
+            lambda M, N: make_tensors(M, N) + (M, N),
+            cases=[(4096, 4096), (8192, 2048)],
+            params_dict={"copy_bits": [64, 128]},
+            accept_percentile=50,  # keep each case's fastest half of the configs
+        )
+        best = recommended[0]["config"]  # accepted in the most cases
+        aot = cute.compile(my_kernel, *args, **best)
+
+    :param func_or_cls: A ``cute.jit`` function whose tunable (``params_dict``)
+        and derived (``derived_params``) parameters must all follow the dynamic
+        ones in its signature. Those are supplied by keyword at compile time,
+        so any that appears before a dynamic (positional) argument collides
+        with the positional fill; keep every dynamic argument first, then the
+        tunable and derived parameters. A ``Constexpr`` parameter without a
+        default must be supplied through ``params_dict``, ``derived_params`` or
+        ``make_arguments``; one with a default falls back to it. Alternatively a
+        kernel class whose constructor
+        takes the tunable parameters and whose ``@cute.jit`` ``__call__`` takes
+        the dynamic arguments (followed by any derived ones); each configuration
+        is instantiated as ``func_or_cls(**config)``.
+    :type func_or_cls: Callable
+    :param make_arguments: Builds the non-tunable (dynamic) positional arguments for one case. 
+        It must match the signature of ``func_or_cls`` in the same order except for the tunable parameters 
+        (which are indicated by ``params_dict``) since they are omitted when the function is called at runtime.
+    :type make_arguments: Callable
+    :param cases: Input cases to sweep. Its items are passed to ``make_arguments`` to generate the inputs for each case.
+    :type cases: List
+    :param params_dict: Parameter names and candidate values to sweep
+    :type params_dict: Dict[str, List[Any]]
+    :param derived_params: Optional map from a keyword-argument name to a
+        function that computes it from the current configuration. For each
+        config, the function is called on the host with the ``params_dict``
+        values whose names match its parameters, and its return value is passed
+        as that keyword argument at compile time (alongside ``config``). Use
+        this for configuration-derived compile-time arguments that cannot be
+        produced by ``make_arguments`` (which is config-blind) nor computed
+        inside a ``@cute.jit`` function -- e.g. a Blackwell persistent GEMM's
+        ``max_active_clusters``, which depends on the swept ``cluster_shape_mn``
+        and must be obtained from ``HardwareInfo`` on the host. Like the tunable
+        parameters, each derived parameter is passed by keyword, so it must come
+        after every dynamic argument in the signature; if the kernel expects it
+        interleaved with dynamic arguments (as the persistent GEMM's
+        ``max_active_clusters`` sits before ``stream`` in ``__call__``), wrap the
+        kernel in a thin ``@cute.jit`` adapter that takes the derived parameter
+        last and positions it correctly for the real call, defaults to None
+    :type derived_params: Dict[str, Callable], optional
+    :param accept_percentile: If set (0 < p <= 100), each case's ``timings`` keeps
+        only its fastest ``p`` percent of configurations (at least one); slower
+        configurations are discarded from the report. ``None`` keeps every
+        configuration, defaults to None
+    :type accept_percentile: float, optional
+    :param print_summary: Print the per-case timing tables and, when
+        ``accept_percentile`` is set, the recommended configs, defaults to True
+    :type print_summary: bool, optional
+    :param warmup_iterations: Warmup iterations per benchmark, defaults to 10
+    :type warmup_iterations: int, optional
+    :param iterations: Benchmark iterations per configuration, defaults to 100
+    :type iterations: int, optional
+    :param workspace_count: Number of workspaces cycled through while
+        benchmarking to keep the L2 cache cold, defaults to 10
+    :type workspace_count: int, optional
+    :param stream: CUDA stream the kernel launches in; must be the same stream
+        ``make_arguments`` puts in its argument tuple. Defaults to the default
+        CUDA stream
+    :type stream: CUstream, optional
+    :return: ``(case_reports, recommended)``. ``case_reports`` holds one report
+        per case, in ``cases`` order: a dict with ``case``, ``best_config`` and
+        ``timings`` (sorted fastest first, truncated by ``accept_percentile``).
+        ``recommended`` holds up to 5 configurations ranked by how many cases
+        accepted them within ``accept_percentile``, each as
+        ``{"config": dict, "count": int}``; it is None when
+        ``accept_percentile`` is None
+    :rtype: Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]]]
+    """
+    from cutlass import cute
+    from cutlass import testing
+
+    if accept_percentile is not None and not 0 < accept_percentile <= 100:
+        raise ValueError(
+            f"accept_percentile must be in (0, 100] or None to accept all configs, got {accept_percentile}"
+        )
+
+    keys = list(params_dict.keys())
+    case_reports = []
+    for case in cases:
+
+        def case_arguments(case=case):
+            return (
+                make_arguments(*case)
+                if isinstance(case, tuple)
+                else make_arguments(case)
+            )
+
+        timings = []
+        for config_values in product(*params_dict.values()):
+            config = dict(zip(keys, config_values))
+            try:
+                args = case_arguments()
+                # Compute configuration-derived compile-time arguments on the
+                # host (e.g. max_active_clusters from cluster_shape_mn), passing
+                # each derive function the config values whose names it declares.
+                derived = {}
+                for name, fn in (derived_params or {}).items():
+                    fn_params = inspect.signature(fn).parameters
+                    derived[name] = fn(
+                        **{k: v for k, v in config.items() if k in fn_params}
+                    )
+                if inspect.isclass(func_or_cls):
+                    # class-style kernel: constexpr config goes to the constructor and the @cute.jit __call__ takes
+                    # only the dynamic arguments.
+                    compiled = cute.compile(func_or_cls(**config), *args, **derived)
+                else:
+                    compiled = cute.compile(func_or_cls, *args, **config, **derived)
+                compiled(*args)
+
+                time_us = testing.benchmark(
+                    compiled,
+                    workspace_generator=lambda: testing.JitArguments(
+                        *case_arguments()
+                    ),
+                    workspace_count=workspace_count,
+                    warmup_iterations=warmup_iterations,
+                    iterations=iterations,
+                    stream=stream,
+                )
+            except NotImplementedError:
+                raise
+            except Exception as e:
+                if print_summary:
+                    print(f"case {case}: skipping config {config}: {e}")
+                continue
+            timings.append({"config": config, "time_us": time_us})
+
+        timings.sort(key=lambda entry: entry["time_us"])
+        if accept_percentile is not None:
+            keep = max(1, math.ceil(len(timings) * accept_percentile / 100))
+            timings = timings[:keep]
+        case_reports.append(
+            {
+                "case": case,
+                "best_config": timings[0]["config"] if timings else None,
+                "timings": timings,
+            }
+        )
+
+    recommended = None
+    if accept_percentile is not None:
+        counts: Dict[tuple, int] = {}
+        for report in case_reports:
+            for entry in report["timings"]:
+                config = tuple(sorted(entry["config"].items()))
+                counts[config] = counts.get(config, 0) + 1
+        recommended = [
+            {"config": dict(config), "count": count}
+            for config, count in sorted(counts.items(), key=lambda kv: -kv[1])[:5]
+        ]
+
+    if print_summary:
+        for report in case_reports:
+            print(f"case {report['case']}: best config {report['best_config']}")
+            for entry in report["timings"]:
+                print(f"    {entry['config']}: {entry['time_us']:.2f} us")
+        if recommended is not None:
+            print("recommended configs:")
+            for entry in recommended:
+                print(
+                    f"    {entry['config']}: accepted in "
+                    f"{entry['count']}/{len(case_reports)} cases"
+                )
+
+    return case_reports, recommended
 
 
 ################################################

--- a/python/CuTeDSL/cutlass/cute/testing.py
+++ b/python/CuTeDSL/cutlass/cute/testing.py
@@ -1114,7 +1114,10 @@ def autotune_suite(
         all dynamic (positional) arguments in the signature.
     :type func_or_cls: Callable
     :param make_arguments: Builds the dynamic positional arguments for one case,
-        i.e. the call arguments minus the tunable/derived params.
+        i.e. the call arguments minus the tunable/derived params, whose values are
+        provided by ``params_dict`` and ``derived_params``.
+        We will pass the current case values plus any config/derived values whose names it declares
+        to ``make_arguments`` as keyword values.
     :type make_arguments: Callable
     :param cases: Input cases; each item is passed to ``make_arguments``.
     :type cases: List
@@ -1167,14 +1170,19 @@ def autotune_suite(
         )
 
     keys = list(params_dict.keys())
+    make_args_params = inspect.signature(make_arguments).parameters
     case_reports = []
     for case in cases:
 
-        def case_arguments(case=case):
+        def case_arguments(overrides, case=case):
+            # Forward any config / derived value whose name make_arguments
+            # declares (e.g. so it can size config-dependent tensors like a
+            # reduction workspace); config keys it does not declare are ignored.
+            extra = {k: v for k, v in overrides.items() if k in make_args_params}
             return (
-                make_arguments(*case)
+                make_arguments(*case, **extra)
                 if isinstance(case, tuple)
-                else make_arguments(case)
+                else make_arguments(case, **extra)
             )
 
         timings = []
@@ -1187,7 +1195,6 @@ def autotune_suite(
             ):
                 continue
             try:
-                args = case_arguments()
                 # Compute configuration-derived compile-time arguments on the
                 # host (e.g. max_active_clusters from cluster_shape_mn), passing
                 # each derive function the config values whose names it declares.
@@ -1197,8 +1204,11 @@ def autotune_suite(
                     derived[name] = fn(
                         **{k: v for k, v in config.items() if k in fn_params}
                     )
+                config_with_derived = {**config, **derived}
+                # Build the dynamic args; make_arguments may size some of them
+                # from the config / derived values whose names it declares.
+                args = case_arguments(config_with_derived)
                 if inspect.isclass(func_or_cls):
-                    config_with_derived = {**config, **derived}
                     init_params = inspect.signature(func_or_cls.__init__).parameters
                     # Attributes to override that are initialized in __init__ method
                     init_configs = {k: v for k, v in config_with_derived.items() if k in init_params}
@@ -1221,8 +1231,8 @@ def autotune_suite(
 
                 time_us = testing.benchmark(
                     compiled,
-                    workspace_generator=lambda: testing.JitArguments(
-                        *case_arguments()
+                    workspace_generator=lambda cad=config_with_derived: testing.JitArguments(
+                        *case_arguments(cad)
                     ),
                     workspace_count=workspace_count,
                     warmup_iterations=warmup_iterations,


### PR DESCRIPTION
This PR adds a lot of things to the overall CuTeDSL autotuning process to make it easier to use and more convenient:

- Add `derived_params` to autotuning API so it computes derived arguments that must be decided during compile time but rely on autotuned parameters (whose values are different per configuration tuned)
- Make `testing.autotune_jit` able to decorate a class. This is for people who prefer to implement kernels as classes that fix the compile time params in `__init__` method and pass runtime params to `__call__`, so now they can do this
```
@testing.autotune_jit(
    params_dict={"COPY_BITS": [32, 64, 128], "THREADS_M": [4, 8]},
    update_on_change=["M", "N"],
    warmup_iterations=10,
    iterations=50,
)
class ElementwiseAddKernel:
    THREADS_M = 4

    def __init__(self, COPY_BITS=128):
        self.COPY_BITS = COPY_BITS

    @cute.jit
    def __call__(self, mA, mB, mC, M, N):
        elementwise_add(
            mA, mB, mC, M, N,
            copy_bits=self.COPY_BITS,
            threads_m=self.THREADS_M,
        )
```
- Support pruning undesired configurations (either invalid or known to be suboptimal) -- this aligns with triton's `prune_configs_by` in their autotuning API
- Add `autotune_suite` API so now user can provide a list of representative shapes and find the best overall kernel candidates with the ranking rule: sort according to how many times a configuration is accepted across all inputs, where "accepted" mean for a input case the configuration is in the top `accept_percentile` fastest ones
- Better autotuning docs. Previously the doc only explains how to autotune manually which is quite painful at least for me