### PR TITLE
[CuTeDSL] Skip the numpy round-trip for in-range integer scalars

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/typing.py
+++ b/python/CuTeDSL/cutlass/base_dsl/typing.py
@@ -10,6 +10,7 @@
 # is strictly prohibited.
 
 import ctypes
+import math
 from abc import abstractmethod
 from itertools import chain
 import numpy as np
@@ -551,6 +552,9 @@ class IntegerMeta(NumericMeta):
     """
 
     signed: bool
+    # Value range that ``_np_dtype`` stores exactly, or None when there is no
+    # numpy dtype to store into. See ``Integer.__init__``.
+    _exact_range: Optional[tuple[int, int]]
 
     def __new__(
         cls,
@@ -590,6 +594,19 @@ class IntegerMeta(NumericMeta):
             cls, name, bases, attrs | new_attrs, width, np_dtype, mlir_type, is_abstract
         )
         new_cls.signed = signed
+        # Precomputed once per type so ``Integer.__init__`` can range-check without
+        # rebuilding the bounds on every construction. These track ``np_dtype``
+        # rather than ``width``, because the numpy cast is what they must agree
+        # with, and a few subclasses (WgmmaSmemDesc) patch ``width`` afterwards.
+        if np_dtype is None:
+            new_cls._exact_range = None
+        elif width == 1:
+            # np.bool_ folds everything nonzero to True, so only 0 and 1 survive
+            # the cast unchanged.
+            new_cls._exact_range = (0, 1)
+        else:
+            info = np.iinfo(np_dtype)
+            new_cls._exact_range = (int(info.min), int(info.max))
         return new_cls
 
     def __str__(cls) -> str:
@@ -1718,6 +1735,7 @@ class Integer(Numeric, metaclass=IntegerMeta, mlir_type=T.i32, is_abstract=True)
 
     # Injected by IntegerMeta.__new__ on every concrete subclass.
     signed: ClassVar[bool]
+    _exact_range: ClassVar[Optional[tuple[int, int]]]
 
     def __init__(
         self,
@@ -1736,14 +1754,25 @@ class Integer(Numeric, metaclass=IntegerMeta, mlir_type=T.i32, is_abstract=True)
         if isinstance(x, (bool, int, float)):
             # Add check for NaN before numpy conversion
             if isinstance(x, float):
-                if np.isnan(x):
+                if math.isnan(x):
                     raise ValueError("Cannot convert float NaN to integer")
-                elif np.isinf(x):
+                elif math.isinf(x):
                     raise OverflowError("Cannot convert float infinity to integer")
 
-            np_dtype = ty.numpy_dtype
-            assert np_dtype is not None, f"expects numpy.dtype, but got {np_dtype}"
-            x_val = int(np.array(x).astype(np_dtype))
+            exact_range = ty._exact_range
+            if exact_range is not None and exact_range[0] <= x <= exact_range[1]:
+                # Already representable, so the cast below would round-trip the
+                # value unchanged. int() truncates floats toward zero and folds
+                # bools to 0/1, which is what astype does for this range too.
+                x_val = int(x)
+            else:
+                # Out of range: defer to numpy for the wrap-around (or the
+                # overflow it raises on values wider than the dtype). _exact_range
+                # is None exactly when there is no dtype to cast to, so this is
+                # still where an unsupported width is rejected.
+                np_dtype = ty.numpy_dtype
+                assert np_dtype is not None, f"expects numpy.dtype, but got {np_dtype}"
+                x_val = int(np.array(x).astype(np_dtype))
         elif type(x) == ty:
             x_val = x.value  # type: ignore[assignment]
         elif isinstance(x, ir.Value):

--- a/test/python/CuTeDSL/test_numeric_construction.py
+++ b/test/python/CuTeDSL/test_numeric_construction.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for constructing Integer types from Python scalars.
+
+`Integer.__init__` skips the numpy round-trip when the incoming value is
+already representable in the target dtype, since the cast would return it
+unchanged. The tests below pin that shortcut to the numpy cast it replaces:
+the same stored value for in-range input, the same wrap-around for out-of-range
+input, and the same exceptions for values numpy refuses outright.
+
+No GPU or compilation is involved, so these run anywhere.
+"""
+
+import math
+import unittest
+
+import numpy as np
+
+import cutlass
+from cutlass import (
+    Boolean,
+    Int4,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    Int128,
+    Uint8,
+    Uint16,
+    Uint32,
+    Uint64,
+    Uint128,
+)
+
+# Integer types backed by a numpy dtype, so a cast reference exists.
+CASTABLE = [Boolean, Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64]
+
+# Widths with no numpy dtype. Constructing these from a Python scalar has always
+# tripped the assert in Integer.__init__, and the shortcut must not start
+# quietly accepting them.
+NOT_CASTABLE = [Int4, Int128, Uint128]
+
+# Boundaries, wrap-around candidates, and values wider than any supported dtype.
+INT_VALUES = [
+    0,
+    1,
+    -1,
+    5,
+    127,
+    128,
+    255,
+    256,
+    -128,
+    -129,
+    32767,
+    32768,
+    -32768,
+    -32769,
+    65535,
+    65536,
+    123456789,
+    2**31 - 1,
+    2**31,
+    -(2**31),
+    -(2**31) - 1,
+    2**32 - 1,
+    2**32,
+    -(2**32),
+    2**63 - 1,
+    2**63,
+    -(2**63),
+    -(2**63) - 1,
+    2**64 - 1,
+    2**64,
+    2**128,
+    10**30,
+    -(10**30),
+]
+
+BOOL_VALUES = [True, False]
+
+# Only floats whose truncation is well defined for the dtype under test are
+# checked against numpy: casting an out-of-range float is undefined behavior in
+# numpy and merely warns, so there is no meaningful reference to compare with.
+FLOAT_VALUES = [0.0, -0.0, 0.5, -0.5, 1.0, -1.0, 3.7, -3.7, 99.9, -99.9]
+
+
+def numpy_reference(dtype, x):
+    """The cast Integer.__init__ used to perform unconditionally."""
+    return int(np.array(x).astype(dtype))
+
+
+class TestIntegerFromPythonScalar(unittest.TestCase):
+    def test_matches_numpy_cast(self):
+        """The shortcut and the numpy cast agree, value for value.
+
+        Where numpy refuses the input outright (integers too wide for any C
+        type), the same exception must still surface.
+        """
+        for ty in CASTABLE:
+            for x in INT_VALUES + BOOL_VALUES + FLOAT_VALUES:
+                if isinstance(x, float) and not (
+                    ty._exact_range[0] <= x <= ty._exact_range[1]
+                ):
+                    continue
+                with self.subTest(dtype=ty.__name__, value=x):
+                    try:
+                        expected = numpy_reference(ty.numpy_dtype, x)
+                    except OverflowError:
+                        with self.assertRaises(OverflowError):
+                            ty(x)
+                    else:
+                        self.assertEqual(ty(x).value, expected)
+
+    def test_in_range_values_are_preserved(self):
+        """Spot-check the shortcut itself rather than its agreement with numpy."""
+        self.assertEqual(Int32(5).value, 5)
+        self.assertEqual(Int32(-5).value, -5)
+        self.assertEqual(Int32(2**31 - 1).value, 2**31 - 1)
+        self.assertEqual(Int32(-(2**31)).value, -(2**31))
+        self.assertEqual(Uint8(255).value, 255)
+        self.assertEqual(Int64(2**63 - 1).value, 2**63 - 1)
+        self.assertEqual(Uint64(2**64 - 1).value, 2**64 - 1)
+
+    def test_out_of_range_values_still_wrap(self):
+        """Values outside the dtype keep the C wrap-around numpy provides."""
+        self.assertEqual(Int32(2**31).value, -(2**31))
+        self.assertEqual(Int32(2**32 + 5).value, 5)
+        self.assertEqual(Int8(128).value, -128)
+        self.assertEqual(Int8(-129).value, 127)
+        self.assertEqual(Uint8(256).value, 0)
+        self.assertEqual(Uint8(-1).value, 255)
+        self.assertEqual(Uint16(65536 + 7).value, 7)
+
+    def test_floats_truncate_toward_zero(self):
+        self.assertEqual(Int32(3.7).value, 3)
+        self.assertEqual(Int32(-3.7).value, -3)
+        self.assertEqual(Int32(0.5).value, 0)
+        self.assertEqual(Int32(-0.5).value, 0)
+        self.assertEqual(Int8(99.9).value, 99)
+
+    def test_bools_fold_to_zero_and_one(self):
+        """bool is an int subclass, so it reaches the same path as an int."""
+        for ty in CASTABLE:
+            with self.subTest(dtype=ty.__name__):
+                self.assertEqual(ty(True).value, 1)
+                self.assertEqual(ty(False).value, 0)
+
+    def test_boolean_folds_nonzero_to_one(self):
+        """Boolean stores 0/1, never the value it was handed."""
+        self.assertEqual(Boolean(0).value, 0)
+        self.assertEqual(Boolean(1).value, 1)
+        self.assertEqual(Boolean(-1).value, 1)
+        self.assertEqual(Boolean(5).value, 1)
+        self.assertEqual(Boolean(256).value, 1)
+        self.assertEqual(Boolean(3.7).value, 1)
+
+    def test_nan_and_infinity_are_rejected(self):
+        """Boolean is exempt: it runs bool() first, so the float never reaches
+        the guard. Every other integer type rejects both."""
+        for ty in CASTABLE:
+            if ty is Boolean:
+                continue
+            with self.subTest(dtype=ty.__name__):
+                with self.assertRaises(ValueError):
+                    ty(math.nan)
+                with self.assertRaises(OverflowError):
+                    ty(math.inf)
+                with self.assertRaises(OverflowError):
+                    ty(-math.inf)
+
+    def test_boolean_folds_nan_and_infinity_to_true(self):
+        """Pins the exemption above, which predates the shortcut."""
+        self.assertEqual(Boolean(math.nan).value, 1)
+        self.assertEqual(Boolean(math.inf).value, 1)
+        self.assertEqual(Boolean(-math.inf).value, 1)
+
+    def test_widths_without_a_numpy_dtype_are_rejected(self):
+        """Int4/Int128/Uint128 have no numpy dtype and must keep failing.
+
+        The shortcut sits behind the same guard as the cast, so these still
+        raise instead of silently gaining support.
+        """
+        for ty in NOT_CASTABLE:
+            with self.subTest(dtype=ty.__name__):
+                self.assertIsNone(ty.numpy_dtype)
+                self.assertIsNone(ty._exact_range)
+                for x in (0, 1, 5, -1, 3.7, True):
+                    with self.assertRaises(AssertionError):
+                        ty(x)
+
+    def test_exact_range_tracks_the_numpy_dtype(self):
+        for ty in CASTABLE:
+            with self.subTest(dtype=ty.__name__):
+                if ty is Boolean:
+                    self.assertEqual(ty._exact_range, (0, 1))
+                    continue
+                info = np.iinfo(ty.numpy_dtype)
+                self.assertEqual(ty._exact_range, (int(info.min), int(info.max)))
+
+    def test_range_follows_the_dtype_not_the_width(self):
+        """A subclass may widen `width` after the class is built.
+
+        WgmmaSmemDesc and Tcgen05SmemDesc do exactly this, which leaves their
+        `min`/`max` describing a wider type than the dtype they actually cast
+        through. The shortcut has to agree with the cast, so it keys off the
+        dtype's range instead of the bounds.
+        """
+
+        class _WidthPatched(Int32):
+            pass
+
+        _WidthPatched.width = Int64.width
+
+        self.assertIs(_WidthPatched.numpy_dtype, np.int32)
+        self.assertEqual(_WidthPatched._exact_range, (-(2**31), 2**31 - 1))
+        # min/max now describe 64 bits, but the value still casts through int32.
+        self.assertEqual(_WidthPatched.max, 2**63 - 1)
+        self.assertEqual(_WidthPatched(2**40).value, numpy_reference(np.int32, 2**40))
+        self.assertEqual(_WidthPatched(2**31).value, -(2**31))
+
+
+class TestIntegerFromNumericTypes(unittest.TestCase):
+    """Construction from another DSL scalar is untouched by the shortcut, but
+    it shares the storage contract, so keep it covered."""
+
+    def test_from_same_type(self):
+        self.assertEqual(Int32(Int32(5)).value, 5)
+        self.assertEqual(Uint8(Uint8(200)).value, 200)
+
+    def test_from_other_integer_type(self):
+        self.assertEqual(Int64(Int32(5)).value, 5)
+        self.assertEqual(Int8(Int32(300)).value, 44)
+        self.assertEqual(Int32(Int8(-1)).value, -1)
+
+    def test_from_float_type(self):
+        self.assertEqual(Int32(cutlass.Float32(5.7)).value, 5)
+        self.assertEqual(Int32(cutlass.Float32(-5.7)).value, -5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3443.

`Integer.__init__` sends every Python scalar through `int(np.array(x).astype(np_dtype))`, and the float path calls `np.isnan`/`np.isinf` on a Python float before that. The cast is there to reproduce C wrap-around, but it is an identity whenever the value already fits the target dtype, which is the usual case for kernel arguments. This range checks first and keeps the cast for the values that really do wrap.

`Float.__init__` already dropped its numpy conversion (the replaced code is still commented in place at the top of that method), so this is the same treatment applied to the integer side. There is nothing equivalent left to remove on the `Float32` path, and its cost is unchanged here.

### Numbers

CPython 3.12.3, numpy 2.5.2, `nvidia-cutlass-dsl` 4.7.0, no GPU. Minimum of 5 runs of 100k constructions each:

| construction | before | after | |
| --- | ---: | ---: | ---: |
| `Int32(5)` | 1165 ns | 607 ns | 1.9x |
| `Int64(5)` | 1056 ns | 651 ns | 1.6x |
| `Int32(3.7)` | 2450 ns | 693 ns | 3.5x |
| `Boolean(1)` | 1281 ns | 805 ns | 1.6x |
| 8x `Int32`, a launch prologue | 10128 ns | 4978 ns | 2.0x |
| `Int32(2**32)`, wraps | 1170 ns | 1268 ns | 0.9x |

The last row is the tradeoff: a value that wraps now pays one extra comparison before reaching the cast, roughly 100 ns against the 1.2 us the cast already costs.

### Where the bounds come from

`IntegerMeta` computes the range once per type at class creation, from `np.iinfo` on the dtype, and stores it as `_exact_range`. It deliberately follows the numpy dtype rather than `width`, because the cast is what it has to agree with and the two do not always match:

- `Boolean` is declared signed at width 1, which puts `min`/`max` at -1/0 while the dtype is `np.bool_`. It is special-cased to (0, 1), the only two values `astype(np.bool_)` leaves alone.
- `WgmmaSmemDesc` and `Tcgen05SmemDesc` assign `width` after the class is built, so their `min`/`max` describe 64 bits while they still cast through `int32`. Keying the check off `min`/`max` would make `WgmmaSmemDesc(2**40)` store 1099511627776 instead of the 0 the cast produces.

`min` and `max` themselves are untouched.

### Behavior

Unchanged, including the parts that are arguably surprising:

- Out-of-range values keep numpy's wrap-around (`Int8(128)` is -128, `Uint8(-1)` is 255), and the `OverflowError` numpy raises for integers too wide for any C type.
- `Int4`, `Int128` and `Uint128` have no numpy dtype and still trip the same assert. The shortcut sits behind that guard rather than in front of it, so they do not quietly gain support.
- NaN and infinity still raise `ValueError` and `OverflowError` with the same messages, except for `Boolean`, which has always folded them to 1 because it runs `bool()` before `Integer.__init__` sees the value.

Checked by snapshotting every integer and float type against 57 inputs (boundaries, wrap-around candidates, bools, floats, NaN and both infinities) plus construction from other DSL scalars, recording either the stored value or the exact exception, and diffing the run before the change against the run after: 1505 cases, no differences.

### Tests

`test/python/CuTeDSL/test_numeric_construction.py` is new, 14 tests, no GPU or compilation needed. The broadest one asserts the constructor against `int(np.array(x).astype(dtype))` directly, so the claim this PR rests on is the thing under test. The rest pin the wrap-around, the truncation direction, the NaN and infinity handling, the types with no numpy dtype, and the dtype-versus-width case above.

I also ran them against four deliberately broken variants to confirm they fail: bounds keyed off `min`/`max`, the range guard removed, the `Boolean` range widened, and the NaN check dropped. Each is caught.

`test/python/CuTeDSL/test_struct_in_if.py` passes before and after (6 tests, real `cute.compile`).
