### PR TITLE
Docs: Remove `dynamic_expr` from examples; deprecated since v4.1

### DIFF
--- a/examples/python/CuTeDSL/cute/notebooks/hello_world.ipynb
+++ b/examples/python/CuTeDSL/cute/notebooks/hello_world.ipynb
@@ -55,7 +55,7 @@
     "    # Get the x component of the thread index (y and z components are unused)\n",
     "    tidx, _, _ = cute.arch.thread_idx()\n",
     "    # Only the first thread (thread 0) prints the message\n",
-    "    if cutlass.dynamic_expr(tidx == 0):\n",
+    "    if tidx == 0:\n",
     "        cute.printf(\"Hello world\")"
    ]
   },


### PR DESCRIPTION
Since `cutlass.dynamic_expr` has been deprecated in v4.1 it should not appear in the very first introductory tutorial.