### PR TITLE
Fix default-build for SM120/121 block-scaled GEMM: keep largest tile  first

### DIFF
--- a/python/cutlass_library/generator.py
+++ b/python/cutlass_library/generator.py
@@ -11220,18 +11220,18 @@ def GenerateSM120_TensorOp_mixed_8bits_UMMA_gemm_with_block_scaled(manifest, cud
   # Pingpong uses AtomLayout Shape<_2,_2,_1>, giving a natural TiledMma N of 16,
   # so pingpong tiles start at N = 16.
   tile_sizes_cooperative = [
-    [128,   8, 128],
-    [128,  16, 128],
-    [128,  32, 128],
+    [128, 128, 128],
     [128,  64, 128],
-    [128, 128, 128]
+    [128,  32, 128],
+    [128,  16, 128],
+    [128,   8, 128]
   ]
 
   tile_sizes_pingpong = [
-    [128,  16, 128],
-    [128,  32, 128],
+    [128, 128, 128],
     [128,  64, 128],
-    [128, 128, 128]
+    [128,  32, 128],
+    [128,  16, 128]
   ]
 
   cluster_shape = [1,1,1]
@@ -11367,28 +11367,28 @@ def GenerateSM120_TensorOp_fp4_UMMA_gemm_with_block_scaled(manifest, cuda_versio
   # Pingpong uses AtomLayout Shape<_2,_2,_1>, giving a natural TiledMma N of 16,
   # so pingpong tiles start at N = 16.
   tile_sizes_cooperative = [
-    [128,   8, 128],
-    [128,   8, 256],
-    [128,  16, 128],
-    [128,  16, 256],
-    [128,  32, 128],
-    [128,  32, 256],
-    [128,  64, 128],
-    [128,  64, 256],
     [128, 128, 128],
     [128, 128, 256],
-    [256, 128, 128]
+    [256, 128, 128],
+    [128,  64, 128],
+    [128,  64, 256],
+    [128,  32, 128],
+    [128,  32, 256],
+    [128,  16, 128],
+    [128,  16, 256],
+    [128,   8, 128],
+    [128,   8, 256]
   ]
 
   tile_sizes_pingpong = [
-    [128,  16, 128],
-    [128,  16, 256],
-    [128,  32, 128],
-    [128,  32, 256],
+    [128, 128, 128],
+    [128, 128, 256],
     [128,  64, 128],
     [128,  64, 256],
-    [128, 128, 128],
-    [128, 128, 256]
+    [128,  32, 128],
+    [128,  32, 256],
+    [128,  16, 128],
+    [128,  16, 256]
   ]
 
   cluster_shape = [1,1,1]

--- a/test/python/cutlass_library/test_sm120_blockscaled_default_tiles.py
+++ b/test/python/cutlass_library/test_sm120_blockscaled_default_tiles.py
@@ -1,0 +1,116 @@
+#################################################################################################
+#
+# Copyright (c) 2026 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#################################################################################################
+
+"""
+Regression test: the default kernel set (empty CUTLASS_LIBRARY_KERNELS) must
+select the largest tile for the SM120/SM121 block-scaled GEMM generators.
+
+With an empty kernel filter, CreateGemmUniversal3xOperator prunes each
+family's tile list to tile_descriptions[0] ("only generate the largest
+tile"). The SM120 block-scaled generators cross every tile with output
+variants (e5m2, FP6, FP4 + block-scale-factor output) that only compile at
+large tile N: the epilogue smem atom, the FP6 ElementD contiguous-extent
+constraint, and the SFVecSize divisibility constraint all reject the small-N
+tiles. If a small-N tile is first in the list, the default sm_120a/121a
+library build fails with static asserts before a single kernel is usable.
+"""
+
+import unittest
+
+from cutlass_library import generator
+from cutlass_library.library import GemmKind
+
+
+class _RecordingManifest:
+  """Minimal manifest stub: empty kernel filter (the default-build path),
+  records every generated operation."""
+
+  def __init__(self):
+    self.kernel_filter = ''
+    self.operations = []
+
+  def append(self, operation):
+    self.operations.append(operation)
+
+
+class TestSm120BlockScaledDefaultTiles(unittest.TestCase):
+
+  GENERATORS = (
+    generator.GenerateSM120_TensorOp_mixed_8bits_UMMA_gemm_with_block_scaled,
+    generator.GenerateSM120_TensorOp_fp4_UMMA_gemm_with_block_scaled,
+  )
+
+  GEMM_KINDS = (
+    GemmKind.BlockScaledUniversal3x,
+    GemmKind.GroupedBlockScaledUniversal3x,
+  )
+
+  def _default_set_operations(self, generate_fn, gemm_kind):
+    manifest = _RecordingManifest()
+    generate_fn(manifest, cuda_version='12.8.0', gemm_kind=gemm_kind)
+    return manifest.operations
+
+  def test_default_set_uses_largest_tile(self):
+    """Every op in the default set must use the family's largest tile:
+    small-N tiles do not support all generated output variants."""
+    for generate_fn in self.GENERATORS:
+      for gemm_kind in self.GEMM_KINDS:
+        with self.subTest(generator=generate_fn.__name__, gemm_kind=gemm_kind):
+          operations = self._default_set_operations(generate_fn, gemm_kind)
+          self.assertTrue(operations, 'generator emitted no operations')
+          for op in operations:
+            m, n, k = op.tile_description.threadblock_shape
+            self.assertGreaterEqual(
+              n, 128,
+              f'{op.procedural_name()}: default set selected TileN={n}; '
+              'small-N tiles do not compile for all of this family\'s '
+              'output variants (see epilogue smem atom / FP6 ElementD / '
+              'SFVecSize constraints)')
+
+  def test_full_set_still_contains_small_n_tiles(self):
+    """A non-empty kernel filter must still instantiate the small-N tiles;
+    the fix reorders the tile lists, it must not remove entries."""
+    for generate_fn in self.GENERATORS:
+      manifest = _RecordingManifest()
+      manifest.kernel_filter = '*'  # non-empty: full tile list
+      generate_fn(manifest, cuda_version='12.8.0',
+                  gemm_kind=GemmKind.BlockScaledUniversal3x)
+      tile_ns = {op.tile_description.threadblock_shape[1]
+                 for op in manifest.operations}
+      with self.subTest(generator=generate_fn.__name__):
+        self.assertIn(8, tile_ns)
+        self.assertIn(16, tile_ns)
+        self.assertIn(128, tile_ns)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
## Problem

A default CUTLASS library / profiler build for SM120-class GPUs — including SM121 (DGX Spark), using the flag set suggested in the Quick Start Guide —

```bash
cmake .. -DCUTLASS_NVCC_ARCHS=121a -DCUTLASS_ENABLE_TESTS=OFF -DCUTLASS_UNITY_BUILD_ENABLED=ON
make cutlass_profiler -j
```

fails with static asserts in every SM120 block-scaled (`bstensorop`) GEMM shard whose data types touch FP4/FP6 or block-scale-factor output. Representative failures (CUDA 13.0, `sm_121a`):

```
include/cutlass/gemm/collective/builders/sm90_common.inl(321): error: static assertion failed with
  "BLK_K0 must be a multiple of size<1>(GMMA::Layout_K_INTER_Atom<ElementType>{})"
  [cutlass3x_sm120_bstensorop_gemm_..._void_e5m2_128x8x128_..._cooperative_q]

include/cute/atom/copy_atom.hpp(206): error: static assertion failed with
  "TiledCopy uses too few vals for selected CopyAtom"
  [cutlass3x_sm120_bstensorop_gemm_ue8m0xe2m1_ue8m0xe2m3_f32_void_f32_128x8x128_..._cooperative_q]

include/cutlass/epilogue/fusion/sm120_visitor_store_tma_warpspecialized.hpp(72): error: static assertion failed with
  "EpilogueTileN should be divisible by SFVecSize"
  [cutlass3x_sm120_bstensorop_gemm_ue4m3xe2m1_ue4m3xe2m1_f32_f16_ue8m0xe2m1_128x8x128_..._epiVs16t]

include/cutlass/epilogue/collective/builders/sm120_builder.inl(158): error: static assertion failed with
  "CTA tile for FP6 ElementD must have a contiguous extent that is a multiple of 128."
```

The consequence is that no NVFP4/MXFP4/FP6 block-scaled GEMM is buildable through the library on SM120/SM121 without hand-maintained `CUTLASS_LIBRARY_EXCLUDE_KERNELS` patterns, even though the underlying kernels are fully functional at larger tiles.

### Root cause

With an empty `CUTLASS_LIBRARY_KERNELS`, `CreateGemmUniversal3xOperator` prunes each family's tile list to `tile_descriptions[0]`:

```python
# by default, only generate the largest tile and largest alignment
if manifest.kernel_filter == '':
    tile_descriptions = [tile_descriptions[0]]
```

This relies on tile lists being ordered largest-first. The SM120 block-scaled generators (`GenerateSM120_TensorOp_mixed_8bits_UMMA_gemm_with_block_scaled`, `GenerateSM120_TensorOp_fp4_UMMA_gemm_with_block_scaled`) list their tiles smallest-first, so the default set instantiates the family **exclusively** at `128x8x128` (cooperative) / `128x16x128` (pingpong), crossed with every output variant the generators emit. Several of those combinations cannot compile at small tile N:

- narrow-byte `ElementD` (`e5m2`, `e2m1`) — no valid epilogue smem atom at N=8 (and N=16 pingpong for `e2m1`+SFD)
- FP6 `ElementD` — requires a contiguous CTA extent that is a multiple of 128
- block-scale-factor output — epilogue tile N (= min(CTA_N, 32)) must be divisible by `SFVecSize`
- FP6 **B** operand — `SM100_SU6_DU8x16_x4_LDSM_N` needs per-MMA-atom N ≥ 16 (fails at N=8 cooperative and N=16 pingpong)

The same combinations compile at `128x128x128`, which was `tile_descriptions[0]` before the small-N tiles were added.

## Fix

Reorder `tile_sizes_cooperative` / `tile_sizes_pingpong` in the two SM120 block-scaled generator functions to largest-first, restoring the `tile_descriptions[0]` convention. The default set then selects `128x128x128`, which compiles for every generated dtype/output combination. No tiles are removed: builds with a non-empty `CUTLASS_LIBRARY_KERNELS` still instantiate the full lists, including the small-N tiles for skinny-N problems.

Add a regression test, `test/python/cutlass_library/test_sm120_blockscaled_default_tiles.py` (pure Python, no GPU required):

- default-set path (empty kernel filter) must select TileN ≥ 128 for both generators and both dense/grouped kinds — fails on current `main` (TileN=8 selected), passes with this change;
- non-empty-filter path must still contain the N=8/16 tiles, guarding against fixing this by deletion.

```bash
PYTHONPATH=python python3 test/python/cutlass_library/test_sm120_blockscaled_default_tiles.py
```

## Validation

Tested on NVIDIA DGX Spark (GB10, SM121) with CUDA 13.0.88.

- Generator run for `121a`, empty kernel filter, no excludes: 500 `bstensorop` kernels emitted, all `128x128x128` (previously: all `128x8x128`/`128x16x128`, of which large subsets fail to compile).
- Full default `cutlass_profiler` build for `121a` with **no** `CUTLASS_LIBRARY_EXCLUDE_KERNELS`: completes with 0 errors (previously fails in every FP4/FP6-touching shard).
- Runtime sweep: all 484 block-scaled kernels in the resulting profiler binary executed at `m=n=k=1024`, one process per kernel: **484/484 passed**, including NVFP4×NVFP4 with FP4-requantization output (`LinCombBlockScaleFactor`) and grouped variants.
- New regression test: passes with this change; fails on current `main` (4 failures, default set selects TileN=8).
- `git diff --check` passes.
