### PR TITLE
[CuTeDSL] Add prepared-launch API for low-overhead kernel replay

### DIFF
--- a/examples/python/CuTeDSL/dsl_tutorials/prepared_launch.py
+++ b/examples/python/CuTeDSL/dsl_tutorials/prepared_launch.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+An example demonstrating prepared launches for low-overhead kernel replay.
+
+Calling a compiled CuTe DSL function re-marshals every argument on every
+call: argument objects are rebuilt, scalars are cast into fresh ctypes
+storage, and the packed argument array is regenerated. For a small kernel
+launched in a tight loop — the steady state of most training and inference
+wrappers — that host-side Python work dominates the launch cost.
+
+``compiled.prepare(*args)`` performs the marshalling exactly once and
+returns a ``PreparedLaunch`` whose ``launch(*args)`` only rewrites pointer
+addresses, scalar values, and the stream handle in place before invoking the
+compiled entry point directly. Launches are bitwise-identical to
+``compiled(*args)``; only the per-call host overhead changes.
+
+Prepared launches accept runtime pointers (``make_ptr``), numeric scalars,
+and CUDA streams — exactly the by-passing-dlpack argument style shown in
+``call_bypass_dlpack.py``. Raw integers are accepted wherever a pointer or
+stream is expected, so the hot loop below needs no per-call object
+construction at all. Argument mixes that need per-call marshalling (e.g.
+dlpack tensors) raise ``PreparedLaunchError`` at prepare time and keep using
+the normal call path.
+
+To run this example:
+
+.. code-block:: bash
+
+    python examples/python/CuTeDSL/dsl_tutorials/prepared_launch.py
+"""
+
+import time
+
+import cuda.bindings.driver as cuda
+import torch
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_ptr
+
+
+@cute.kernel
+def scale_kernel(
+    gOut: cute.Tensor, gIn: cute.Tensor, alpha: cutlass.Float32, n: cutlass.Int32
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    bdim, _, _ = cute.arch.block_dim()
+    i = bidx * bdim + tidx
+    if i < n:
+        gOut[i] = gIn[i] * alpha
+
+
+@cute.jit
+def scale(
+    out_ptr: cute.Pointer,
+    in_ptr: cute.Pointer,
+    alpha: cutlass.Float32,
+    n: cutlass.Int32,
+    stream: cuda.CUstream,
+):
+    layout = cute.make_layout(n)
+    gOut = cute.make_tensor(out_ptr, layout)
+    gIn = cute.make_tensor(in_ptr, layout)
+    scale_kernel(gOut, gIn, alpha, n).launch(
+        grid=((n + 255) // 256, 1, 1), block=(256, 1, 1), stream=stream
+    )
+
+
+def f32_ptr(tensor: torch.Tensor) -> cute.Pointer:
+    return make_ptr(
+        cutlass.Float32, tensor.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+    )
+
+
+def run_prepared_launch(n: int = 4096, iterations: int = 2000):
+    x = torch.randn(n, device="cuda", dtype=torch.float32)
+    y = torch.empty_like(x)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Compile once, then bind the launch arguments once.
+    compiled = cute.compile(scale, f32_ptr(y), f32_ptr(x), 2.0, n, stream)
+    prepared = compiled.prepare(f32_ptr(y), f32_ptr(x), 2.0, n, stream)
+
+    # Steady state: raw addresses and values only, no per-call objects.
+    out_addr, in_addr, handle = y.data_ptr(), x.data_ptr(), int(stream)
+    prepared.launch(out_addr, in_addr, 2.0, n, handle)
+    torch.cuda.synchronize()
+    assert torch.equal(y, x * 2.0)
+
+    # Arguments may change between launches: new buffers, new scalar values.
+    x2 = torch.randn(2 * n, device="cuda", dtype=torch.float32)
+    y2 = torch.empty_like(x2)
+    prepared.launch(y2.data_ptr(), x2.data_ptr(), -0.5, 2 * n, handle)
+    torch.cuda.synchronize()
+    assert torch.equal(y2, x2 * -0.5)
+
+    # Compare steady-state host launch cost against the normal call path.
+    def per_call_us(fn) -> float:
+        for _ in range(100):
+            fn()
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(iterations):
+            fn()
+        elapsed = time.perf_counter() - start
+        torch.cuda.synchronize()
+        return elapsed / iterations * 1e6
+
+    direct_us = per_call_us(lambda: compiled(f32_ptr(y), f32_ptr(x), 2.0, n, stream))
+    prepared_us = per_call_us(
+        lambda: prepared.launch(out_addr, in_addr, 2.0, n, handle)
+    )
+    print(f"direct call:     {direct_us:6.2f} us/launch (host)")
+    print(f"prepared launch: {prepared_us:6.2f} us/launch (host)")
+
+
+if __name__ == "__main__":
+    run_prepared_launch()

--- a/python/CuTeDSL/cutlass/__init__.py
+++ b/python/CuTeDSL/cutlass/__init__.py
@@ -77,6 +77,8 @@ from .cutlass_dsl import (
     DSLRuntimeError,
     DSLUserCodeError,
     JitArgAdapterRegistry,
+    PreparedLaunch,
+    PreparedLaunchError,
     # Construction utilities for user-defined classes
     extract_mlir_values,
     new_from_mlir_values,

--- a/python/CuTeDSL/cutlass/base_dsl/diagnostics.py
+++ b/python/CuTeDSL/cutlass/base_dsl/diagnostics.py
@@ -1934,6 +1934,48 @@ class DiagId(_DiagMixin, enum.Enum):
             "Wrap the launch in a host function decorated with @cute.jit and call that host function.",
         ),
     )
+    LAUNCH_PREPARED_ARG_COUNT = (
+        "This prepared launch takes {expected} runtime arguments, but {provided} were provided.",
+        (
+            "Pass every runtime argument on each launch, in the order used at prepare().",
+        ),
+    )
+    LAUNCH_PREPARED_BAD_VALUE = (
+        "Prepared-launch argument `{arg_name}` cannot be updated from a {value_type} value.",
+        (
+            "Pass the same kind of value the argument was prepared with: a pointer "
+            "(or raw integer address), a numeric scalar, or a CUDA stream.",
+        ),
+    )
+    LAUNCH_PREPARED_MODULE_UNLOADED = (
+        "This prepared launch refers to a compiled module that has been unloaded.",
+        ("Prepare the launch again from a live compiled function.",),
+    )
+    LAUNCH_PREPARE_EXTRA_ARGS = (
+        "prepare() takes at most {expected} runtime arguments matching the function signature, but {provided} were provided.",
+        (
+            "Pass only the arguments declared by the function signature; extra "
+            "trailing arguments are not supported by prepared launches.",
+        ),
+    )
+    LAUNCH_PREPARE_UNSUPPORTED_ARG = (
+        "Argument `{arg_name}` of type {arg_type} cannot be re-bound in place by a prepared launch.",
+        (
+            "Eligible arguments are cute runtime pointers (`make_ptr`), "
+            "Boolean/Int8-Int64/Uint8-Uint64/Float32/Float64/TFloat32 scalars "
+            "(or plain Python bool/int/float), and CUDA streams.",
+            "Call the compiled function directly for argument types that need "
+            "per-call marshalling (e.g. dlpack tensors).",
+        ),
+    )
+    LAUNCH_PREPARE_UNSUPPORTED_EXECUTOR = (
+        "Prepared launches are not supported for `{function_kind}` compiled functions.",
+        (
+            "TVM-FFI compiled functions dispatch through their own direct "
+            "entry point; call the compiled function directly instead of "
+            "preparing it.",
+        ),
+    )
     # --- PHASE ---
     PHASE_CONDITIONAL_NOT_DYNAMIC = (
         "The condition must be a {staged} value, not a {meta}.",

--- a/python/CuTeDSL/cutlass/base_dsl/jit_executor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/jit_executor.py
@@ -353,6 +353,262 @@ def _convert_python_pointer_arg(
     return arg, False
 
 
+class PreparedLaunchError(DSLUserCodeError):
+    """Raised when a compiled function cannot be prepared for in-place launch.
+
+    :meth:`JitCompiledFunction.prepare` validates every runtime argument up
+    front; an argument mix it cannot re-bind in place raises this error at
+    prepare time instead of failing (or silently mis-launching) later.
+    ``compiled(*args)`` remains available for any argument mix.
+    """
+
+
+# Numeric scalar types a prepared launch can update in place, mapped to the
+# ctypes storage their ``__c_pointers__`` marshalling produces (see
+# ``NumericMeta`` and the ``Float32``/``Float64`` implementations in
+# ``typing``). Types whose marshalling is not a plain ctypes scalar store
+# (Float16/BFloat16 bit conversions, Int4/Int128) are intentionally absent
+# and rejected at prepare time.
+_PREPARED_NUMERIC_CTYPES: dict[Any, Any] = {
+    t.Boolean: ctypes.c_bool,
+    t.Int8: ctypes.c_int8,
+    t.Int16: ctypes.c_int16,
+    t.Int32: ctypes.c_int32,
+    t.Int64: ctypes.c_int64,
+    t.Uint8: ctypes.c_uint8,
+    t.Uint16: ctypes.c_uint16,
+    t.Uint32: ctypes.c_uint32,
+    t.Uint64: ctypes.c_uint64,
+    t.Float32: ctypes.c_float,
+    t.Float64: ctypes.c_double,
+    t.TFloat32: ctypes.c_float,
+}
+
+# Plain Python scalars marshal through the registered JIT argument adapter
+# (``_convert_python_scalar``), which fixes their DSL type as follows.
+_PREPARED_PYTHON_SCALAR_TYPES: dict[type, Any] = {
+    bool: t.Boolean,
+    int: t.Int32,
+    float: t.Float32,
+}
+
+
+class _PreparedArgSlot:
+    """Stable storage backing one packed argument slot of a prepared launch.
+
+    ``prepare()`` snapshots the bytes the normal marshalling produced into
+    ``storage`` once; later launches only rewrite ``storage`` in place via
+    :meth:`write`, so the packed argument array never has to be rebuilt.
+    """
+
+    def __init__(self, name: str, ctype: Any) -> None:
+        self.name = name
+        self.storage = ctype()
+
+    @property
+    def address(self) -> int:
+        return ctypes.addressof(self.storage)
+
+    def snapshot(self, exe_arg: Any) -> None:
+        """Copy the marshalled bytes referenced by ``exe_arg`` into this slot."""
+        source = exe_arg.value if type(exe_arg) is ctypes.c_void_p else exe_arg
+        ctypes.memmove(self.address, source, ctypes.sizeof(self.storage))
+
+    def write(self, value: Any) -> None:
+        """Rewrite the slot from ``value``; raises TypeError on a bad value."""
+        raise NotImplementedError
+
+
+class _PreparedPointerSlot(_PreparedArgSlot):
+    """Pointer-sized slot for runtime pointers and pointer-address arguments."""
+
+    def __init__(self, name: str, desc_owner: Any = None) -> None:
+        super().__init__(name, ctypes.c_void_p)
+        # Runtime pointer objects marshal the address of their c_void_p
+        # ``_desc`` cell; remember the prepare-time argument so snapshot()
+        # can verify the marshalling actually followed that contract.
+        self._desc_owner = desc_owner
+
+    def snapshot(self, exe_arg: Any) -> None:
+        owner = self._desc_owner
+        if owner is not None:
+            self._desc_owner = None  # never outlive prepare()
+            source = exe_arg.value if type(exe_arg) is ctypes.c_void_p else exe_arg
+            if source != ctypes.addressof(owner._desc):
+                # An object that looks like a runtime pointer (c_void_p
+                # ``_desc`` plus ``__c_pointers__``) but marshals something
+                # other than its ``_desc`` cannot be re-bound in place.
+                raise PreparedLaunchError(
+                    DiagId.LAUNCH_PREPARE_UNSUPPORTED_ARG,
+                    arg_name=self.name,
+                    arg_type=type(owner).__name__,
+                )
+            self.storage.value = owner._desc.value
+            return
+        super().snapshot(exe_arg)
+
+    def write(self, value: Any) -> None:
+        if type(value) is int:
+            self.storage.value = value
+            return
+        # Runtime pointer storage contract: cute runtime Pointer objects and
+        # _RuntimePointerArg both keep their address in a c_void_p ``_desc``.
+        desc = getattr(value, "_desc", None)
+        if type(desc) is ctypes.c_void_p:
+            self.storage.value = desc.value
+            return
+        address = _python_pointer_address(value)
+        if address is None:
+            raise TypeError(f"expected a pointer-like value, got {type(value)!r}")
+        self.storage.value = address
+
+
+class _PreparedScalarSlot(_PreparedArgSlot):
+    """Fixed-width numeric slot; accepts Python scalars and Numeric instances.
+
+    Values are stored through plain ctypes assignment: the same bytes the
+    normal marshalling would produce for values of the prepared kind, with
+    ctypes conversion semantics (out-of-range integers truncate; a value the
+    storage rejects, such as a float for an integer slot, raises instead of
+    applying the DSL cast a direct call would).
+    """
+
+    def write(self, value: Any) -> None:
+        self.storage.value = value.value if isinstance(value, t.Numeric) else value
+
+
+class _PreparedBooleanSlot(_PreparedArgSlot):
+    """Boolean slot; accepts bool/int values only (no truthiness coercion)."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name, ctypes.c_bool)
+
+    def write(self, value: Any) -> None:
+        if isinstance(value, t.Numeric):
+            value = value.value
+        if type(value) is not bool and type(value) is not int:
+            raise TypeError(f"expected a bool, got {type(value)!r}")
+        self.storage.value = value
+
+
+def _make_scalar_slot(name: str, ctype: Any) -> _PreparedArgSlot:
+    if ctype is ctypes.c_bool:
+        return _PreparedBooleanSlot(name)
+    return _PreparedScalarSlot(name, ctype)
+
+
+class _PreparedStreamSlot(_PreparedArgSlot):
+    """Pointer-sized slot holding a raw CUDA stream handle."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name, ctypes.c_void_p)
+
+    def write(self, value: Any) -> None:
+        if type(value) is int:
+            self.storage.value = value
+            return
+        if isinstance(
+            value, (cuda_helpers.cuda.CUstream, cuda_helpers.cudart.cudaStream_t)
+        ):
+            self.storage.value = int(value)
+            return
+        # Framework stream objects (e.g. torch.cuda.Stream) expose the raw
+        # driver handle as an integer ``cuda_stream`` attribute.
+        try:
+            handle = value.cuda_stream
+        except AttributeError:
+            handle = None
+        except Exception as e:
+            raise TypeError(f"reading cuda_stream from {type(value)!r} failed") from e
+        if type(handle) is int:
+            self.storage.value = handle
+            return
+        raise TypeError(
+            "expected a CUDA stream, a framework stream with an integer "
+            f"cuda_stream attribute, or a raw integer handle, got {type(value)!r}"
+        )
+
+
+def _is_stream_annotation(annotation: Any) -> bool:
+    return getattr(annotation, "__name__", None) in ("CUstream", "cudaStream_t")
+
+
+def _is_stream_instance(arg: Any) -> bool:
+    return isinstance(
+        arg, (cuda_helpers.cuda.CUstream, cuda_helpers.cudart.cudaStream_t)
+    )
+
+
+def _prepared_slot_for_arg(
+    name: str,
+    arg: Any,
+    annotation: Any,
+    is_numeric: bool,
+    spec: PointerAddressArgSpec,
+) -> _PreparedArgSlot:
+    """Classify one runtime argument into an in-place-updatable slot.
+
+    Mirrors the marshalling decisions of ``generate_execution_args`` for the
+    closed set of argument kinds whose storage a prepared launch can rewrite:
+    pointer-address slots, numeric scalars with plain ctypes storage, CUDA
+    streams, and runtime pointer objects. Classification is driven by the
+    declared annotation where it is informative (numeric, pointer, stream),
+    so a value of the wrong kind for a declared slot is rejected here rather
+    than mis-marshalled; unannotated slots classify by value. Anything else —
+    dlpack tensors, structs, sequences, custom JIT arguments — raises
+    :class:`PreparedLaunchError`.
+    """
+    if spec is True and _python_pointer_address(arg) is not None:
+        return _PreparedPointerSlot(name)
+    if is_numeric:
+        ctype = _PREPARED_NUMERIC_CTYPES.get(annotation)
+        if ctype is not None:
+            return _make_scalar_slot(name, ctype)
+        raise PreparedLaunchError(
+            DiagId.LAUNCH_PREPARE_UNSUPPORTED_ARG,
+            arg_name=name,
+            arg_type=getattr(annotation, "__name__", str(annotation)),
+        )
+    if _is_pointer_annotation(annotation):
+        # A declared pointer slot must be prepared with a runtime pointer
+        # (storage contract: address held in a c_void_p ``_desc``).
+        desc = getattr(arg, "_desc", None)
+        if type(desc) is ctypes.c_void_p and hasattr(arg, "__c_pointers__"):
+            return _PreparedPointerSlot(name, desc_owner=arg)
+        raise PreparedLaunchError(
+            DiagId.LAUNCH_PREPARE_UNSUPPORTED_ARG,
+            arg_name=name,
+            arg_type=type(arg).__name__,
+        )
+    if _is_stream_annotation(annotation):
+        # A declared stream slot must be prepared with a real CUDA stream
+        # object (raw integer handles are accepted at launch time only).
+        if _is_stream_instance(arg):
+            return _PreparedStreamSlot(name)
+        raise PreparedLaunchError(
+            DiagId.LAUNCH_PREPARE_UNSUPPORTED_ARG,
+            arg_name=name,
+            arg_type=type(arg).__name__,
+        )
+    if isinstance(arg, t.Numeric):
+        ctype = _PREPARED_NUMERIC_CTYPES.get(type(arg))
+        if ctype is not None:
+            return _make_scalar_slot(name, ctype)
+    dsl_scalar_type = _PREPARED_PYTHON_SCALAR_TYPES.get(type(arg))
+    if dsl_scalar_type is not None:
+        return _make_scalar_slot(name, _PREPARED_NUMERIC_CTYPES[dsl_scalar_type])
+    if _is_stream_instance(arg):
+        return _PreparedStreamSlot(name)
+    desc = getattr(arg, "_desc", None)
+    if type(desc) is ctypes.c_void_p and hasattr(arg, "__c_pointers__"):
+        return _PreparedPointerSlot(name, desc_owner=arg)
+    raise PreparedLaunchError(
+        DiagId.LAUNCH_PREPARE_UNSUPPORTED_ARG,
+        arg_name=name,
+        arg_type=type(arg).__name__,
+    )
+
+
 class ExecutionArgs:
     """Runtime argument binder for compiled JIT functions.
 
@@ -679,6 +935,63 @@ class ExecutionArgs:
                     exe_args.extend(pointer_arg.__c_pointers__())
 
         return exe_args, adapted_args
+
+    def generate_prepared_slots(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> list[_PreparedArgSlot]:
+        """Validate and marshal arguments once for a prepared launch.
+
+        Classifies every runtime argument into a stable, in-place-updatable
+        slot (pointer / numeric scalar / CUDA stream), then runs the normal
+        ``generate_execution_args`` marshalling once and snapshots the
+        resulting bytes into private per-argument storage. Later launches only
+        rewrite those bytes, so the initial slot contents — and therefore the
+        launch itself — are bit-identical to a direct call with the same
+        argument values.
+
+        :raises PreparedLaunchError: If any argument cannot be re-bound in
+            place (dlpack tensors, structs, sequences, custom JIT arguments,
+            numeric types without plain ctypes storage such as Float16), or if
+            extra arguments beyond the runtime signature are passed.
+        """
+        meta = self._meta
+        n = meta.arg_count
+        if len(args) > n:
+            raise PreparedLaunchError(
+                DiagId.LAUNCH_PREPARE_EXTRA_ARGS,
+                expected=n,
+                provided=len(args),
+            )
+
+        input_args: Sequence[Any]
+        if not kwargs and len(args) == n:
+            input_args = args
+        else:
+            input_args = self.get_rectified_args(args, kwargs)
+
+        slots = [
+            _prepared_slot_for_arg(
+                meta.all_names[index],
+                arg,
+                meta.annotated_types[index],
+                meta.numeric_flags[index],
+                self._pointer_address_arg_specs[index],
+            )
+            for index, arg in enumerate(input_args)
+        ]
+
+        # Every eligible argument kind marshals to exactly one execution
+        # argument, so the flat list maps 1:1 onto the slots.
+        exe_args, _adapted_args = self.generate_execution_args(tuple(input_args), {})
+        if len(exe_args) != len(slots):
+            raise DSLRuntimeError(
+                "prepared-launch classification disagrees with "
+                f"generate_execution_args ({len(slots)} slots for "
+                f"{len(exe_args)} execution arguments)"
+            )
+        for slot, exe_arg in zip(slots, exe_args):
+            slot.snapshot(exe_arg)
+        return slots
 
     def _arg_marshals_to_pointers(self, arg: Any, spec: PointerAddressArgSpec) -> bool:
         """Whether ``arg`` will contribute at least one C pointer at launch.
@@ -1089,6 +1402,147 @@ class JitExecutor:
         exe_args, adapted_args = self.generate_execution_args(*args, **kwargs)
         return self.run_compiled_program(exe_args)
 
+    def prepare(self, *args: Any, **kwargs: Any) -> "PreparedLaunch":
+        """Bind arguments once and return a replayable :class:`PreparedLaunch`.
+
+        Mirrors the :meth:`JitCompiledFunction.to` / ``__call__`` split: the
+        prepared launch is tied to this executor's device context. See
+        :meth:`JitCompiledFunction.prepare` for the full contract.
+        """
+        slots = self.jit_module.execution_args.generate_prepared_slots(args, kwargs)
+        return PreparedLaunch(self, slots)
+
+
+class PreparedLaunch:
+    """A compiled function with its launch arguments bound to stable storage.
+
+    Created by :meth:`JitCompiledFunction.prepare` (or
+    :meth:`JitExecutor.prepare` for a device-bound executor). ``prepare()``
+    runs the normal argument marshalling once and snapshots the marshalled
+    bytes into private per-argument storage referenced by a private packed
+    argument array; :meth:`launch` then only rewrites those bytes in place and
+    invokes the compiled entry point directly. No Python objects are allocated
+    per launch and no packing is repeated, which removes nearly all of the
+    per-call host overhead of ``compiled(*args)``.
+
+    A launch is bitwise-identical to calling the compiled function with the
+    same argument values of the prepared kinds: the compiled entry point reads
+    the same packed bytes either way. (A direct call additionally applies DSL
+    numeric casts to scalar values of a mismatched kind; a prepared launch
+    rejects such values with :class:`PreparedLaunchError` instead of silently
+    converting.)
+
+    **Lifecycle.** The instance keeps its executor — and therefore the JIT
+    engine, loaded CUDA modules, and device context — alive. Launching after
+    the owning module has been explicitly unloaded raises
+    :class:`PreparedLaunchError`.
+
+    **Threads.** Instances are not thread-safe: two threads launching through
+    one instance would interleave writes to the same argument storage. Create
+    one prepared launch per thread; instances never share mutable argument or
+    result storage (each owns its slots, packed array, and CUDA result slot),
+    so different instances of the same compiled function may launch
+    concurrently. The compiled module and entry point are shared and
+    read-only in normal operation; ``jit_module.unload()`` affects every
+    instance of that module.
+
+    **CUDA graphs.** :meth:`launch` issues the same driver launch as the
+    normal call path, so it can be captured into a CUDA graph via a capturing
+    stream. Standard capture semantics apply: the driver copies the argument
+    bytes at capture time, so later ``launch`` argument updates do not change
+    what a captured graph replays. A launch that is illegal during capture
+    (e.g. onto the legacy default stream) raises the same CUDA error the
+    normal call path would.
+    """
+
+    def __init__(self, executor: JitExecutor, slots: list[_PreparedArgSlot]) -> None:
+        packed_args = (ctypes.c_void_p * (len(slots) + executor._num_extra_args))()
+        for index, slot in enumerate(slots):
+            packed_args[index] = slot.address
+
+        # Private CUDA result storage: launches from this instance never race
+        # the executor's shared result slot (or another instance's).
+        index = len(slots)
+        cuda_result = (
+            type(executor.cuda_result)() if executor._has_cuda_result else None
+        )
+        if cuda_result is not None:
+            packed_args[index] = ctypes.addressof(cuda_result)
+            index += 1
+        if executor._kernel_ptrs is not None:
+            for ptr in executor._kernel_ptrs:
+                packed_args[index] = ptr
+                index += 1
+
+        self._executor = executor
+        self._jit_module = executor.jit_module
+        self._slots = slots
+        self._writers = [slot.write for slot in slots]
+        self._packed_args = packed_args
+        self._cuda_result = cuda_result
+        self._capi_func = executor.capi_func
+
+    def launch(self, *args: Any, **kwargs: Any) -> int | None:
+        """Rewrite the bound argument storage in place and launch.
+
+        Takes the same runtime arguments as calling the compiled function
+        (keyword arguments and omitted defaulted parameters rectify through
+        the signature; full positional calls are the fast path). Pointer
+        arguments accept a runtime pointer object or a raw integer address;
+        numeric arguments accept a Python scalar or a ``Numeric`` instance;
+        stream arguments accept a CUDA stream object, a framework stream
+        exposing an integer ``cuda_stream`` attribute (e.g.
+        ``torch.cuda.Stream``), or a raw integer handle. Scalar values are
+        written through the prepared ctypes storage with plain ctypes
+        assignment semantics: out-of-range integers truncate to the declared
+        width (the same trust-the-caller posture as the normal launch path),
+        and a value the storage rejects — e.g. a float for an integer slot —
+        raises :class:`PreparedLaunchError` instead of applying the implicit
+        DSL cast a direct call would perform.
+
+        :return: The CUDA result code (0) when the compiled function reports
+            one, otherwise None — the same contract as calling the compiled
+            function.
+        :raises PreparedLaunchError: If the argument count does not match the
+            prepared signature, a value's type cannot update its slot, or the
+            compiled module has been unloaded.
+        :raises DSLCudaRuntimeError: If the launch reports a CUDA error.
+        """
+        writers = self._writers
+        if kwargs or len(args) != len(writers):
+            # Same binding contract as a direct call: keyword arguments and
+            # omitted defaulted parameters rectify through the signature,
+            # raising the shared too-many/missing-argument diagnostics.
+            args = tuple(
+                self._jit_module.execution_args.get_rectified_args(args, kwargs)
+            )
+            if len(args) != len(writers):
+                raise PreparedLaunchError(
+                    DiagId.LAUNCH_PREPARED_ARG_COUNT,
+                    expected=len(writers),
+                    provided=len(args),
+                )
+        if self._jit_module._unloaded:
+            raise PreparedLaunchError(DiagId.LAUNCH_PREPARED_MODULE_UNLOADED)
+        index = 0
+        try:
+            for index, value in enumerate(args):
+                writers[index](value)
+        except (TypeError, ValueError) as e:
+            raise PreparedLaunchError(
+                DiagId.LAUNCH_PREPARED_BAD_VALUE,
+                arg_name=self._slots[index].name,
+                value_type=type(args[index]).__name__,
+                cause=e,
+            )
+        self._capi_func(self._packed_args)
+        if self._cuda_result is None:
+            return None
+        error_code = self._cuda_result.value
+        if error_code == 0:
+            return error_code
+        raise cuda_helpers.create_cuda_runtime_error(error_code)
+
 
 @dataclass
 class JitFunctionArtifacts:
@@ -1400,13 +1854,60 @@ class JitCompiledFunction:
             return executor.run_compiled_program(exe_args)
         return self.run_compiled_program(exe_args)
 
-    def run_compiled_program(self, exe_args: list[Any]) -> int | None:
-        """Executes the jit-compiled function under the currently active CUDA context.
+    def prepare(self, *args: Any, **kwargs: Any) -> "PreparedLaunch":
+        """Bind arguments once and return a replayable :class:`PreparedLaunch`.
 
-        Calling this method multiple devices is not allowed and will result in unexpected
-        CUDA errors. If you need to call the kernel on multiple devices use `to`
-        to return a per-device function.
+        Calling a compiled function re-marshals every argument: argument
+        objects are rebuilt, scalars are cast into fresh ctypes storage, and
+        the packed argument array is regenerated, even when only pointer
+        addresses and scalar values change between calls. For launch-bound
+        callers this method performs that work exactly once:
+        ``prepare(*args)`` validates and marshals the arguments like a normal
+        call, then snapshots the marshalled bytes into storage owned by the
+        returned :class:`PreparedLaunch`, whose :meth:`PreparedLaunch.launch`
+        rewrites the bytes in place and invokes the compiled entry point
+        directly.
+
+        .. code-block:: python
+
+            compiled = cute.compile(fn, out_ptr, in_ptr, alpha, n, stream)
+            prepared = compiled.prepare(out_ptr, in_ptr, alpha, n, stream)
+            for step in range(steps):
+                ...
+                prepared.launch(out_ptr, in_ptr, alpha, n, stream)
+
+        Eligibility is validated here, not at launch: every runtime argument
+        must be a runtime pointer (``make_ptr``/pointer-address slot), a
+        numeric scalar with plain ctypes storage (Boolean, Int8-Int64,
+        Uint8-Uint64, Float32, Float64, TFloat32, or a plain Python
+        bool/int/float), or a CUDA stream. Anything else — dlpack tensors,
+        structs, sequences, custom JIT arguments — raises
+        :class:`PreparedLaunchError`, and ``compiled(*args)`` remains the
+        general path.
+
+        Like ``__call__``, the prepared launch is bound to the default
+        executor's device context; use ``to(device).prepare(...)`` for
+        per-device prepared launches. See :class:`PreparedLaunch` for the
+        lifecycle, threading, and CUDA-graph-capture contract.
+
+        :param args: Runtime arguments, as passed to a normal call.
+        :param kwargs: Runtime keyword arguments, as passed to a normal call.
+        :return: A prepared launch bound to this function and device context.
+        :rtype: PreparedLaunch
+        :raises PreparedLaunchError: If any runtime argument is not eligible
+            for in-place re-binding.
         """
+        executor = self._ensure_default_executor()
+        if not isinstance(executor, JitExecutor):
+            # e.g. TVM-FFI compiled functions: their to() returns the compiled
+            # function itself, which dispatches through its own entry point.
+            raise PreparedLaunchError(
+                DiagId.LAUNCH_PREPARE_UNSUPPORTED_EXECUTOR,
+                function_kind=type(self).__name__,
+            )
+        return executor.prepare(*args, **kwargs)
+
+    def _ensure_default_executor(self) -> JitExecutor:
         with self._executor_lock:
             if self._default_executor is None:
                 log().debug("Creating default executor.")
@@ -1415,7 +1916,16 @@ class JitCompiledFunction:
                 proxy_self = weakref.proxy(self)
                 self._default_executor = proxy_self.to(None)
         assert self._default_executor is not None
-        return self._default_executor.run_compiled_program(exe_args)
+        return self._default_executor
+
+    def run_compiled_program(self, exe_args: list[Any]) -> int | None:
+        """Executes the jit-compiled function under the currently active CUDA context.
+
+        Calling this method multiple devices is not allowed and will result in unexpected
+        CUDA errors. If you need to call the kernel on multiple devices use `to`
+        to return a per-device function.
+        """
+        return self._ensure_default_executor().run_compiled_program(exe_args)
 
     def _generate_c_header_arguments(
         self,

--- a/python/CuTeDSL/cutlass/cutlass_dsl/cutlass.py
+++ b/python/CuTeDSL/cutlass/cutlass_dsl/cutlass.py
@@ -92,7 +92,12 @@ from ..base_dsl.utils.tree_utils import (
 )
 from ..base_dsl.leaf_utils import is_frozen_dataclass
 from ..base_dsl.runtime.jit_arg_adapters import is_arg_annotation_constexpr
-from ..base_dsl.jit_executor import ExecutionArgs, _is_pointer_annotation  # noqa: F401
+from ..base_dsl.jit_executor import (
+    ExecutionArgs,  # noqa: F401
+    PreparedLaunch,  # noqa: F401
+    PreparedLaunchError,  # noqa: F401
+    _is_pointer_annotation,
+)
 from ..base_dsl.runtime import cuda as cuda_helpers
 from .cuda_stream_adapter import CudaDriverStreamAdapter, CudaRuntimeStreamAdapter  # noqa: F401
 from .cuda_library_adapter import CudaDialectLibraryAdapter  # noqa: F401

--- a/test/python/CuTeDSL/test_prepared_launch.py
+++ b/test/python/CuTeDSL/test_prepared_launch.py
@@ -1,0 +1,791 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for the prepared-launch API
+(`JitCompiledFunction.prepare` / `PreparedLaunch.launch`).
+
+A prepared launch binds a compiled function's runtime arguments to stable
+storage once and replays the launch with in-place updates only, so it must be
+observably identical to the normal call path. The tests here prove:
+
+* bitwise parity with the normal call path on a real device kernel;
+* argument mutation between launches (pointers, scalars of several widths,
+  stream) takes effect, including raw-integer fast-path values and framework
+  stream objects;
+* launches never re-enter ExecutionArgs marshalling and reuse the packed
+  argument array in place;
+* the handle owns stable argument storage (long read-modify-write accumulate
+  under GC/allocator churn);
+* prepare-time eligibility errors for argument kinds that cannot be re-bound
+  in place, and launch-time errors for arg-count/value-type/lifecycle misuse;
+* per-thread instances launch concurrently without sharing state, and a
+  single instance can be handed off between threads sequentially;
+* explicitly device-bound executors (``to(device).prepare``) work;
+* behavior under CUDA graph capture (captures cleanly; standard
+  frozen-at-capture argument semantics; no corruption of later launches);
+* a micro-benchmark of steady-state host launch cost, prepared vs direct.
+"""
+
+import ctypes
+import gc
+import threading
+import time
+import unittest
+
+import cuda.bindings.driver as cuda_driver
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import DSLUserCodeError, PreparedLaunchError
+from cutlass.cute.runtime import from_dlpack, make_ptr
+
+try:
+    import torch
+
+    _HAS_TORCH_CUDA = torch.cuda.is_available()
+except ImportError:
+    _HAS_TORCH_CUDA = False
+
+requires_gpu = unittest.skipUnless(
+    _HAS_TORCH_CUDA, "prepared-launch tests need torch with a CUDA device"
+)
+
+
+@cute.kernel
+def _scale_kernel(
+    gOut: cute.Tensor, gIn: cute.Tensor, alpha: cutlass.Float32, n: cutlass.Int32
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    bdim, _, _ = cute.arch.block_dim()
+    i = bidx * bdim + tidx
+    if i < n:
+        gOut[i] = gIn[i] * alpha
+
+
+@cute.jit
+def _scale(
+    out_ptr: cute.Pointer,
+    in_ptr: cute.Pointer,
+    alpha: cutlass.Float32,
+    n: cutlass.Int32,
+    stream: cuda_driver.CUstream,
+):
+    layout = cute.make_layout(n)
+    gOut = cute.make_tensor(out_ptr, layout)
+    gIn = cute.make_tensor(in_ptr, layout)
+    _scale_kernel(gOut, gIn, alpha, n).launch(
+        grid=((n + 255) // 256, 1, 1), block=(256, 1, 1), stream=stream
+    )
+
+
+@cute.kernel
+def _mixed_scalars_kernel(
+    gOut: cute.Tensor,
+    gIn: cute.Tensor,
+    alpha: cutlass.Float64,
+    bias: cutlass.Int64,
+    flag: cutlass.Boolean,
+    n: cutlass.Int32,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    bdim, _, _ = cute.arch.block_dim()
+    i = bidx * bdim + tidx
+    if i < n:
+        scaled = gIn[i].to(cutlass.Float64) * alpha + bias.to(cutlass.Float64)
+        if flag:
+            gOut[i] = scaled.to(cutlass.Float32)
+        else:
+            gOut[i] = -scaled.to(cutlass.Float32)
+
+
+@cute.jit
+def _mixed_scalars(
+    out_ptr: cute.Pointer,
+    in_ptr: cute.Pointer,
+    alpha: cutlass.Float64,
+    bias: cutlass.Int64,
+    flag: cutlass.Boolean,
+    n: cutlass.Int32,
+    stream: cuda_driver.CUstream,
+):
+    layout = cute.make_layout(n)
+    gOut = cute.make_tensor(out_ptr, layout)
+    gIn = cute.make_tensor(in_ptr, layout)
+    _mixed_scalars_kernel(gOut, gIn, alpha, bias, flag, n).launch(
+        grid=((n + 255) // 256, 1, 1), block=(256, 1, 1), stream=stream
+    )
+
+
+@cute.kernel
+def _accumulate_kernel(gAcc: cute.Tensor, gIn: cute.Tensor, n: cutlass.Int32):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    bdim, _, _ = cute.arch.block_dim()
+    i = bidx * bdim + tidx
+    if i < n:
+        gAcc[i] = gAcc[i] + gIn[i]
+
+
+@cute.jit
+def _accumulate(
+    acc_ptr: cute.Pointer,
+    in_ptr: cute.Pointer,
+    n: cutlass.Int32,
+    stream: cuda_driver.CUstream,
+):
+    layout = cute.make_layout(n)
+    gAcc = cute.make_tensor(acc_ptr, layout)
+    gIn = cute.make_tensor(in_ptr, layout)
+    _accumulate_kernel(gAcc, gIn, n).launch(
+        grid=((n + 255) // 256, 1, 1), block=(256, 1, 1), stream=stream
+    )
+
+
+@cute.jit
+def _scale_default(
+    out_ptr: cute.Pointer,
+    in_ptr: cute.Pointer,
+    n: cutlass.Int32,
+    stream: cuda_driver.CUstream,
+    alpha: cutlass.Float32 = 2.5,
+):
+    layout = cute.make_layout(n)
+    gOut = cute.make_tensor(out_ptr, layout)
+    gIn = cute.make_tensor(in_ptr, layout)
+    _scale_kernel(gOut, gIn, alpha, n).launch(
+        grid=((n + 255) // 256, 1, 1), block=(256, 1, 1), stream=stream
+    )
+
+
+@cute.jit
+def _tensor_signature(gA: cute.Tensor, alpha: cutlass.Float32):
+    pass
+
+
+@cute.jit
+def _f16_scalar_signature(alpha: cutlass.Float16):
+    pass
+
+
+@cute.jit
+def _sequence_signature(xs: list):
+    pass
+
+
+def _f32_ptr(tensor):
+    return make_ptr(
+        cutlass.Float32,
+        tensor.data_ptr(),
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+
+
+def _current_stream():
+    return cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+class _CompiledCache:
+    """Compile each test function once per test session."""
+
+    _cache: dict = {}
+
+    @classmethod
+    def scale(cls):
+        if "scale" not in cls._cache:
+            x = torch.zeros(16, device="cuda", dtype=torch.float32)
+            cls._cache["scale"] = cute.compile(
+                _scale, _f32_ptr(x), _f32_ptr(x), 1.0, 16, _current_stream()
+            )
+        return cls._cache["scale"]
+
+    @classmethod
+    def mixed(cls):
+        if "mixed" not in cls._cache:
+            x = torch.zeros(16, device="cuda", dtype=torch.float32)
+            cls._cache["mixed"] = cute.compile(
+                _mixed_scalars,
+                _f32_ptr(x),
+                _f32_ptr(x),
+                1.0,
+                cutlass.Int64(0),
+                cutlass.Boolean(True),
+                16,
+                _current_stream(),
+            )
+        return cls._cache["mixed"]
+
+
+@requires_gpu
+class TestPreparedLaunchParity(unittest.TestCase):
+    def test_bitwise_parity_with_direct_call(self):
+        """The prepared path must produce bit-identical outputs to the
+        normal call path for the same kernel and inputs; prepare() must
+        also work before the compiled function was ever called directly."""
+        compiled = _CompiledCache.scale()
+        n = 4096
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y_direct = torch.full((n,), float("nan"), device="cuda")
+        y_prepared = torch.full((n,), float("nan"), device="cuda")
+        stream = _current_stream()
+
+        prepared = compiled.prepare(_f32_ptr(y_prepared), _f32_ptr(x), 1.7, n, stream)
+        result = prepared.launch(_f32_ptr(y_prepared), _f32_ptr(x), 1.7, n, stream)
+        compiled(_f32_ptr(y_direct), _f32_ptr(x), 1.7, n, stream)
+        torch.cuda.synchronize()
+
+        self.assertEqual(result, 0)
+        self.assertTrue(
+            torch.equal(y_direct.view(torch.int32), y_prepared.view(torch.int32)),
+            "prepared launch output differs bitwise from the direct call",
+        )
+
+    def test_argument_mutation_between_launches(self):
+        """New pointers, scalar values, and stream between launches must all
+        take effect; raw integer addresses/handles are accepted."""
+        compiled = _CompiledCache.scale()
+        stream = _current_stream()
+        n1, n2 = 4096, 2048
+        x1 = torch.randn(n1, device="cuda", dtype=torch.float32)
+        x2 = torch.randn(n2, device="cuda", dtype=torch.float32)
+        y1 = torch.empty_like(x1)
+        y2 = torch.empty_like(x2)
+
+        prepared = compiled.prepare(_f32_ptr(y1), _f32_ptr(x1), 2.0, n1, stream)
+        prepared.launch(_f32_ptr(y1), _f32_ptr(x1), 2.0, n1, stream)
+
+        # Everything changes: buffers, scalar values, and the value forms
+        # (raw addresses, raw stream handle, Numeric instances).
+        prepared.launch(
+            y2.data_ptr(),
+            x2.data_ptr(),
+            cutlass.Float32(-0.25),
+            cutlass.Int32(n2),
+            int(stream),
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(y1, x1 * 2.0))
+        self.assertTrue(torch.equal(y2, x2 * -0.25))
+
+        # Keyword arguments are rectified like a normal call.
+        prepared.launch(_f32_ptr(y2), _f32_ptr(x2), 3.0, n2, stream=stream)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y2, x2 * 3.0))
+
+    def test_scalar_widths_parity(self):
+        """Float64/Int64/Boolean scalar slots update correctly and match the
+        direct call bitwise, including flipping the Boolean between launches."""
+        compiled = _CompiledCache.mixed()
+        stream = _current_stream()
+        n = 1024
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y_direct = torch.empty_like(x)
+        y_prepared = torch.empty_like(x)
+
+        prepared = compiled.prepare(
+            _f32_ptr(y_prepared),
+            _f32_ptr(x),
+            1.0,
+            cutlass.Int64(0),
+            cutlass.Boolean(True),
+            n,
+            stream,
+        )
+        for alpha, bias, flag in [(0.5, 7, True), (-1.25, -3, False), (2.0, 0, True)]:
+            compiled(
+                _f32_ptr(y_direct),
+                _f32_ptr(x),
+                alpha,
+                cutlass.Int64(bias),
+                cutlass.Boolean(flag),
+                n,
+                stream,
+            )
+            prepared.launch(
+                _f32_ptr(y_prepared),
+                _f32_ptr(x),
+                alpha,
+                cutlass.Int64(bias),
+                cutlass.Boolean(flag),
+                n,
+                stream,
+            )
+            torch.cuda.synchronize()
+            self.assertTrue(
+                torch.equal(y_direct.view(torch.int32), y_prepared.view(torch.int32)),
+                f"bitwise mismatch for alpha={alpha}, bias={bias}, flag={flag}",
+            )
+
+    def test_framework_stream_at_launch(self):
+        """launch() accepts a framework stream object exposing an integer
+        ``cuda_stream`` attribute (e.g. torch.cuda.Stream) for a stream slot;
+        the launch must actually run on that stream."""
+        compiled = _CompiledCache.scale()
+        n = 1024
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.zeros_like(x)
+        prepared = compiled.prepare(_f32_ptr(y), _f32_ptr(x), 4.0, n, _current_stream())
+
+        side_stream = torch.cuda.Stream()
+        side_stream.wait_stream(torch.cuda.current_stream())
+        prepared.launch(_f32_ptr(y), _f32_ptr(x), 4.0, n, side_stream)
+        side_stream.synchronize()
+        self.assertTrue(torch.equal(y, x * 4.0))
+
+    def test_defaulted_argument_at_prepare_and_launch(self):
+        """Omitted defaulted parameters bind through the signature at both
+        prepare and launch, exactly like a direct call."""
+        n = 512
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.zeros_like(x)
+        stream = _current_stream()
+        compiled = cute.compile(
+            _scale_default, _f32_ptr(y), _f32_ptr(x), n, stream, 2.5
+        )
+
+        prepared = compiled.prepare(_f32_ptr(y), _f32_ptr(x), n, stream)
+        prepared.launch(_f32_ptr(y), _f32_ptr(x), n, stream)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y, x * 2.5))
+
+        prepared.launch(y.data_ptr(), x.data_ptr(), n, int(stream), -1.0)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y, x * -1.0))
+
+    def test_launch_does_not_regenerate_execution_args(self):
+        """The whole point of the fast path: positional launches must not
+        re-enter ExecutionArgs marshalling, and the packed argument array
+        must be reused in place rather than rebuilt."""
+        compiled = _CompiledCache.scale()
+        n = 256
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.empty_like(x)
+        stream = _current_stream()
+        prepared = compiled.prepare(_f32_ptr(y), _f32_ptr(x), 2.0, n, stream)
+        packed_address = ctypes.addressof(prepared._packed_args)
+
+        execution_args = compiled.jit_module.execution_args
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("prepared launch regenerated ExecutionArgs")
+
+        original = execution_args.generate_execution_args
+        execution_args.generate_execution_args = fail_if_called
+        try:
+            prepared.launch(_f32_ptr(y), _f32_ptr(x), 2.0, n, stream)
+            prepared.launch(y.data_ptr(), x.data_ptr(), 3.0, n, int(stream))
+        finally:
+            execution_args.generate_execution_args = original
+        torch.cuda.synchronize()
+
+        self.assertEqual(ctypes.addressof(prepared._packed_args), packed_address)
+        self.assertTrue(torch.equal(y, x * 3.0))
+
+    def test_repeated_launch_storage_stability(self):
+        """The handle must own stable argument storage: a long read-modify-
+        write accumulate over many launches, with GC pressure and allocator
+        churn in between, must not corrupt any argument slot. (The slow
+        path's scalar ctypes storage is ephemeral; a prepared launch that
+        merely snapshotted those addresses would dangle here.)"""
+        n = 1024
+        stream = _current_stream()
+        ones = torch.ones(n, device="cuda", dtype=torch.float32)
+        acc = torch.zeros(n, device="cuda", dtype=torch.float32)
+        compiled = cute.compile(_accumulate, _f32_ptr(acc), _f32_ptr(ones), n, stream)
+        prepared = compiled.prepare(_f32_ptr(acc), _f32_ptr(ones), n, stream)
+
+        iters = 1000
+        for i in range(iters):
+            prepared.launch(acc.data_ptr(), ones.data_ptr(), n, int(stream))
+            if i % 100 == 99:
+                gc.collect()
+                _churn = [ctypes.c_double(float(j)) for j in range(2000)]
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(acc, torch.full_like(acc, float(iters))))
+
+
+@requires_gpu
+class TestPreparedLaunchEligibility(unittest.TestCase):
+    def test_dlpack_tensor_rejected(self):
+        a = torch.zeros(32, device="cuda", dtype=torch.float32)
+        compiled = cute.compile(_tensor_signature, from_dlpack(a), 1.0)
+        with self.assertRaises(PreparedLaunchError) as raised:
+            compiled.prepare(from_dlpack(a), 1.0)
+        self.assertIn("gA", str(raised.exception))
+
+    def test_non_ctypes_numeric_annotation_rejected(self):
+        compiled = cute.compile(_f16_scalar_signature, 1.0)
+        with self.assertRaises(PreparedLaunchError) as raised:
+            compiled.prepare(1.0)
+        self.assertIn("Float16", str(raised.exception))
+
+    def test_sequence_argument_rejected(self):
+        compiled = cute.compile(_sequence_signature, [1, 2])
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare([1, 2])
+
+    def test_extra_tail_arguments_rejected(self):
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare(_f32_ptr(x), _f32_ptr(x), 1.0, 16, _current_stream(), 123)
+
+    def test_multi_slot_custom_argument_rejected(self):
+        """A user object marshalling to multiple ABI slots (custom
+        ``__c_pointers__``) is not re-bindable in place and must be rejected
+        at prepare time."""
+
+        class MultiSlotStruct:
+            def __c_pointers__(self):
+                return [ctypes.c_void_p(), ctypes.c_void_p()]
+
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare(MultiSlotStruct(), _f32_ptr(x), 1.0, 16, _current_stream())
+
+    def test_framework_stream_rejected_at_prepare(self):
+        """prepare() marshals through the normal path, so a stream slot must
+        be prepared with a CUstream; framework stream objects are accepted at
+        launch time only."""
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare(
+                _f32_ptr(x), _f32_ptr(x), 1.0, 16, torch.cuda.current_stream()
+            )
+
+    def test_missing_argument_diagnosed(self):
+        """prepare() with too few arguments raises the same missing-argument
+        diagnostic a direct call would (rectification is shared)."""
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        with self.assertRaises(DSLUserCodeError):
+            compiled.prepare(_f32_ptr(x), _f32_ptr(x), 1.0)
+
+    def test_wrong_kind_value_rejected_at_prepare(self):
+        """Classification is annotation-driven: a scalar for a declared
+        pointer slot, or an integer for a declared stream slot, is rejected
+        at prepare time instead of being mis-marshalled."""
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        stream = _current_stream()
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare(1.5, _f32_ptr(x), 1.0, 16, stream)
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare(_f32_ptr(x), _f32_ptr(x), 1.0, 16, 7)
+
+    def test_pointer_contract_lookalike_rejected(self):
+        """An object that merely looks like a runtime pointer (c_void_p
+        ``_desc`` plus ``__c_pointers__``) but marshals storage other than
+        its ``_desc`` must be rejected at prepare, not silently re-bound to
+        the wrong bytes on later launches."""
+
+        class DescLookalike:
+            def __init__(self):
+                self._cell = ctypes.c_int32(7)
+                self._desc = ctypes.c_void_p(0xDEAD0000)
+
+            def __c_pointers__(self):
+                return [ctypes.addressof(self._cell)]
+
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        with self.assertRaises(PreparedLaunchError):
+            compiled.prepare(DescLookalike(), _f32_ptr(x), 1.0, 16, _current_stream())
+
+    def test_non_jit_executor_rejected(self):
+        """TVM-FFI compiled functions override to() to return the compiled
+        function itself (their calls dispatch through a different entry
+        point); prepare() must reject such executors cleanly instead of
+        recursing. Simulated by forcing a non-JitExecutor default executor."""
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        args = (_f32_ptr(x), _f32_ptr(x), 1.0, 16, _current_stream())
+        original = compiled._default_executor
+        compiled._default_executor = object()
+        try:
+            with self.assertRaises(PreparedLaunchError):
+                compiled.prepare(*args)
+        finally:
+            compiled._default_executor = original
+
+    def test_direct_call_still_works_for_ineligible_args(self):
+        """prepare() rejecting an argument mix must leave the normal call
+        path untouched."""
+        a = torch.zeros(32, device="cuda", dtype=torch.float32)
+        compiled = cute.compile(_tensor_signature, from_dlpack(a), 1.0)
+        compiled(from_dlpack(a), 1.0)  # no raise
+
+
+@requires_gpu
+class TestPreparedLaunchMisuse(unittest.TestCase):
+    def _prepared(self):
+        compiled = _CompiledCache.scale()
+        x = torch.zeros(64, device="cuda", dtype=torch.float32)
+        y = torch.empty_like(x)
+        stream = _current_stream()
+        args = (_f32_ptr(y), _f32_ptr(x), 1.0, 64, stream)
+        return compiled.prepare(*args), args, (x, y)
+
+    def test_launch_argument_count_mismatch(self):
+        """Too few arguments without defaults raise the shared missing-
+        argument diagnostic; extra arguments raise the shared too-many
+        diagnostic — the same binding contract as a direct call."""
+        prepared, args, _keep = self._prepared()
+        with self.assertRaises(DSLUserCodeError):
+            prepared.launch(*args[:-1])
+        with self.assertRaises(DSLUserCodeError):
+            prepared.launch(*args, 5)
+
+    def test_launch_bad_stream_value(self):
+        """Stream slots accept streams, framework streams, and raw integer
+        handles only — not floats, bools, strings, or arbitrary objects."""
+        prepared, args, _keep = self._prepared()
+
+        class WithInt:
+            def __int__(self):
+                return 0
+
+        for bad_stream in (1.75, True, "0", WithInt()):
+            with self.assertRaises(PreparedLaunchError, msg=repr(bad_stream)):
+                prepared.launch(*args[:-1], bad_stream)
+
+    def test_launch_bad_boolean_value(self):
+        """Boolean slots take bool/int values; truthiness of arbitrary
+        objects is not silently coerced."""
+        compiled = _CompiledCache.mixed()
+        stream = _current_stream()
+        n = 64
+        x = torch.zeros(n, device="cuda", dtype=torch.float32)
+        y = torch.empty_like(x)
+        prepared = compiled.prepare(
+            _f32_ptr(y),
+            _f32_ptr(x),
+            1.0,
+            cutlass.Int64(0),
+            cutlass.Boolean(True),
+            n,
+            stream,
+        )
+        for bad_flag in ("false", None, [], object()):
+            with self.assertRaises(PreparedLaunchError, msg=repr(bad_flag)):
+                prepared.launch(
+                    _f32_ptr(y),
+                    _f32_ptr(x),
+                    1.0,
+                    cutlass.Int64(0),
+                    bad_flag,
+                    n,
+                    stream,
+                )
+
+    def test_launch_bad_value_type(self):
+        prepared, args, _keep = self._prepared()
+        bad = (args[0], "not a pointer", *args[2:])
+        with self.assertRaises(PreparedLaunchError) as raised:
+            prepared.launch(*bad)
+        self.assertIn("in_ptr", str(raised.exception))
+
+    def test_launch_after_module_unload(self):
+        n = 64
+        x = torch.zeros(n, device="cuda", dtype=torch.float32)
+        y = torch.empty_like(x)
+        stream = _current_stream()
+        compiled = cute.compile(_scale, _f32_ptr(y), _f32_ptr(x), 1.0, n, stream)
+        prepared = compiled.prepare(_f32_ptr(y), _f32_ptr(x), 1.0, n, stream)
+        prepared.launch(_f32_ptr(y), _f32_ptr(x), 1.0, n, stream)
+        torch.cuda.synchronize()
+        compiled.jit_module.unload()
+        with self.assertRaises(PreparedLaunchError):
+            prepared.launch(_f32_ptr(y), _f32_ptr(x), 1.0, n, stream)
+
+
+@requires_gpu
+class TestPreparedLaunchThreads(unittest.TestCase):
+    def test_one_instance_per_thread(self):
+        """The documented threading model: each thread prepares its own
+        instance; concurrent launches must not interfere (instances share no
+        mutable state)."""
+        compiled = _CompiledCache.scale()
+        n, iters = 4096, 50
+        errors = []
+
+        def worker(alpha):
+            try:
+                stream_obj = torch.cuda.Stream()
+                with torch.cuda.stream(stream_obj):
+                    x = torch.randn(n, device="cuda", dtype=torch.float32)
+                    y = torch.empty_like(x)
+                    stream = cuda_driver.CUstream(stream_obj.cuda_stream)
+                    prepared = compiled.prepare(
+                        _f32_ptr(y), _f32_ptr(x), alpha, n, stream
+                    )
+                    for _ in range(iters):
+                        y.fill_(0.0)
+                        prepared.launch(_f32_ptr(y), _f32_ptr(x), alpha, n, stream)
+                    stream_obj.synchronize()
+                    if not torch.equal(y, x * alpha):
+                        errors.append(f"wrong result for alpha={alpha}")
+            except Exception as e:  # pragma: no cover - failure reporting
+                errors.append(f"alpha={alpha}: {e!r}")
+
+        threads = [
+            threading.Thread(target=worker, args=(alpha,)) for alpha in (2.0, -3.0)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        self.assertEqual(errors, [])
+
+    def test_cross_thread_handoff(self):
+        """Instances are not thread-safe but are not thread-bound either:
+        preparing on one thread and launching from another (sequential
+        handoff, e.g. an init thread and a worker loop) must work."""
+        compiled = _CompiledCache.scale()
+        n = 1024
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.zeros_like(x)
+        stream = _current_stream()
+        prepared = compiled.prepare(_f32_ptr(y), _f32_ptr(x), 5.0, n, stream)
+        errors = []
+
+        def worker():
+            try:
+                prepared.launch(_f32_ptr(y), _f32_ptr(x), 5.0, n, stream)
+            except Exception as e:  # pragma: no cover - failure reporting
+                errors.append(repr(e))
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        torch.cuda.synchronize()
+        self.assertEqual(errors, [])
+        self.assertTrue(torch.equal(y, x * 5.0))
+
+
+@requires_gpu
+class TestPreparedLaunchDeviceBinding(unittest.TestCase):
+    def test_explicit_device_executor_prepare(self):
+        """prepare() mirrors the to()/__call__ split: an explicitly
+        device-bound executor prepares and launches correctly."""
+        compiled = _CompiledCache.scale()
+        n = 512
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.zeros_like(x)
+        stream = _current_stream()
+        prepared = compiled.to(0).prepare(_f32_ptr(y), _f32_ptr(x), 3.0, n, stream)
+        result = prepared.launch(_f32_ptr(y), _f32_ptr(x), 3.0, n, stream)
+        torch.cuda.synchronize()
+        self.assertEqual(result, 0)
+        self.assertTrue(torch.equal(y, x * 3.0))
+
+
+@requires_gpu
+class TestPreparedLaunchCudaGraph(unittest.TestCase):
+    def test_capture_and_replay(self):
+        """A prepared launch is capturable into a CUDA graph through a
+        capturing stream, with standard capture semantics: the argument bytes
+        are frozen into the graph at capture time, later launch() argument
+        updates affect neither the graph nor vice versa."""
+        compiled = _CompiledCache.scale()
+        n = 2048
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y_graph = torch.zeros_like(x)
+        y_other = torch.zeros_like(x)
+        stream = _current_stream()
+        prepared = compiled.prepare(_f32_ptr(y_graph), _f32_ptr(x), 2.0, n, stream)
+
+        # Warm up outside capture (loads the module, primes caches).
+        prepared.launch(_f32_ptr(y_graph), _f32_ptr(x), 2.0, n, stream)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            capture_stream = torch.cuda.current_stream().cuda_stream
+            result = prepared.launch(
+                _f32_ptr(y_graph), _f32_ptr(x), 2.0, n, capture_stream
+            )
+        # Capture queues the launch into the graph; it must still report
+        # success and must not have executed yet.
+        self.assertEqual(result, 0)
+
+        y_graph.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y_graph, x * 2.0))
+
+        # Ordinary launches after capture keep working and do not disturb
+        # the captured graph (frozen-at-capture semantics).
+        prepared.launch(_f32_ptr(y_other), _f32_ptr(x), -1.0, n, stream)
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y_other, x * -1.0))
+
+        y_graph.zero_()
+        y_other.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(y_graph, x * 2.0))
+        self.assertTrue(torch.equal(y_other, torch.zeros_like(x)))
+
+
+@requires_gpu
+class TestPreparedLaunchBenchmark(unittest.TestCase):
+    def test_benchmark_prepared_vs_direct(self):
+        """Micro-benchmark of steady-state host launch cost. Asserts only the
+        direction (prepared must not be slower than the direct call); the
+        printed numbers are the evidence."""
+        compiled = _CompiledCache.scale()
+        n, iters, warmup = 4096, 1000, 100
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.empty_like(x)
+        stream = _current_stream()
+        args = (_f32_ptr(y), _f32_ptr(x), 2.0, n, stream)
+        prepared = compiled.prepare(*args)
+        y_addr, x_addr, handle = y.data_ptr(), x.data_ptr(), int(stream)
+
+        def timed(fn):
+            for _ in range(warmup):
+                fn()
+            torch.cuda.synchronize()
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+            start_event.record()
+            start = time.perf_counter()
+            for _ in range(iters):
+                fn()
+            wall_us = (time.perf_counter() - start) / iters * 1e6
+            end_event.record()
+            torch.cuda.synchronize()
+            event_us = start_event.elapsed_time(end_event) / iters * 1e3
+            return wall_us, event_us
+
+        direct_wall, direct_event = timed(lambda: compiled(*args))
+        prepared_wall, prepared_event = timed(
+            lambda: prepared.launch(y_addr, x_addr, 2.0, n, handle)
+        )
+
+        print(
+            f"\n[prepared-launch bench] direct call:     "
+            f"{direct_wall:7.2f} us/call host wall, {direct_event:7.2f} us/call cuda-event\n"
+            f"[prepared-launch bench] prepared launch: "
+            f"{prepared_wall:7.2f} us/call host wall, {prepared_event:7.2f} us/call cuda-event"
+        )
+        self.assertLess(prepared_wall, direct_wall)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3418 ([FEA] CuTe DSL: prepared-launch API to eliminate
per-call host marshalling overhead).

## What

A first-class "bind once, replay cheaply" handle on compiled CuTe DSL
functions:

```python
compiled = cute.compile(fn, out_ptr, in_ptr, alpha, n, stream)
prepared = compiled.prepare(out_ptr, in_ptr, alpha, n, stream)   # validate + marshal once
for step in range(steps):
    prepared.launch(out.data_ptr(), x.data_ptr(), alpha, n, handle)  # in-place + direct call
```

Steady-state launches of an already-compiled function currently re-marshal
every argument on every call (`ExecutionArgs.generate_execution_args` plus
packed `void**` regeneration; wrappers typically also rebuild the argument
objects themselves each step) before a ~2.6 us C call. On a B200 with a
trivial 5-argument kernel that is 13.5-20.8 us/launch of host time;
`prepared.launch` is 3.8 us/launch (table below).

## Design

- `JitCompiledFunction.prepare(*args, **kwargs) -> PreparedLaunch` validates
  eligibility once, runs the normal marshalling exactly once, and snapshots
  the marshalled bytes into private per-slot ctypes storage owned by the
  returned handle. It delegates to `JitExecutor.prepare` through the extracted
  `_ensure_default_executor()` (same lock/weakref-proxy pattern as before), so
  `compiled.to(device).prepare(...)` is the multi-device variant — the API
  mirrors the existing `to()` / `__call__` split exactly.
  `CudaDialectJitCompiledFunction` inherits `prepare()`; `cuda_jit_executor.py`
  needs zero changes.
- `PreparedLaunch.launch(*args, **kwargs) -> int | None` has the same
  signature and return contract as calling the compiled function: keyword
  arguments and omitted defaulted parameters rectify through the existing
  `get_rectified_args` (raising the shared binding diagnostics); full
  positional calls are the fast path. It rewrites per-argument slots in place
  (no allocation, no repacking, no ExecutionArgs regeneration) and invokes
  the compiled entry point directly, checking a private CUDA-result slot.
  Pointer slots accept runtime `Pointer` objects or raw integer addresses;
  scalar slots accept Python scalars or `Numeric` instances (written with
  plain ctypes assignment semantics — a value the storage rejects, such as a
  float for an integer slot, raises a typed error instead of applying the
  implicit DSL cast a direct call would); stream slots accept CUDA stream
  objects, raw integer handles, or framework streams exposing an integer
  `cuda_stream` attribute (`torch.cuda.Stream`).
- Eligibility (validated at prepare, not at launch) is annotation-driven
  where the declaration is informative — a declared pointer, stream, or
  numeric slot must be prepared with a value of that kind — and value-driven
  for unannotated slots: runtime pointers (`make_ptr` / pointer-address
  slots; the marshalling contract is verified against the pointer's `_desc`
  storage, so contract lookalikes are rejected), numeric scalars with plain
  ctypes storage (Boolean, Int8-64, Uint8-64, Float32/64, TFloat32, plain
  Python bool/int/float), CUDA streams. Anything else (dlpack tensors,
  structs, sequences, custom JIT arguments, bit-cast scalar storage such as
  Float16, and TVM-FFI compiled functions, which dispatch through their own
  entry point) raises `PreparedLaunchError` — a `DSLUserCodeError` carried by
  six new `LAUNCH_*` entries in the DiagId catalog, so errors render like
  every other DSL diagnostic. The normal call path remains for rejected
  mixes.
- Bitwise identity: the initial slot bytes are the slow path's bytes
  (memmoved from the storages `generate_execution_args` just produced), and
  launch-time writes produce the same bytes the slow path would marshal for
  the same values of the prepared kinds. Verified per-slot (packed payload
  byte comparison) and end-to-end (bitwise output comparison in the tests).
- Ownership and lifecycle: each instance owns its packed `void**` array and
  CUDA-result slot (the executor's are shared/thread-local), so instances
  never race each other or the normal call path. The slow path's scalar
  ctypes storage is ephemeral, so the handle snapshots into cells it owns.
  Launching after `jit_module.unload()` raises cleanly; a recompiled or
  autotuned function needs a new handle. One instance per thread is the
  documented model (instances share no mutable state; sequential cross-thread
  handoff works). CUDA-graph capture through a capturing stream works with
  standard frozen-at-capture semantics.

## What this PR does NOT change

- No changes to `__call__`'s hot path; the only change to existing code is
  extracting `_ensure_default_executor()` from `run_compiled_program`
  (verbatim, same locking).
- No changes to `cuda_jit_executor.py`.
- No behavior change for non-users; the feature is purely additive.

## Performance

B200 (sm_100), trivial 4096-element f32 scale kernel (~2 us device time,
host-bound), 300 warmup + 5000 timed calls x 3 repeats, median; host wall =
`perf_counter` around the loop, cuda-event = events on the stream around the
loop (agreement to 0.01 us confirms the host is the bottleneck). Numbers vary
~±0.3 us run to run on a shared host:

| path | host wall (us/call) | cuda-event (us/call) |
|---|---|---|
| direct call, reused arg objects | 13.48 | 13.49 |
| direct call, rebuilt arg objects (wrapper steady state) | 20.76 | 20.76 |
| prepared.launch, raw int addresses/handle | **3.77** | **3.78** |
| prepared.launch, rebuilt pointer objects | 6.40 | 6.40 |

Slow-path host breakdown (isolated medians): ~5.9 us argument-object
construction (wrapper-side, applies to the rebuilt-args row), ~8.2 us
`generate_execution_args`, ~1.2 us packed-array population, ~2.6 us bare
entry-point call. In a production Megatron-Core integration the same
mechanism cut 30-220 us/launch wrapper steady state to ~3.6 us (externally
measured corroboration; see the issue).

## Tests

`test/python/CuTeDSL/test_prepared_launch.py` (unittest style, matches the
existing suite; device behavior is exercised on a real sm_100 kernel, and
eligibility rejections also use host-only signatures):

- bitwise output parity with the direct call (incl. prepare before any call);
- pointer/scalar/stream mutation between launches, raw ints, kwargs,
  defaulted parameters omitted at prepare and launch, framework streams at
  launch; Float64/Int64/Boolean width coverage with bitwise checks;
- fast-path contract: launches never re-enter `generate_execution_args`
  (monkeypatch guard) and reuse the packed array in place;
- storage stability: 1000-launch read-modify-write accumulate under periodic
  gc + allocator churn;
- eligibility rejections (dlpack, sequence, Float16, multi-slot custom
  `__c_pointers__`, pointer-contract lookalikes, wrong-kind values for
  declared pointer/stream slots, framework stream at prepare, extra tail
  args, missing args, TVM-FFI-style non-JitExecutor executors) and that the
  direct call keeps working for rejected mixes;
- misuse: launch arg-count mismatches (shared binding diagnostics), bad
  pointer/scalar/stream/boolean values (naming the argument), launch after
  `jit_module.unload()`;
- threading: concurrent per-thread instances + sequential cross-thread
  handoff;
- `to(device).prepare(...)`;
- CUDA-graph capture + replay and frozen-at-capture semantics both directions;
- an in-test micro-benchmark asserting prepared is not slower than direct
  (direction-only, load-tolerant).

28 tests; full `test/python/CuTeDSL/` suite: 34 passed (includes the
pre-existing `test_struct_in_if.py`), zero regressions.

A tutorial example (`examples/python/CuTeDSL/dsl_tutorials/prepared_launch.py`)
follows the by-passing-dlpack argument style of `call_bypass_dlpack.py`.

## Notes for reviewers

- The eligibility whitelist is deliberately conservative for v1; the slot
  mechanism extends naturally (Float16/BFloat16 bit-pattern writers,
  multi-slot dlpack descriptors) if there is interest.
- Launch-time value checking is intentionally light — ctypes assignment
  semantics with typed errors on rejected values (out-of-range integers
  truncate to the declared width, like the existing fast path; wrong-kind
  scalars, non-stream stream values, and non-bool Boolean values raise
  `PreparedLaunchError`). Full `_full_arg_check` validation still runs at
  prepare via the normal marshalling; kind-level validation is done once at
  prepare, annotation-driven.
- Related issues: #3351 (RSS growth from per-launch `__c_pointers__`
  allocations — this PR's replay path performs none), #2852 (AOT/TVM-FFI
  export — complementary deployment model).

(To run the tests in-tree via the editable flow on current wheels you'll also want #3417.)