### PR TITLE
docs: fix broken CuTe DSL educational notebook links

### DIFF
--- a/media/docs/pythonDSL/cute_dsl_general/notebooks.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/notebooks.rst
@@ -3,14 +3,18 @@
 Educational Notebooks
 =====================
 
-A number of notebooks for educational purposes are provided in the `CUTLASS GitHub repository <https://github.com/NVIDIA/cutlass>`__.
+A number of notebooks for educational purposes are provided in the CUTLASS GitHub repository <https://github.com/NVIDIA/cutlass>__.
 A list with handful links is given below:
 
-- `"Hello world" <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/hello_world.ipynb>`__
-- `Printing <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/print.ipynb>`__
-- `Data Types Basics <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/data_types.ipynb>`__
-- `Tensors <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/tensor.ipynb>`__
-- `The TensorSSA Abstraction <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/tensorssa.ipynb>`__
-- `Layout Algebra <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/cute_layout_algebra.ipynb>`__
-- `Element-wise Add Tutorial <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/elementwise_add.ipynb>`__
-- `Using CUDA Graphs <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/notebooks/cuda_graphs.ipynb>`__
+- "Hello world" <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/hello_world.ipynb>__
+- Printing <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/print.ipynb>__
+- Data Types Basics <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/data_types.ipynb>__
+- Tensors <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/tensor.ipynb>__
+- The TensorSSA Abstraction <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/tensorssa.ipynb>__
+- Layout Algebra <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/cute_layout_algebra.ipynb>__
+- Composed Layouts <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/composed_layout.ipynb>__
+- Element-wise Add Tutorial <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/elementwise_add.ipynb>__
+- Using CUDA Graphs <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/cuda_graphs.ipynb>__
+- Async Pipeline <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/async_pipeline.ipynb>__
+- Benchmark Autotune <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/benchmark_autotune.ipynb>__
+- Port to SOL GEMM <https://github.com/NVIDIA/cutlass/tree/main/examples/python/CuTeDSL/cute/notebooks/port_to_sol_gemm.ipynb>__


### PR DESCRIPTION
## Summary
- Fixes notebook URLs on the CuTe DSL educational notebooks docs page.
- Notebooks moved to `examples/python/CuTeDSL/cute/notebooks/`; docs still linked to `examples/python/CuTeDSL/notebooks/` (404).
- Adds links for notebooks already in-tree but missing from the list (composed layouts, async pipeline, benchmark autotune, port to SOL GEMM).

Fixes #3414

## Test plan
- [x] Verified each linked `.ipynb` exists on `main` under `examples/python/CuTeDSL/cute/notebooks/`
- [ ] Confirm docs site renders the updated list after publish

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/