### PR TITLE
feat(sm120): add tileN = 8,16 for the dense F8F6F4 GEMM

### DIFF
--- a/include/cutlass/gemm/collective/builders/sm120_mma_builder.inl
+++ b/include/cutlass/gemm/collective/builders/sm120_mma_builder.inl
@@ -147,7 +147,7 @@ struct CollectiveBuilder<
                 "Unsupported kernel schedule by this collective mainloop dispatch policy.");                                                                    
 
   using SmemCopyAtomA = Copy_Atom<decltype(detail::sm120_rr_smem_copy_selector_A<ElementA, ElementB, UseF8f6f4>()), SmemAllocTypeA>;
-  using SmemCopyAtomB = Copy_Atom<decltype(detail::sm120_rr_smem_copy_selector_B<ElementA, ElementB, UseF8f6f4>()), SmemAllocTypeB>;
+  using SmemCopyAtomB = Copy_Atom<decltype(detail::sm120_rr_smem_copy_selector_B<ElementA, ElementB, UseF8f6f4, size<1>(TileShape_MNK{})>()), SmemAllocTypeB>;
 
   using CollectiveOp = CollectiveMma<
       DispatchPolicy,

--- a/test/unit/gemm/device/sm120_tensorop_gemm/sm120_gemm_f8_f8_f32_tensor_op.cu
+++ b/test/unit/gemm/device/sm120_tensorop_gemm/sm120_gemm_f8_f8_f32_tensor_op.cu
@@ -108,4 +108,212 @@ TEST(SM120_Device_Gemm_fe4m3t_fe4m3n_f32n_tensor_op_f32, 128x64x64_1x1x1) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+TEST(SM120_Device_Gemm_fe4m3t_fe4m3n_f32n_tensor_op_f32, 128x32x64_1x1x1) {
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = float;
+  using ElementD = float;
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::ColumnMajor;
+  using LayoutD = cutlass::layout::ColumnMajor;
+
+  static constexpr int Alignment = 16;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+  using TileShape = Shape<_128,_32,_64>;
+  using ClusterShape = Shape<_1,_1,_1>;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      TileShape, ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator, ElementCompute,
+      ElementC, LayoutC, AlignmentC,
+      ElementD, LayoutD, AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto
+    >::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      ElementA, LayoutA, Alignment,
+      ElementB, LayoutB, Alignment,
+      ElementAccumulator,
+      TileShape, ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::collective::KernelScheduleAuto
+    >::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int,int,int,int>,
+      CollectiveMainloop,
+      CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  bool result = test::gemm::device::TestSmall<Gemm, true>(1.0, 0.0);
+  EXPECT_TRUE(result);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+TEST(SM120_Device_Gemm_fe4m3t_fe4m3n_f32n_tensor_op_f32, 128x16x64_1x1x1) {
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = float;
+  using ElementD = float;
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::ColumnMajor;
+  using LayoutD = cutlass::layout::ColumnMajor;
+
+  static constexpr int Alignment = 16;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+  using TileShape = Shape<_128,_16,_64>;
+  using ClusterShape = Shape<_1,_1,_1>;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      TileShape, ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator, ElementCompute,
+      ElementC, LayoutC, AlignmentC,
+      ElementD, LayoutD, AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto
+    >::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      ElementA, LayoutA, Alignment,
+      ElementB, LayoutB, Alignment,
+      ElementAccumulator,
+      TileShape, ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::collective::KernelScheduleAuto
+    >::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int,int,int,int>,
+      CollectiveMainloop,
+      CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  bool result = test::gemm::device::TestSmall<Gemm, true>(1.0, 0.0);
+  EXPECT_TRUE(result);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+TEST(SM120_Device_Gemm_fe4m3t_fe4m3n_f32n_tensor_op_f32, 128x8x64_1x1x1) {
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = float;
+  using ElementD = float;
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::ColumnMajor;
+  using LayoutD = cutlass::layout::ColumnMajor;
+
+  static constexpr int Alignment = 16;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+  using TileShape = Shape<_128,_8,_64>;
+  using ClusterShape = Shape<_1,_1,_1>;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      TileShape, ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator, ElementCompute,
+      ElementC, LayoutC, AlignmentC,
+      ElementD, LayoutD, AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto
+    >::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      ElementA, LayoutA, Alignment,
+      ElementB, LayoutB, Alignment,
+      ElementAccumulator,
+      TileShape, ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::collective::KernelScheduleAuto
+    >::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int,int,int,int>,
+      CollectiveMainloop,
+      CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  bool result = test::gemm::device::TestSmall<Gemm, true>(1.0, 0.0);
+  EXPECT_TRUE(result);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+TEST(SM120_Device_Gemm_fe4m3t_fe4m3n_f32n_tensor_op_f32, 128x8x64_1x1x1_pingpong) {
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = float;
+  using ElementD = float;
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::ColumnMajor;
+  using LayoutD = cutlass::layout::ColumnMajor;
+
+  static constexpr int Alignment = 16;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+  using TileShape = Shape<_128,_8,_64>;
+  using ClusterShape = Shape<_1,_1,_1>;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      TileShape, ClusterShape,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator, ElementCompute,
+      ElementC, LayoutC, AlignmentC,
+      ElementD, LayoutD, AlignmentD,
+      cutlass::epilogue::collective::EpilogueScheduleAuto
+    >::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+      ElementA, LayoutA, Alignment,
+      ElementB, LayoutB, Alignment,
+      ElementAccumulator,
+      TileShape, ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::KernelTmaWarpSpecializedPingpong
+    >::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int,int,int,int>,
+      CollectiveMainloop,
+      CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  bool result = test::gemm::device::TestSmall<Gemm, true>(1.0, 0.0);
+  EXPECT_TRUE(result);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 #endif // (defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED) || defined(CUTLASS_ARCH_MMA_SM121_SUPPORTED))


### PR DESCRIPTION
`sm120_rr_smem_copy_selector_B` has taken a `TileShapeN` parameter since #3292, and uses it to pick between the 1-, 2- and 4-matrix `ldmatrix` atoms. The block-scaled builder passes the real tile width. The dense F8F6F4 builder never does, so it always resolves to the default of 32 and takes the 4-matrix atom no matter how narrow the tile is.

The result is that any tile narrower than 32 fails to build, and it fails with a message that never names the tile as the cause:

```
cute/atom/copy_atom.hpp(206): error: static assertion failed with
  "TiledCopy uses too few vals for selected CopyAtom"
```

This forwards `size<1>(TileShape_MNK{})` exactly the way the block-scaled builder already does. 128x16 and 128x8 go from not building to building and computing correctly. It's the same narrow-tile capability #3176 and #3292 added on the block-scaled side, which the dense path never picked up.

### why this cannot change an existing kernel

Every branch of the selector is `TileShapeN < 16` → x1, `< 32` → x2, else x4, and the default is 32. Any tile with N >= 32 therefore resolves to the identical atom it resolves to today. The only configurations whose behaviour changes are ones that currently fail to compile, so there is no kernel in the library or the profiler that this can move.

### verified

RTX 5070 Ti (sm_120a), CUDA 13.0.3, driver 610.74, reference checks via `TestSmall`:

| tile | before | after |
| --- | --- | --- |
| 128x64x64, 128x32x64 | builds, passes | builds, passes |
| 128x16x64, 128x8x64 | **fails to compile** | builds, passes |

Beyond what's in the test file, I ran a wider matrix while narrowing this down: `e4m3` and `e5m2`, cooperative and pingpong, N = 64/32/16/8, all passing. Pingpong at N=8 is covered in the committed tests specifically because that's the shape that produced reference failures on the block-scaled path during #3292 review.

Non-regression: full SM120 tensorop suite green, **35/35** across `tensorop_f32_sm120` (15), `tensorop_f16_sm120` (14) and `sm120_grouped_gemm_device_tensorop` (6).

Tests go into the existing `sm120_gemm_f8_f8_f32_tensor_op.cu` alongside the 128x64x64 case, matching the one-test-per-tile-shape layout the block-scaled narrow-N tests already use, so there's no new file and no CMakeLists change.

### deliberately not included

The array, sparse and blockwise SM120 builders have the same omission. I left them alone because each needs its own verification matrix and I've only proven the dense F8F6F4 path on hardware I have. Happy to extend in a follow-up if you want them, or to fold them in here if you'd rather it land as one change.

Two things I checked and they are pre-existing, not affected by this: sub-8-bit operands (`e2m1`) don't build on this builder at N=64 or N=32 either, so that's a separate constraint; and `cutlass_library` emits 128x16 and 128x8 only for the block-scaled generators, so nothing currently shipped was broken by the missing forward.

@depaulmillz you're the closest thing to an owner I can identify from blame here, since #3176 is where small tile N started and this is the sibling builder that didn't get it. Point me at someone else if that's not right.
