### PR TITLE
Widen the coordinate offset arithmetic to 64 bits (include/cutlass/coord.h)

### DIFF
--- a/include/cutlass/coord.h
+++ b/include/cutlass/coord.h
@@ -254,10 +254,14 @@ public:
   CUTLASS_HOST_DEVICE Index const& operator[](int dim) const { return idx[dim]; }
 
   /// Computes the dot product with anotherCoord object
+  ///
+  /// Each operand becomes a LongIndex before the multiplication. A product of two
+  /// Index values that does not fit in an Index thus stays exact. The free function
+  /// cutlass::dot() in cutlass/fast_math.h widens in the same way.
   CUTLASS_HOST_DEVICE
   LongIndex dot(Coord const& b, LongIndex sum = LongIndex(0)) const {
     for (int i = 0; i < kRank; ++i) {
-      sum += idx[i] * b.idx[i];
+      sum += LongIndex(idx[i]) * LongIndex(b.idx[i]);
     }
     return sum;
   }

--- a/include/cutlass/tensor_ref.h
+++ b/include/cutlass/tensor_ref.h
@@ -105,10 +105,13 @@ public:
   }
 
   /// Compute the number of contiguous elements needed to store a tensor with the given size
+  ///
+  /// Each operand becomes a LongIndex before the multiplication. A tensor of 2 to the
+  /// 31 elements or more thus gets an exact capacity.
   CUTLASS_HOST_DEVICE
   LongIndex capacity(TensorCoord const &size) const {
     int idx = stride_.max_dim_index();
-    return stride_[idx] * size[idx];
+    return LongIndex(stride_[idx]) * LongIndex(size[idx]);
   }
 };
 

--- a/test/unit/core/tensor_ref.cu
+++ b/test/unit/core/tensor_ref.cu
@@ -107,6 +107,30 @@ TEST(TensorRef, rank2_row_major) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// A coordinate offset and a layout capacity are LongIndex values. Each product of two
+// Index values widens before the multiplication, thus a tensor of 2 to the 31 elements
+// or more keeps an exact offset. The test needs no memory.
+TEST(TensorRef, offset_and_capacity_wider_than_32_bits) {
+
+  using Layout = cutlass::IdentityTensorLayout<2>;
+  using LongIndex = Layout::LongIndex;
+
+  Layout layout(cutlass::make_Coord(65536, 1));
+
+  EXPECT_EQ(layout(cutlass::make_Coord(65536, 0)), LongIndex(4294967296LL));
+  EXPECT_EQ(layout(cutlass::make_Coord(-65536, 0)), LongIndex(-4294967296LL));
+
+  // Two coordinates of one extent must not give one offset.
+  EXPECT_NE(layout(cutlass::make_Coord(65536, 0)), layout(cutlass::make_Coord(0, 0)));
+
+  EXPECT_EQ(layout.capacity(cutlass::make_Coord(49152, 65536)), LongIndex(3221225472LL));
+
+  EXPECT_EQ(cutlass::make_Coord(65536, 65536).dot(cutlass::make_Coord(65536, 65536)),
+            LongIndex(8589934592LL));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 TEST(TensorRef, rank2_contiguous_dynamic) {
   int const M = 8;
   int const N = 16;


### PR DESCRIPTION
## Summary

`Coord::dot` and `IdentityTensorLayout::capacity` each give a 64-bit result and calculate the product in 32 bits. The product overflows at 2^31, and two coordinates of one tensor then give the same offset.

```diff
  // include/cutlass/coord.h:260, and the same shape at tensor_ref.h:111
- sum += idx[i] * b.idx[i];
+ sum += LongIndex(idx[i]) * LongIndex(b.idx[i]);

  // a layout with the stride (65536, 1)
  offset(65536, 0)                  0  ->  4294967296
  capacity(49152, 65536)  -1073741824  ->  3221225472
```

`Coord::product` in the same class already holds the value in 64 bits.

## Test

Five cases, and each one gives a wrong answer without this change. The test allocates nothing, because a layout gives an offset without a buffer. `test/unit/core/tensor_ref.cu` is already in `test/unit/core/CMakeLists.txt`.

## Register cost

A kernel that calls `IdentityTensorLayout::operator()` gives the same register count before and after, with `-O3 -DNDEBUG`:

```
sm_80     12  ->  12
sm_90a    14  ->  14
sm_120a   14  ->  14
```

No stack frame and no spill in any of the six builds.

Pull request #2651  widened the same arithmetic in `include/cutlass/layout/tensor.h` and closed with this reason:

> if we do the address computation in int64_t, it takes more registers and hurt the performance of small conv. so, we eventually decided to not do it in large extent for conv.

That reason holds for the per-element conv address path. The same widening in `TensorNHWC::operator()` costs 2 registers at sm_80 and 4 at sm_90a. This pull request adds no such cost, and it corrects the overflow. `Coord::dot` already gives a `LongIndex`, and the two operands are already loaded, so the wider multiply needs no more registers.

## Each 64-bit path in the two headers

```
                                              before        after
coord.h:320      product(65536,65536)     4294967296   4294967296   already exact
coord.h:258      dot(65536,65536 twice)            0   8589934592   this change
tensor_ref.h:91  operator()(65536,0)               0   4294967296   through dot
tensor_ref.h:109 capacity(49152,65536)   -1073741824   3221225472   this change
tensor_ref.h:316 offset(65536,0)                   0   4294967296   through operator()
```

Those five are every function in `coord.h` and `tensor_ref.h` that gives a `LongIndex`. `product` was already exact, because its accumulator starts as a `LongIndex`.

## Related

Issue #2312   reports the same 32-bit stride mechanism in the CuTe DSL path. This change covers the 2.x `Coord` and `TensorRef` classes only.
