### PR TITLE
Remove stale SM100 grouped scheduler helper

### DIFF
--- a/include/cutlass/gemm/kernel/sm100_tile_scheduler_group.hpp
+++ b/include/cutlass/gemm/kernel/sm100_tile_scheduler_group.hpp
@@ -319,14 +319,6 @@ public:
 
 private:
   //
-  // Methods
-  //
-  [[nodiscard]] CUTLASS_DEVICE
-  static auto
-  load_query_response(uint32_t smem_ptr) {
-    return UnderlyingScheduler::load_query_response(smem_ptr);
-  }
-  //
   // Storage
   //
   Params scheduler_params;


### PR DESCRIPTION
CUDA lowers `PersistentTileSchedulerSm100Group::load_query_response` to `void`, so its `[[nodiscard]]` attribute fails builds using `-Werror=attributes`. The helper is unused and forwards to a nonexistent underlying method, so remove it.

Tested with CUDA 13 explicit instantiation and the SM100a grouped GEMM example.