### PR TITLE
[CuTe DSL] Preserve runtime tensor strides in Blackwell FMHA

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell/kernel/attention/fmha/fmha.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/attention/fmha/fmha.py
@@ -445,17 +445,10 @@ class BlackwellFusedMultiHeadAttentionForward:
         d = cute.assume(Int32(d), align)
         dv = cute.assume(Int32(dv), align)
 
-        # The head dimension must be the static contiguous mode. Besides being a
-        # layout requirement of the kernel, this lets the compiler vectorize the
-        # global-memory accesses along d/dv.
-        if cutlass.const_expr(q_tensor.stride[4] != 1):
-            raise ValueError("q_tensor must be contiguous in the d mode")
-        if cutlass.const_expr(k_tensor.stride[4] != 1):
-            raise ValueError("k_tensor must be contiguous in the d mode")
-        if cutlass.const_expr(v_tensor.stride[4] != 1):
-            raise ValueError("v_tensor must be contiguous in the dv mode")
-        if cutlass.const_expr(o_tensor.stride[4] != 1):
-            raise ValueError("o_tensor must be contiguous in the dv mode")
+        assert q_tensor.stride[4] == 1
+        assert k_tensor.stride[4] == 1
+        assert v_tensor.stride[4] == 1
+        assert o_tensor.stride[4] == 1
 
         stride_b_q = q_tensor.stride[0] if cum_seqlen_q is None else 0
         stride_b_o = o_tensor.stride[0] if cum_seqlen_q is None else 0
@@ -503,8 +496,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         )
         o = cute.make_tensor(o_tensor.iterator, o_layout)
         if cutlass.const_expr(lse_tensor is not None):
-            if cutlass.const_expr(lse_tensor.stride[3] != 1):
-                raise ValueError("lse_tensor must be contiguous in the h_r mode")
+            assert lse_tensor.stride[3] == 1
             # (s, ((h_r, h_k), b)) - head stride=1 to match FlashInfer (total_q, h_q) convention
             stride_b_lse = lse_tensor.stride[0] if cum_seqlen_q is None else 0
             lse_layout = cute.make_layout(
@@ -3630,12 +3622,15 @@ def run(
             is_dynamic_layout,
             assumed_align=32,
         )
-        if is_dynamic_layout and divisibility > 1:
-            cute_tensor = cute_tensor.mark_compact_shape_dynamic(
-                mode=len(shape) - 1,
-                stride_order=tuple(range(len(shape))),
-                divisibility=divisibility,
-            )
+        if is_dynamic_layout:
+            leading_dim = len(shape) - 1
+            cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+            if divisibility > 1:
+                cute_tensor = cute_tensor.mark_compact_shape_dynamic(
+                    mode=leading_dim,
+                    stride_order=tuple(range(len(shape))),
+                    divisibility=divisibility,
+                )
         f32_torch_tensor_gpu = f32_torch_tensor.cuda()
         cute.testing.convert(
             cute_tensor, from_dlpack(f32_torch_tensor_gpu, assumed_align=32)

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/attention/fmha/fmha.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/attention/fmha/fmha.py
@@ -445,41 +445,60 @@ class BlackwellFusedMultiHeadAttentionForward:
         d = cute.assume(Int32(d), align)
         dv = cute.assume(Int32(dv), align)
 
-        stride_b_q = h_r * h_k * s_q * d if cum_seqlen_q is None else 0
-        stride_b_o = h_r * h_k * s_q * dv if cum_seqlen_q is None else 0
-        stride_b_k = h_k * s_k * d if cum_seqlen_k is None else 0
-        stride_b_v = h_k * s_v * dv if cum_seqlen_k is None else 0
-        stride_b_lse = h_r * h_k * s_lse if cum_seqlen_q is None else 0
+        stride_b_q = q_tensor.stride[0] if cum_seqlen_q is None else 0
+        stride_b_o = o_tensor.stride[0] if cum_seqlen_q is None else 0
+        stride_b_k = k_tensor.stride[0] if cum_seqlen_k is None else 0
+        stride_b_v = v_tensor.stride[0] if cum_seqlen_k is None else 0
 
         # (b, s_q, h_k, h_r, d) -> (s_q, d, ((h_r, h_k), b))
         q_layout = cute.make_layout(
             (s_q, d, ((h_r, h_k), b)),
-            stride=(d * h_r * h_k, 1, ((d, d * h_r), stride_b_q)),
+            stride=(
+                q_tensor.stride[1],
+                q_tensor.stride[4],
+                ((q_tensor.stride[3], q_tensor.stride[2]), stride_b_q),
+            ),
         )
         q = cute.make_tensor(q_tensor.iterator, q_layout)
         # (b, s_k, h_k, 1, d) -> (s_k, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
         k_layout = cute.make_layout(
             (s_k, d, ((h_r, h_k), b)),
-            stride=(d * h_k, 1, ((0, d), stride_b_k)),
+            stride=(
+                k_tensor.stride[1],
+                k_tensor.stride[4],
+                ((0, k_tensor.stride[2]), stride_b_k),
+            ),
         )
         k = cute.make_tensor(k_tensor.iterator, k_layout)
         # (b, s_v, h_k, 1, dv) -> (dv, s_v, ((h_r, h_k), b)), 0-stride for h_r to broadcast
         v_layout = cute.make_layout(
             (dv, s_v, ((h_r, h_k), b)),
-            stride=(1, dv * h_k, ((0, dv), stride_b_v)),
+            stride=(
+                v_tensor.stride[4],
+                v_tensor.stride[1],
+                ((0, v_tensor.stride[2]), stride_b_v),
+            ),
         )
         v = cute.make_tensor(v_tensor.iterator, v_layout)
         # (b, s_q, h_k, h_r, dv) -> (s_q, dv, ((h_r, h_k), b))
         o_layout = cute.make_layout(
             (s_q, dv, ((h_r, h_k), b)),
-            stride=(dv * h_r * h_k, 1, ((dv, dv * h_r), stride_b_o)),
+            stride=(
+                o_tensor.stride[1],
+                o_tensor.stride[4],
+                ((o_tensor.stride[3], o_tensor.stride[2]), stride_b_o),
+            ),
         )
         o = cute.make_tensor(o_tensor.iterator, o_layout)
         if cutlass.const_expr(lse_tensor is not None):
             # (s, ((h_r, h_k), b)) - head stride=1 to match FlashInfer (total_q, h_q) convention
+            stride_b_lse = lse_tensor.stride[0] if cum_seqlen_q is None else 0
             lse_layout = cute.make_layout(
                 (s_lse, ((h_r, h_k), b)),
-                stride=(h_r * h_k, ((1, h_r), stride_b_lse)),
+                stride=(
+                    lse_tensor.stride[1],
+                    ((lse_tensor.stride[3], lse_tensor.stride[2]), stride_b_lse),
+                ),
             )
             lse = cute.make_tensor(lse_tensor.iterator, lse_layout)
         else:
@@ -3611,7 +3630,7 @@ def run(
     # Tensor shapes: 5D for q/k/v/o, 4D for lse
     # q/o: (b, s_q, h_k, h_r, d/dv)
     # k/v: (b, s_k, h_k, 1, d/dv)
-    # lse: (b, h_k, h_r, s_q)
+    # lse: (b, s_q, h_k, h_r)
     qo_shape = (b, s_q, h_k, h_r, d)
     o_shape = (b, s_q, h_k, h_r, dv)
     kv_shape = (b, s_k, h_k, 1, d)

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/attention/fmha/fmha.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/attention/fmha/fmha.py
@@ -445,6 +445,18 @@ class BlackwellFusedMultiHeadAttentionForward:
         d = cute.assume(Int32(d), align)
         dv = cute.assume(Int32(dv), align)
 
+        # The head dimension must be the static contiguous mode. Besides being a
+        # layout requirement of the kernel, this lets the compiler vectorize the
+        # global-memory accesses along d/dv.
+        if cutlass.const_expr(q_tensor.stride[4] != 1):
+            raise ValueError("q_tensor must be contiguous in the d mode")
+        if cutlass.const_expr(k_tensor.stride[4] != 1):
+            raise ValueError("k_tensor must be contiguous in the d mode")
+        if cutlass.const_expr(v_tensor.stride[4] != 1):
+            raise ValueError("v_tensor must be contiguous in the dv mode")
+        if cutlass.const_expr(o_tensor.stride[4] != 1):
+            raise ValueError("o_tensor must be contiguous in the dv mode")
+
         stride_b_q = q_tensor.stride[0] if cum_seqlen_q is None else 0
         stride_b_o = o_tensor.stride[0] if cum_seqlen_q is None else 0
         stride_b_k = k_tensor.stride[0] if cum_seqlen_k is None else 0
@@ -491,6 +503,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         )
         o = cute.make_tensor(o_tensor.iterator, o_layout)
         if cutlass.const_expr(lse_tensor is not None):
+            if cutlass.const_expr(lse_tensor.stride[3] != 1):
+                raise ValueError("lse_tensor must be contiguous in the h_r mode")
             # (s, ((h_r, h_k), b)) - head stride=1 to match FlashInfer (total_q, h_q) convention
             stride_b_lse = lse_tensor.stride[0] if cum_seqlen_q is None else 0
             lse_layout = cute.make_layout(
@@ -3578,6 +3592,7 @@ def run(
         shape,
         dtype,
         is_dynamic_layout=True,
+        divisibility=1,
         use_random_int=True,
         zero_out=False,
     ):
@@ -3615,6 +3630,12 @@ def run(
             is_dynamic_layout,
             assumed_align=32,
         )
+        if is_dynamic_layout and divisibility > 1:
+            cute_tensor = cute_tensor.mark_compact_shape_dynamic(
+                mode=len(shape) - 1,
+                stride_order=tuple(range(len(shape))),
+                divisibility=divisibility,
+            )
         f32_torch_tensor_gpu = f32_torch_tensor.cuda()
         cute.testing.convert(
             cute_tensor, from_dlpack(f32_torch_tensor_gpu, assumed_align=32)
@@ -3657,24 +3678,28 @@ def run(
         qo_shape,
         qk_dtype,
         is_dynamic_layout=True,
+        divisibility=256 // qk_dtype.width,
         use_random_int=use_random,
     )
     k_ref, k_tensor, k_torch = create_and_permute_tensor(
         kv_shape,
         qk_dtype,
         is_dynamic_layout=True,
+        divisibility=256 // qk_dtype.width,
         use_random_int=use_random,
     )
     v_ref, v_tensor, v_torch = create_and_permute_tensor(
         v_shape,
         pv_dtype,
         is_dynamic_layout=True,
+        divisibility=256 // pv_dtype.width,
         use_random_int=use_random,
     )
     _, o_tensor, o_torch = create_and_permute_tensor(
         o_shape,
         out_dtype,
         is_dynamic_layout=True,
+        divisibility=256 // out_dtype.width,
         zero_out=True,
     )
     if lse_calculation:
@@ -4110,24 +4135,28 @@ def run(
             qo_shape,
             qk_dtype,
             is_dynamic_layout=True,
+            divisibility=256 // qk_dtype.width,
             use_random_int=False,
         )
         _, k_tensor_workspace, _ = create_and_permute_tensor(
             kv_shape,
             qk_dtype,
             is_dynamic_layout=True,
+            divisibility=256 // qk_dtype.width,
             use_random_int=False,
         )
         _, v_tensor_workspace, _ = create_and_permute_tensor(
             v_shape,
             pv_dtype,
             is_dynamic_layout=True,
+            divisibility=256 // pv_dtype.width,
             use_random_int=False,
         )
         _, o_tensor_workspace, _ = create_and_permute_tensor(
             o_shape,
             out_dtype,
             is_dynamic_layout=True,
+            divisibility=256 // out_dtype.width,
             zero_out=True,
         )
         if lse_calculation:


### PR DESCRIPTION
## Summary

Blackwell CuTe DSL FMHA accepts dynamic-layout Q/K/V/O/LSE tensors, but rebuilt its internal layouts from problem sizes using packed strides. Because the original iterators were paired with these synthesized layouts, padded tensor views could be addressed as if they were contiguous and silently produce incorrect results.

This change:

- maps the internal Q/K/V/O/LSE layouts from each input tensor runtime stride;
- preserves the intentional zero batch stride for varlen inputs, whose batch offsets come from cumulative sequence lengths; and
- corrects the LSE shape comment to match the actual allocation.

## Validation

- Python syntax check for fmha.py.
- NVIDIA GB200, CUDA 13.3, nvidia-cutlass-dsl 4.7.0: contiguous FP16 FMHA compilation and reference check passed.
- NVIDIA GB200: a local padded-stride case with B=2, GQA (8 query heads / 2 KV heads), and LSE enabled compiled and passed the reference check.