### PR TITLE
Fix ScaledBasis equality for mismatched bases, add SM120 sparse metadata K assert

### DIFF
--- a/include/cute/numeric/arithmetic_tuple.hpp
+++ b/include/cute/numeric/arithmetic_tuple.hpp
@@ -369,7 +369,13 @@ CUTE_HOST_DEVICE constexpr
 auto
 operator==(ScaledBasis<T,Ns...> const& t, ScaledBasis<U,Ms...> const& u) {
   if constexpr (sizeof...(Ns) == sizeof...(Ms)) {
-    return bool_constant<((Ns == Ms) && ...)>{} && t.value() == u.value();
+    // Values of different bases need not be comparable types, so only form the value
+    // comparison when the bases match.
+    if constexpr (((Ns == Ms) && ...)) {
+      return bool_constant<true>{} && t.value() == u.value();
+    } else {
+      return false_type{};
+    }
   } else {
     return false_type{};
   }

--- a/include/cutlass/gemm/collective/sm120_blockscaled_sparse_mma_tma.hpp
+++ b/include/cutlass/gemm/collective/sm120_blockscaled_sparse_mma_tma.hpp
@@ -268,6 +268,12 @@ struct CollectiveMma<
   using SmemLayoutAtomE  = ComposedLayout<Swizzle<0,4,3>,
                                           smem_sparse_ptr_flag_bits<TensorEMmaSparsity, sizeof_bits_v<ElementE>>,
                                           SmemLayoutAtomE_>;
+
+  static_assert(rank(SmemLayoutAtomE{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert((size<0>(TileShape{}) % size<0>(SmemLayoutAtomE{})) == 0, "SmemLayoutAtomE must evenly divide tile shape.");
+  static_assert((size<2>(TileShape{}) % size<1>(SmemLayoutAtomE{})) == 0,
+                "TileShape_K must be a multiple of the metadata atom K extent (256 for nvf4 and mxf4, 128 for mxf8f6f4).");
+
   using SmemLayoutE = decltype(tile_to_shape(
                   SmemLayoutAtomE{},
                   make_shape(shape<0>(TileShape{}), shape<2>(TileShape{}), Int<DispatchPolicy::StagesE>{}),
@@ -278,9 +284,6 @@ struct CollectiveMma<
   using TensorEAtomM = typename SparseConfig::TensorEAtomM;
   using TensorEAtomK = typename SparseConfig::TensorEAtomK;
   static constexpr bool IsELoadPred = not (TensorEAtomM{} == size<0>(TileShape{}) && TensorEAtomK{} == size<2>(TileShape{}));
-
-  static_assert(rank(SmemLayoutAtomE{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
-  static_assert((size<0>(TileShape{}) % size<0>(SmemLayoutAtomE{})) == 0, "SmemLayoutAtomE must evenly divide tile shape.");
 
   // Set the bytes transferred in this TMA transaction
   static constexpr uint32_t TmaTransactionBytesMK = static_cast<uint32_t>(


### PR DESCRIPTION
### Summary

Issue #3393 reported two SM120 block-scaled sparse tile shapes that fail to
compile, `256x128x256` and `128x128x128`, and asked whether the restriction is
intended. They have different causes and this PR handles both.

`256x128x256` is not a restriction of the collective. It fails inside
`cute::operator==(ScaledBasis, ScaledBasis)`, which forms `t.value() == u.value()`
even when the basis IDs already differ. With the value comparison formed only
when the bases match, the tile compiles and produces correct results on sm_121a.

`128x128x128` is a real constraint. The metadata tensor is tiled with
`SmemLayoutAtomE`, whose K extent is 256 for nvf4 operands, so a K tile of 128
cannot be expressed. The collective asserts that the metadata atom divides the
tile along M and does not assert the same along K, so the first thing a user sees
is a `tile_to_shape` failure inside cute rather than a statement of the
constraint.

Files:
- `include/cute/numeric/arithmetic_tuple.hpp`
- `include/cutlass/gemm/collective/sm120_blockscaled_sparse_mma_tma.hpp`

### Mechanism, 256x128x256

`CollectiveMma::load_init` tiles the metadata TMA tensor with the CTA tile
(`sm120_blockscaled_sparse_mma_tma.hpp`, lines 703 and 724 on main):

```cpp
Tensor mE_mkl = mainloop_params.tma_load_e.get_tma_tensor(mainloop_params.layout_e.shape());
Tensor gE_mkl = local_tile(mE_mkl, TileShape{}, make_coord(_,_,_), Step<_1, X,_1>{});
```

`layout_e` comes from `Sm1xxGemmSparseConfig::deduce_layoutE`, which blocks the
metadata by the atom, `((TensorEAtomM, M/TensorEAtomM), (TensorEAtomK, K/TensorEAtomK), L)`.
`TensorEAtomM` is 128, so a CTA tile of 256 rows leaves the M mode rank 2 and
`coalesce_x` runs `bw_coalesce` over the flattened `(_128,_2,_256)`. Its merge
test is

```cpp
is_static<decltype(get<0>(new_shape))>::value &&
is_constant<true, decltype(get<I>(old_shape) * get<I>(old_stride) == get<0>(new_stride))>::value
```

which here compares a `ScaledBasis<int,1>` against a `ScaledBasis<cute::R<1,16>,0>`.
The basis IDs differ, so the answer is false, but the current body still forms the
value comparison and `int32_t == cute::R<1,16>` has no operator:

```
cute/numeric/arithmetic_tuple.hpp(372): error: no operator "==" matches these operands
            operand types are: const int32_t == cute::R<1, 16>
      return bool_constant<((Ns == Ms) && ...)>{} && t.value() == u.value();
```

The change forms the value comparison only when the basis IDs match and returns
`false_type` otherwise, which is what the two neighbouring `ScaledBasis` equality
overloads in the same file already do for mismatched operands. The matching-basis
branch keeps the original expression verbatim, so its return type does not change.

### Mechanism, 128x128x128

`SmemLayoutE` is `tile_to_shape(SmemLayoutAtomE{}, (TileShape_M, TileShape_K, StagesE), ...)`,
so `tile_to_shape` requires the atom to divide the tile in both modes. Only the M
half was asserted. `TensorEAtom_MMA_F4` is `Shape<_128,_256>`, so `TileShape_K` of
128 fails the K half and is reported four layers down as
`"tile_to_shape: block shape does not divide the target shape."`

The K assert is added next to the M one and both are moved above `SmemLayoutE`, so
the named message is the first error. A failed `static_assert` does not stop
instantiation, so the downstream layout errors still follow it.

### Reproducer

One-line tile substitution in the in-tree example, compile only:

```bash
sed 's|Shape<_128,_128,_256>|Shape<_256,_128,_256>|' \
  examples/80_blackwell_geforce_sparse_gemm/80b_blackwell_geforce_nvfp4_nvfp4_sparse_gemm.cu > /tmp/probe.cu
nvcc -O3 -DNDEBUG -std=c++17 --generate-code=arch=compute_121a,code=[sm_121a] \
  -DCUTLASS_ENABLE_TENSOR_CORE_MMA=1 --expt-relaxed-constexpr \
  -Iinclude -Iexamples/common -Itools/util/include -c /tmp/probe.cu -o /tmp/probe.o
```

### Testing done

Hardware: GB10 (DGX Spark), sm_121a. CUDA 13.1, driver 580.95.05. Tree: main @
`f94ec46f`.

Four tile shapes through example 80b, compiled and run at 2048x2048x2048,
4096x4096x4096 and 8192x4096x4096:

| tile | before | after |
|---|---|---|
| 128x128x256 | compiles, runs | compiles, runs, all three sizes pass |
| 128x64x256 | compiles, runs | compiles, runs, all three sizes pass |
| 256x128x256 | 1 error, 83 log lines of cute backtrace | compiles, runs, all three sizes pass |
| 128x128x128 | 4 errors, first is `tile_to_shape` | 5 errors, first is the new assert |

`cutlass_test_unit_gemm_device_sm120_bssp_general`, built for `120a;121a` and run
on sm_121a: 7 of 7 pass.

The full `cutlass_test_unit_cute` target builds and its executables pass: 44 core,
4 layout, 3 msvc_compilation, 2 turing, the rest gated off on this arch.

A 21 point tile sweep on examples 80a and 80b, with M in {64,128,256,384,512},
N in {32,64,96,128,256} and K in {128,256,384,512}: `256x128x256` and `256x64x256`
change from failing to compiling. Every other shape keeps its verdict. Two shapes
that already failed, `128x128x128` and `128x128x384`, gain the new assert as their
first error, and `64x128x256` now leads with the existing M assert instead of a
`tile_to_shape` failure. No shape that compiled before fails after.

### Notes

`TileShape_M` of 384 compiles and then fails `cuTensorMapEncodeTiled` at runtime,
because a TMA box dimension is capped at 256 and the A descriptor's M box extent
is `TileShape_M`:

```
boxDim         (128,384,1,1,1)
Error: Failed to initialize the TMA descriptor 1
```

That is a separate gap with no compile-time guard, and I am happy to look at it in
its own PR.

The same missing K assert is present in `sm120_sparse_mma_tma.hpp` and in the two
SM100 sparse collectives. This PR stays with the collective named in #3393.

No in-tree test covers a 256-row SM120 sparse tile. I can add `256x128x256` to
`test/unit/gemm/device/sm120_blockscaled_sparse_tensorop_gemm` during review.

This answers #3393.

cc @thakkarV @hwu36
