### PR TITLE
Fix the atomicCAS retry condition in SubbyteReference::set()

### DIFF
--- a/include/cutlass/subbyte_reference.h
+++ b/include/cutlass/subbyte_reference.h
@@ -815,29 +815,30 @@ public:
     if(high_storage_unit_idx_ != low_storage_unit_idx_){
       /// Only need update 2 storage unit at once.
       /// consider misaligned address issue, we need to do atomicCAS twice 
-      StorageUnit original_low_bits, original_high_bits, update_low_bits, update_high_bits;
+      StorageUnit assumed;
+      StorageUnit original = ((*ptr_)[low_storage_unit_idx_]);
       do {
-        original_low_bits  = ((*ptr_)[low_storage_unit_idx_]);
-        update_low_bits  = (original_low_bits & kLowUpdateMask) | low_new_bits;
-        original_low_bits = atomicCAS(&((*ptr_)[low_storage_unit_idx_]), original_low_bits, update_low_bits);
-      } while (update_low_bits != original_low_bits);
+        assumed = original;
+        StorageUnit updated = StorageUnit((assumed & kLowUpdateMask) | low_new_bits);
+        original = atomicCAS(&((*ptr_)[low_storage_unit_idx_]), assumed, updated);
+      } while (original != assumed);
+
+      original = ((*ptr_)[high_storage_unit_idx_]);
       do {
-        original_high_bits = ((*ptr_)[high_storage_unit_idx_]);
-        update_high_bits  = (original_high_bits & kHighUpdateMask) | high_new_bits;
-        original_high_bits = atomicCAS(&((*ptr_)[high_storage_unit_idx_]), original_high_bits, update_high_bits);
-      } while (update_high_bits != original_high_bits);
+        assumed = original;
+        StorageUnit updated = StorageUnit((assumed & kHighUpdateMask) | high_new_bits);
+        original = atomicCAS(&((*ptr_)[high_storage_unit_idx_]), assumed, updated);
+      } while (original != assumed);
     }
     else {
       /// Only need update 1 storage unit.
-      StorageUnit original, updated;
+      StorageUnit assumed;
+      StorageUnit original = ((*ptr_)[low_storage_unit_idx_]);
       do {
-        original = ((*ptr_)[low_storage_unit_idx_]);
-
-        updated = (original & kLowUpdateMask) | low_new_bits;
-
-        original = atomicCAS(&((*ptr_)[low_storage_unit_idx_]), original, updated);
-
-      } while (updated != original);
+        assumed = original;
+        StorageUnit updated = StorageUnit((assumed & kLowUpdateMask) | low_new_bits);
+        original = atomicCAS(&((*ptr_)[low_storage_unit_idx_]), assumed, updated);
+      } while (original != assumed);
     }
 #else
 

--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -45,4 +45,5 @@ cutlass_test_unit_add_executable(
   numeric_conversion_subbyte.cu
   fast_numeric_conversion.cu
   functional.cu
+  subbyte_reference.cu
   )

--- a/test/unit/core/subbyte_reference.cu
+++ b/test/unit/core/subbyte_reference.cu
@@ -1,0 +1,185 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Unit tests for device-side SubbyteReference stores.
+
+    Element types whose bit width does not divide the storage unit (the 6-bit types) are
+    stored across two storage units, so a store is a read-modify-write over bits shared with
+    neighbouring elements. These tests pin the observable contract of that path: a store must
+    land exactly, and it must not disturb an element a concurrent thread owns.
+*/
+
+#include "../common/cutlass_unit_test.h"
+
+#include "cutlass/subbyte_reference.h"
+#include "cutlass/float_subbyte.h"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/util/host_tensor.h"
+
+namespace test {
+namespace core {
+
+/// Element payload is the low sizeof_bits<Element> bits of the storage byte.
+template <typename Element>
+CUTLASS_HOST_DEVICE Element element_from_payload(int payload) {
+  constexpr int kMask = (1 << cutlass::sizeof_bits<Element>::value) - 1;
+  Element e{};
+  e.storage = static_cast<decltype(e.storage)>(payload & kMask);
+  return e;
+}
+
+template <typename Element>
+CUTLASS_HOST_DEVICE int payload_of(Element e) {
+  constexpr int kMask = (1 << cutlass::sizeof_bits<Element>::value) - 1;
+  return static_cast<int>(e.storage) & kMask;
+}
+
+/// One thread per element: every store races with the stores to its neighbours.
+template <typename Element>
+__global__ void scatter_kernel(Element *ptr, int n) {
+  int i = int(blockIdx.x) * int(blockDim.x) + int(threadIdx.x);
+  if (i < n) {
+    cutlass::SubbyteReference<Element> ref(ptr, i);
+    ref.set(element_from_payload<Element>(i * 7 + 1));
+  }
+}
+
+template <typename Element>
+__global__ void gather_kernel(int *out, Element *ptr, int n) {
+  int i = int(blockIdx.x) * int(blockDim.x) + int(threadIdx.x);
+  if (i < n) {
+    cutlass::SubbyteReference<Element> ref(ptr, i);
+    out[i] = payload_of<Element>(ref.get());
+  }
+}
+
+/// Single thread walking every offset, so both the one-unit and the straddling branch are
+/// exercised deterministically rather than by scheduling luck.
+template <typename Element>
+__global__ void sweep_kernel(int *out, Element *ptr, int n) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+  for (int i = 0; i < n; ++i) {
+    cutlass::SubbyteReference<Element> ref(ptr, i);
+    ref.set(element_from_payload<Element>(i * 5 + 3));
+  }
+  for (int i = 0; i < n; ++i) {
+    cutlass::SubbyteReference<Element> ref(ptr, i);
+    out[i] = payload_of<Element>(ref.get());
+  }
+}
+
+template <typename Element>
+void run_concurrent_test() {
+  int const kElements = 4096;
+
+  cutlass::HostTensor<Element, cutlass::layout::RowMajor> data({kElements, 1});
+  cutlass::HostTensor<int, cutlass::layout::RowMajor> observed({kElements, 1});
+
+  for (int i = 0; i < kElements; ++i) {
+    data.at({i, 0}) = element_from_payload<Element>(0);
+    observed.at({i, 0}) = -1;
+  }
+  data.sync_device();
+  observed.sync_device();
+
+  dim3 grid((kElements + 127) / 128, 1);
+  dim3 block(128, 1);
+
+  scatter_kernel<Element><<<grid, block>>>(data.device_data(), kElements);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "Kernel launch error.";
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  gather_kernel<Element><<<grid, block>>>(observed.device_data(), data.device_data(), kElements);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "Kernel launch error.";
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  observed.sync_host();
+
+  int errors = 0;
+  for (int i = 0; i < kElements && errors < 8; ++i) {
+    int expected = payload_of<Element>(element_from_payload<Element>(i * 7 + 1));
+    if (observed.at({i, 0}) != expected) {
+      ++errors;
+      EXPECT_EQ(observed.at({i, 0}), expected) << "element " << i;
+    }
+  }
+}
+
+template <typename Element>
+void run_sweep_test() {
+  int const kElements = 256;
+
+  cutlass::HostTensor<Element, cutlass::layout::RowMajor> data({kElements, 1});
+  cutlass::HostTensor<int, cutlass::layout::RowMajor> observed({kElements, 1});
+
+  for (int i = 0; i < kElements; ++i) {
+    data.at({i, 0}) = element_from_payload<Element>(0);
+    observed.at({i, 0}) = -1;
+  }
+  data.sync_device();
+  observed.sync_device();
+
+  sweep_kernel<Element><<<dim3(1, 1), dim3(1, 1)>>>(observed.device_data(), data.device_data(), kElements);
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "Kernel launch error.";
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  observed.sync_host();
+
+  int errors = 0;
+  for (int i = 0; i < kElements && errors < 8; ++i) {
+    int expected = payload_of<Element>(element_from_payload<Element>(i * 5 + 3));
+    if (observed.at({i, 0}) != expected) {
+      ++errors;
+      EXPECT_EQ(observed.at({i, 0}), expected) << "element " << i;
+    }
+  }
+}
+
+} // namespace core
+} // namespace test
+
+TEST(SubbyteReference, e2m3_device_store_sweep) {
+  test::core::run_sweep_test<cutlass::float_e2m3_t>();
+}
+
+TEST(SubbyteReference, e3m2_device_store_sweep) {
+  test::core::run_sweep_test<cutlass::float_e3m2_t>();
+}
+
+TEST(SubbyteReference, e2m3_device_store_concurrent_neighbours) {
+  test::core::run_concurrent_test<cutlass::float_e2m3_t>();
+}
+
+TEST(SubbyteReference, e3m2_device_store_concurrent_neighbours) {
+  test::core::run_concurrent_test<cutlass::float_e3m2_t>();
+}


### PR DESCRIPTION
`SubbyteReference::set()`'s device path is a compare-and-swap loop over a storage unit shared with neighbouring elements. the multi-storage-unit specialization exits on `updated != cas_return`, which is not the read-modify-write retry contract: [`atomicCAS` returns the value that was already in memory](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomiccas), so a CAS that successfully changes the slot returns the *old* value and never the new one. the loop therefore does not stop when it succeeds. it goes around again, re-reads the slot, recomputes the same bits, and issues a second CAS purely to observe its own write. every store through this path costs at least two atomics, and under contention it keeps re-entering a race it has already won.

this is the same defect that was fixed for `ConstSubbyteReference` in 4.5 ("Fix atomicCAS read-modify-write loop in `ConstSubbyteReference`" in the [changelog](https://github.com/NVIDIA/cutlass/blob/main/CHANGELOG.md)), and the sibling specialization higher up in this same file already uses the correct `assumed` / `original` form. the three loops in the multi-storage-unit specialization were missed. closes #3428.

the fix is the standard idiom: seed `original` once, then reuse the CAS return as the next `assumed`.

### which types this actually touches

this specialization is selected when `sizeof_bits<StorageUnit> % sizeof_bits<Element> != 0`, which in practice means the 6-bit types, `float_e2m3_t` and `float_e3m2_t`. it is the scalar element store reached through `TensorRef::Reference`, not the tensor-core mainloop, so the blast radius is element-wise access on packed fp6 tensors rather than GEMM inner loops.

### numbers

measured through the real `cutlass::SubbyteReference<float_e2m3_t>::set()` path rather than a replica, by compiling one benchmark against the upstream and the patched include tree. rtx 5070 ti (sm_120), cuda 13.0.3, driver 610.74, medians of 9 runs:

| | upstream | patched |
| --- | --- | --- |
| contended stores | 105.0 ms `[104.2, 106.1]` | 44.6 ms `[44.3, 45.3]` |
| disjoint stores | 0.12 ms | 0.08 ms |

2.35x on the contended case, with non-overlapping ranges. clocks were not locked on this part, which is why medians and ranges are reported instead of a single number. a separate isolated reproduction of the two loop forms counts the CAS operations directly: 2 versus 1 for a single uncontended store, and a mean of 268 versus 1.98 with 4096 threads on one field.

### what the new tests prove, and what they do not

`test/unit/core/subbyte_reference.cu` is new; there was no coverage for this class at all. it walks every offset in a container so both the straddling and the single-unit branch are exercised deterministically rather than by scheduling luck, and it runs one thread per element so every store races its neighbours.

being straight about it: these tests pass on unpatched main as well. the old loop does converge, it just pays for it, so no correctness test can catch this. the tests are here to hold the store contract while the loop is rewritten, and the measurements above are what justify rewriting it.

### verified

- 505/505 `cutlass_test_unit_core` green on sm_120a, both before and after the header change
- the host path (`#else`) and the sibling specialization are untouched
- diff is functional only: no copyright header edits, no reformatting, no whitespace churn

@hwu36 flagging for routing since you've taken the recent core C++ correctness fixes (#3427, #3244, #3048). happy to add coverage elsewhere or re-measure with locked clocks if that would help.
