### PR TITLE
[CuTe DSL] Fix REPL crash: clear diagnostic and keep the interpreter alive (issue #3413)

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
@@ -785,12 +785,11 @@ class DSLPreprocessor(ast.NodeTransformer):
                         _node.col_offset += _col_shift  # type: ignore[attr-defined]
                     if getattr(_node, "end_col_offset", None) is not None:
                         _node.end_col_offset += _col_shift  # type: ignore[attr-defined]
-        except Exception:
-            # Under REPL mode, there is no way to get source of a function object, error out
-            raise DSLRuntimeError(
-                f"Failed to parse function {func_name}",
-                suggestion="DSL does not support REPL mode, save the function to a file instead.",
-            )
+        except OSError as e:
+            # No retrievable source (REPL / exec())
+            raise DSLUserCodeError(DiagId.UNSUP_NO_SOURCE, func=func_name, cause=e)
+        except Exception as e:
+            raise DSLRuntimeError(f"Failed to parse function {func_name}", cause=e)
 
         # Step 1.2 Check the decorator
         if not self.check_decorator(tree.body[0]):

--- a/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
@@ -785,7 +785,7 @@ class DSLPreprocessor(ast.NodeTransformer):
                         _node.col_offset += _col_shift  # type: ignore[attr-defined]
                     if getattr(_node, "end_col_offset", None) is not None:
                         _node.end_col_offset += _col_shift  # type: ignore[attr-defined]
-        except OSError as e:
+        except (OSError, TypeError) as e:
             # No retrievable source (REPL / exec())
             raise DSLUserCodeError(DiagId.UNSUP_NO_SOURCE, func=func_name, cause=e)
         except Exception as e:

--- a/python/CuTeDSL/cutlass/base_dsl/common.py
+++ b/python/CuTeDSL/cutlass/base_dsl/common.py
@@ -99,8 +99,8 @@ def _dsl_excepthook(
         else:
             # Just print the formatted message (which is in __str__)
             print(str(exc_value), file=sys.stderr)
-        # Don't kill an interactive session (REPL, `python -i`)
-        if not (hasattr(sys, "ps1") or sys.flags.interactive):
+        # Don't kill an interactive session (REPL, `python -i`, PYTHONINSPECT)
+        if not (hasattr(sys, "ps1") or sys.flags.interactive or sys.flags.inspect):
             sys.exit(1)
     else:
         # Use the original exception hook for other exceptions

--- a/python/CuTeDSL/cutlass/base_dsl/common.py
+++ b/python/CuTeDSL/cutlass/base_dsl/common.py
@@ -99,7 +99,9 @@ def _dsl_excepthook(
         else:
             # Just print the formatted message (which is in __str__)
             print(str(exc_value), file=sys.stderr)
-        sys.exit(1)
+        # Don't kill an interactive session (REPL, `python -i`)
+        if not (hasattr(sys, "ps1") or sys.flags.interactive):
+            sys.exit(1)
     else:
         # Use the original exception hook for other exceptions
         _original_excepthook(exc_type, exc_value, exc_traceback)

--- a/python/CuTeDSL/cutlass/base_dsl/diagnostics.py
+++ b/python/CuTeDSL/cutlass/base_dsl/diagnostics.py
@@ -1269,6 +1269,11 @@ class DiagId(_DiagMixin, enum.Enum):
         "single line is not supported here.",
         ("Split it into separate assignment statements, one kind of target per line.",),
     )
+    UNSUP_NO_SOURCE = (
+        "The source of `{func}` is not available (e.g. defined in the REPL or "
+        "via exec()), so it cannot be compiled.",
+        ("Save the function to a .py file and import it from there.",),
+    )
 
     # =====================================================================
     # Migrated from raw DSLRuntimeError raises across the DSL (author

--- a/test/python/CuTeDSL/test_no_source_diagnostics.py
+++ b/test/python/CuTeDSL/test_no_source_diagnostics.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Regression tests for issue #3413: a ``@cute.jit`` function with no
+retrievable source raised an internal error and killed the interpreter.
+"""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+import cutlass.cute as cute
+from cutlass.base_dsl.common import DSLUserCodeError
+
+
+class TestNoSourceDiagnostic(unittest.TestCase):
+    def test_exec_defined_function_raises_user_error(self):
+        namespace = {"cute": cute}
+        exec(
+            textwrap.dedent(
+                """
+                @cute.jit
+                def kernel_without_source():
+                    pass
+                """
+            ),
+            namespace,
+        )
+        with self.assertRaises(DSLUserCodeError) as ctx:
+            namespace["kernel_without_source"]()
+        self.assertEqual(ctx.exception.code, "UNSUP_NO_SOURCE")
+        rendered = str(ctx.exception)
+        self.assertNotIn("Internal Error", rendered)
+        self.assertIn("Save the function to a .py file", rendered)
+
+
+class TestReplSurvivesDslError(unittest.TestCase):
+    def test_uncaught_dsl_error_does_not_kill_interactive_session(self):
+        # Session from issue #3413; the interpreter used to exit at run()
+        repl_session = textwrap.dedent(
+            """\
+            from cutlass import cute
+
+            @cute.jit
+            def run(f):
+                f()
+
+            run(lambda: 0)
+            print("REPL-STILL-ALIVE")
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-i"],
+            input=repl_session,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        self.assertIn("REPL-STILL-ALIVE", proc.stdout)
+        self.assertEqual(proc.returncode, 0)
+        self.assertNotIn("Internal Error", proc.stderr)
+        self.assertIn("Save the function to a .py file", proc.stderr)
+
+    def test_uncaught_dsl_error_in_script_still_exits_nonzero(self):
+        script = textwrap.dedent(
+            """\
+            from cutlass.base_dsl.common import DSLRuntimeError
+
+            raise DSLRuntimeError("boom test")
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("boom test", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3413

Calling a `@cute.jit` function defined in the REPL (or via `exec()`) causes 2 problems:

1. The "no source available" failure gets raised as `DSLRuntimeError`, rendering as "[Internal Error] This is a bug in the DSL ... please report this". It isn't a DSL bug, REPL is a known unsupported case (#2636 says a clear message was added for it in 4.3, but it doesn't reach the user because of the error class).
2. The DSL excepthook unconditionally calls `sys.exit(1)`, so the uncaught error kills the whole interactive session instead of returning to the prompt. Same thing happens when debugging a normal file-based kernel with `python -i`.

Changes:

- `ast_preprocessor.py`: catch `OSError` from `inspect.getsourcelines` separately and raise `DSLUserCodeError` with a new catalog entry `UNSUP_NO_SOURCE` ("save the function to a .py file"). Other parse failures still raise `DSLRuntimeError`, now with the cause chained.
- `common.py`: skip the `sys.exit(1)` in `_dsl_excepthook` when the session is interactive. Scripts still exit 1 on uncaught DSL errors.

This doesn't add REPL support, it just makes the failure behave as intended.

With the patch, the repro from the issue now gives:

    >>> run(lambda: 0)
    error[UNSUP_NO_SOURCE]: The source of `run` is not available (e.g. defined in the REPL or via exec()), so it cannot be compiled.
      = note: Caused exception: could not get source code
      suggestion: Save the function to a .py file and import it from there.
    >>> print("still alive")
    still alive

Tested against the 4.6.1 wheel on a DGX Spark (GB10): the two new regression tests in `test/python/CuTeDSL/test_no_source_diagnostics.py` fail on the stock wheel and pass with the patch; a third checks script exit status is unchanged. Also verified a normal file-based kernel still compiles and launches.

Note: #3396 touches the same `except` block for a different bug (stale on-disk source), small rebase likely needed