### PR TITLE
Fix pre-Blackwell validation in the Ada FP8 GEMM example

### DIFF
--- a/examples/58_ada_fp8_gemm/ada_fp8_gemm.cu
+++ b/examples/58_ada_fp8_gemm/ada_fp8_gemm.cu
@@ -770,6 +770,9 @@ int main(int argc, char const** argv) {
 
   bool satisfied;
   if (props.major < 10) {
+    // Pre-Blackwell 
+    satisfied =  (__CUDACC_VER_MAJOR__ > 12) || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 4);
+    satisfied &= (props.major > 8) || (props.major == 8 && props.minor == 9); 
   }
   else {
     satisfied = (__CUDACC_VER_MAJOR__ > 12) || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8);


### PR DESCRIPTION
## Description

Restore the pre-Blackwell device and CUDA Toolkit validation in example 58.

## Problem

Starting with CUTLASS v4.0.0, the `props.major < 10` branch in `examples/58_ada_fp8_gemm/ada_fp8_gemm.cu` is empty:

```cpp
bool satisfied;
if (props.major < 10) {
}
else {
  satisfied = (__CUDACC_VER_MAJOR__ > 12) ||
              (__CUDACC_VER_MAJOR__ == 12 &&
               __CUDACC_VER_MINOR__ >= 8);
}
```

As a result, satisfied may be read without being initialized when running on a pre-Blackwell GPU. This is undefined behavior.
A supported GPU with compute capability 8.9 or greater and CUDA Toolkit 12.4 or later may therefore incorrectly enter the unsupported-device path and print:
`CUTLASS's FP8 SM89 example requires an NVIDIA GPU with compute capability 8.9 or greater and CUDA toolkit version 12.4 or later`
The example then exits without running the GEMM.

## Changes
Restore the pre-v4.0.0 validation logic for pre-Blackwell devices.  
- Initialize satisfied for pre-Blackwell devices.
- Require CUDA Toolkit 12.4 or later for the pre-Blackwell path.
- Require compute capability 8.9 or greater for the pre-Blackwell path.
- Preserve the existing CUDA Toolkit 12.8 requirement for Blackwell and newer devices.

## Testing

Built the example for SM89 with CUDA Toolkit 12.4 and ran it with reference checking enabled:

```bash
./build-sm89/examples/58_ada_fp8_gemm/58_ada_fp8_gemm \
  --reference-check=1
```

The results are as follows:
```
Running GEMM with staged accumulation (OpMultiplyAdd)
=====================================================
Problem size: 1024x1024x1024
Runtime (ms): 0.0116736
GFLOPs/sec:   183961
Passed

Running GEMM with fast accumulation (OpMultiplyAddFastAccum)
============================================================
Problem size: 1024x1024x1024
Runtime (ms): 0.0110432
GFLOPs/sec:   194462
Passed
```