### PR TITLE
Add missing template disambiguators

### DIFF
--- a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized.hpp
@@ -901,7 +901,7 @@ public:
       // unflushed global memory prior to this instruction
       cutlass::arch::wait_on_dependent_grids();
 
-      auto load_inputs = collective_mainloop.load_init<IsTensorMapUpdateAsync>(
+      auto load_inputs = collective_mainloop.template load_init<IsTensorMapUpdateAsync>(
         problem_shape_MNKL, params.mainloop,
         shared_storage.tensors.mainloop,
         shared_storage.tensormaps[0].mainloop,
@@ -1130,7 +1130,7 @@ public:
         clc_pipe_consumer_state += updater_id;
         tensor_map_ready_pipe_producer_state += updater_id;
 
-        auto tensormaps_mainloop = collective_mainloop.tensormaps_init<IsTensorMapUpdateAsync>(
+        auto tensormaps_mainloop = collective_mainloop.template tensormaps_init<IsTensorMapUpdateAsync>(
           params.mainloop,shared_storage.tensormaps[updater_id+1].mainloop, params.hw_info.sm_count, sm_id);
         auto tensormaps_epilogue_load = collective_epilogue.template tensormaps_init<true /*IsLoad*/, IsTensorMapUpdateAsync /*IsTmaAsyncUpdate*/>(
           params.epilogue, shared_storage.tensormaps[updater_id+1].epilogue, params.hw_info.sm_count, sm_id);

--- a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
@@ -1175,7 +1175,7 @@ public:
           }
 
           bool reverse_epi_n = IsOverlappingAccum && (current_wave % 2 == 0);
-          epi_load_pipe_producer_state = collective_epilogue.load<IsOverlappingAccum>(
+          epi_load_pipe_producer_state = collective_epilogue.template load<IsOverlappingAccum>(
             epi_load_pipeline,
             epi_load_pipe_producer_state,
             problem_shape_MNKL,

--- a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_tma_warpspecialized.hpp
@@ -986,7 +986,7 @@ public:
           }
 
           bool reverse_epi_n = IsOverlappingAccum && (current_wave % 2 == 0);
-          epi_load_pipe_producer_state = collective_epilogue.load<IsOverlappingAccum>(
+          epi_load_pipe_producer_state = collective_epilogue.template load<IsOverlappingAccum>(
             epi_load_pipeline,
             epi_load_pipe_producer_state,
             problem_shape_MNKL,


### PR DESCRIPTION
## Summary

Add missing `template` disambiguators to four dependent member-template calls in SM100 and SM103 GEMM kernels.

## Root cause

`CollectiveMainloop` and `CollectiveEpilogue` are aliases of class template parameters, so member-template calls through their instances are dependent names. Standard C++ requires the `template` disambiguator in these expressions.

NVCC accepts the existing non-empty calls through permissive parsing, but stricter C++ frontends can reject them because `<` is not unambiguously parsed as the beginning of a template argument list.

## Changes

- Disambiguate `CollectiveMainloop::load_init` and `CollectiveMainloop::tensormaps_init` calls in the SM100 array/grouped kernel.
- Disambiguate `CollectiveEpilogue::load` calls in the SM103 block-scaled GEMM and array/grouped GEMM kernels.

This is a syntax-only portability fix with no intended runtime or code-generation change.

## Validation

- `git diff --check`
- Compiled `75_blackwell_grouped_gemm` for `sm_100a` with CUDA 13.2.
- Built CMake target `89_sm103_fp4_ultra_gemm` with `CUTLASS_NVCC_ARCHS=103a`.
- Built CMake target `90_sm103_fp4_ultra_grouped_gemm` with `CUTLASS_NVCC_ARCHS=103a`.
