### PR TITLE
Add CuTeDSL math tests for sqrt operation

### DIFF
--- a/test/examples/CuTeDSL/test_math.py
+++ b/test/examples/CuTeDSL/test_math.py
@@ -115,3 +115,38 @@ def test_binary_ops():
     torch.cuda.synchronize()
 
     assert torch.equal(out, expected)
+
+
+@cute.kernel
+def _sqrt_ops_kernel(
+    inp: cute.Tensor,
+    out: cute.Tensor,
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    out[tidx] = cute.math.sqrt(inp[tidx])
+
+
+@cute.jit
+def _sqrt_ops_host(
+    inp: cute.Tensor,
+    out: cute.Tensor,
+):
+    _sqrt_ops_kernel(inp, out).launch(
+        grid=[1, 1, 1], block=[inp.shape[0], 1, 1]
+    )
+
+
+def test_sqrt_ops():
+    inp = torch.tensor([1.0, 4.0, 9.0, 16.0], device="cuda", dtype=torch.float32)
+    expected = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=torch.float32)
+    out = torch.zeros(4, device="cuda", dtype=torch.float32)
+
+    inp_cute = from_dlpack(inp)
+    out_cute = from_dlpack(out)
+
+    args = (inp_cute, out_cute)
+
+    cute.compile(_sqrt_ops_host, *args)(*args)
+    torch.cuda.synchronize()
+
+    assert torch.equal(out, expected)


### PR DESCRIPTION
## Add sqrt unary math operation test

### Description
Add coverage for `cute.math.sqrt` by introducing a new unary operation test.

This change:
- Adds a `_sqrt_ops_kernel` that applies `cute.math.sqrt` elementwise.
- Adds a `_sqrt_ops_host` JIT wrapper to launch the kernel.
- Adds `test_sqrt_ops` to verify correctness against expected square root values using CUDA tensors.

The test ensures that `cute.math.sqrt` correctly lowers and executes through CuTe's math operation interface.

### Testing
- Added a CUDA unit test covering `float32` sqrt operations.
- Verified output correctness against expected values:
  - sqrt(1.0) = 1.0
  - sqrt(4.0) = 2.0
  - sqrt(9.0) = 3.0
  - sqrt(16.0) = 4.0