### PR TITLE
Guard the FastDivmodU64 sum against a wrap

### DIFF
--- a/include/cutlass/fast_math.h
+++ b/include/cutlass/fast_math.h
@@ -511,14 +511,22 @@ struct FastDivmodU64 {
   }
 
   /// Returns the quotient of floor(dividend / divisor)
+  ///
+  /// The divisor must not be 0. A default-constructed object holds 0, and the two
+  /// arms then disagree: the host divides by 0, and the device gives the dividend.
   CUTLASS_HOST_DEVICE
   uint64_t divide(uint64_t dividend) const {
+    assert(divisor != 0);
     uint64_t quotient = 0;
 
     #ifdef __CUDA_ARCH__
       uint64_t x = dividend;
       if (multiplier) {
-        x = __umul64hi(dividend + round_up, multiplier);
+        // round_up is 0 or 1, thus the sum wraps only for the dividend 2^64-1.
+        // The exact product of 2^64 and the multiplier puts the multiplier in
+        // the high half.
+        uint64_t const rounded = dividend + round_up;
+        x = (rounded < dividend) ? multiplier : __umul64hi(rounded, multiplier);
       }
       quotient = (x >> shift_right);
     #else

--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -45,4 +45,5 @@ cutlass_test_unit_add_executable(
   numeric_conversion_subbyte.cu
   fast_numeric_conversion.cu
   functional.cu
+  fast_math.cu
   )

--- a/test/unit/core/fast_math.cu
+++ b/test/unit/core/fast_math.cu
@@ -1,0 +1,117 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Tests for cutlass::FastDivmodU64 at the largest dividend.
+*/
+
+#include "../common/cutlass_unit_test.h"
+
+#include "cutlass/fast_math.h"
+#include "cutlass/util/device_memory.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+/// The device arm adds round_up to the dividend before the multiply. The sum wraps
+/// for the largest dividend, and only for a divisor that carries round_up 1. Of the
+/// first 1048576 divisors, 325628 carry it. The smallest one is 7.
+uint64_t const kDivisors[] = {7, 23, 100, 1000};
+int const kNumDivisors = int(sizeof(kDivisors) / sizeof(kDivisors[0]));
+
+__global__ void divide_kernel(
+    cutlass::FastDivmodU64 object, uint64_t dividend, uint64_t* quotient, uint64_t* remainder) {
+
+  *quotient = object.divmod(*remainder, dividend);
+}
+
+__global__ void decompose_kernel(
+    uint64_t linear_idx, cutlass::FastDivmodU64 const* divmod, cutlass::Coord<4>* out) {
+
+  *out = cutlass::CoordinateDecomposition<4>(linear_idx, divmod);
+}
+
+}  // namespace
+
+/// The wrap gave the quotient 0, and it gave the whole dividend as the remainder.
+TEST(fast_math, fast_divmod_u64_at_the_largest_dividend) {
+  uint64_t const kMax = ~uint64_t(0);
+
+  cutlass::device_memory::allocation<uint64_t> device_u64(2);
+
+  for (int i = 0; i < kNumDivisors; ++i) {
+    uint64_t const divisor = kDivisors[i];
+    cutlass::FastDivmodU64 const object(divisor);
+
+    divide_kernel<<<1, 1>>>(object, kMax, device_u64.get(), device_u64.get() + 1);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    uint64_t from_device[2] = {0, 0};
+    cutlass::device_memory::copy_to_host(from_device, device_u64.get(), 2);
+
+    EXPECT_EQ(from_device[0], kMax / divisor) << "divisor " << divisor;
+    EXPECT_EQ(from_device[1], kMax % divisor) << "divisor " << divisor;
+  }
+}
+
+/// The quotient 0 left the whole dividend for the next mode, and the decomposition
+/// then gave the coordinate -1.
+TEST(fast_math, coordinate_decomposition_at_the_largest_dividend) {
+  uint64_t const kMax = ~uint64_t(0);
+  int const kExtent[3] = {3, 5, 7};
+
+  cutlass::FastDivmodU64 host_divmod[3] = {
+      cutlass::FastDivmodU64(uint64_t(kExtent[0])),
+      cutlass::FastDivmodU64(uint64_t(kExtent[1])),
+      cutlass::FastDivmodU64(uint64_t(kExtent[2]))};
+
+  cutlass::device_memory::allocation<cutlass::FastDivmodU64> device_divmod(3);
+  cutlass::device_memory::allocation<cutlass::Coord<4>> device_coord(1);
+  cutlass::device_memory::copy_to_device(device_divmod.get(), host_divmod, 3);
+
+  decompose_kernel<<<1, 1>>>(kMax, device_divmod.get(), device_coord.get());
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  cutlass::Coord<4> coord;
+  cutlass::device_memory::copy_to_host(&coord, device_coord.get(), 1);
+
+  cutlass::Coord<4> const reference =
+      cutlass::CoordinateDecomposition<4>(kMax, host_divmod);
+
+  // The wrap gives the mode 3 the value -1, and it gives the mode 2 the value 0
+  // against the exact 2. A coordinate is a remainder, thus a negative value is
+  // outside the domain.
+  EXPECT_GE(coord[3], 0);
+  EXPECT_EQ(coord[2], reference[2]);
+  EXPECT_EQ(coord[3], reference[3]);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

`FastDivmodU64::divide` adds `round_up` to the dividend before the multiply. The sum wraps for the dividend 2^64-1, and the quotient becomes 0. This happens for 325628 of the first 1048576 divisors.

```diff
  // include/cutlass/fast_math.h:521, the device arm
- x = __umul64hi(dividend + round_up, multiplier);
+ uint64_t const rounded = dividend + round_up;
+ x = (rounded < dividend) ? multiplier : __umul64hi(rounded, multiplier);

  // dividend 2^64-1, divisor 7
  quotient                    0  ->  2635249153387078802
  remainder 18446744073709551615  ->  1
```

`CoordinateDecomposition` calls the same function, so the quotient 0 gives the whole dividend back as the remainder. A rank 4 decomposition of that dividend then gives the coordinate -1, which is a negative offset into a tensor.

The `assert` covers a separate case: a default-constructed object holds the divisor 0, the host arm divides by 0, and the device arm gives the dividend back.

## Test

The file is new, because `fast_math.h` had no unit test. Eleven assertions, and each one fails without this change. The divisor list holds only values whose `round_up` is 1, because a power of two skips the branch.

## Cost

A kernel that calls `divmod`, built at `-O3 -DNDEBUG`, gives this:

```
           SASS instructions      registers
           before   after         before   after
sm_75          48      48             14      14
sm_80          56      64             14      14
sm_86          56      64             14      14
sm_89          56      64             14      14
sm_90a         64      72             16      16
sm_100a        56      64             16      16
sm_120a        56      56             18      16
```

The register count does not grow on any architecture. The instruction count grows by 8 on five of the seven, and the guard costs one compare and one select on the path that the multiplier takes. On sm_75 and sm_120a the scheduler absorbs it.

The `assert` is compiled out under `NDEBUG`. The same kernel at sm_120a gives 56 instructions with `-DNDEBUG` and 80 with `-UNDEBUG`, and the unit test build uses `-DNDEBUG`.
