### PR TITLE
Bound the SM90 TMA descriptor writes

### DIFF
--- a/include/cute/arch/copy_sm90_desc.hpp
+++ b/include/cute/arch/copy_sm90_desc.hpp
@@ -363,10 +363,13 @@ tma_descriptor_replace_dims_strides_in_shared_mem(TmaDescriptor                 
 {
 #if defined(CUTE_ARCH_DEVICE_MODIFIABLE_TMA_SM90_ENABLED)
   uint32_t smem_int_desc = cast_smem_ptr_to_uint(&smem_desc);
-  uint64_t const smem_int64_desc = 0;
+  // cvt.u64.u32 writes its first operand, so that operand needs an output
+  // constraint. As an input the compiler still models the value as 0.
+  uint64_t smem_int64_desc = 0;
   asm volatile (
     "cvt.u64.u32 %0, %1;"
-    :: "l"(smem_int64_desc), "r"(smem_int_desc));
+    : "=l"(smem_int64_desc)
+    : "r"(smem_int_desc));
   asm volatile (
     "tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], 0, %1;"
     :: "l"(smem_int64_desc), "r"(prob_shape[0]));

--- a/include/cute/atom/copy_traits_sm90_im2col.hpp
+++ b/include/cute/atom/copy_traits_sm90_im2col.hpp
@@ -409,6 +409,10 @@ make_im2col_tma_copy_desc(
 
   constexpr uint32_t num_total_modes   = LayoutA::rank;
   constexpr int      num_spatial_modes = num_total_modes - 2;
+  // gmem_prob_shape, gmem_prob_stride and tma_traversal_strides below each hold
+  // 5 elements, and the loops that fill them index by the tensor rank.
+  static_assert(num_total_modes >= 3 && num_total_modes <= 5,
+                "im2col TMA needs a tensor of rank 3, 4 or 5: C, 1 to 3 spatial modes, and N.");
 
   // Gmem starting address
   void* gmem_address = (void*) raw_pointer_cast(tensor_cwhdn.data());

--- a/include/cute/atom/copy_traits_sm90_tma.hpp
+++ b/include/cute/atom/copy_traits_sm90_tma.hpp
@@ -994,12 +994,16 @@ make_tma_copy_desc(Tensor<GEngine,GLayout> const& gtensor,         // The origin
     smem_box_shape[i] *= size<i>(tma_gbasis);
   });
   // Finally, truncate the tma box by the num_multicast
-  for (uint32_t i = tma_dim-1, multicast = num_multicast; multicast > 1; --i) {
+  // Stop at mode 0. num_multicast can exceed the product of the box modes, and
+  // a condition on multicast alone lets the index run below 0.
+  uint32_t multicast = num_multicast;
+  for (int i = tma_dim-1; i >= 0 && multicast > 1; --i) {
     assert(smem_box_shape[i] % multicast == 0 || multicast % smem_box_shape[i] == 0);
     uint32_t new_mult = ceil_div(multicast, smem_box_shape[i]);
     smem_box_shape[i] = ceil_div(smem_box_shape[i], multicast);
     multicast = new_mult;
   }
+  assert(multicast <= 1 && "TMA box is too small for the requested multicast size");
 
   assert(smem_box_shape[0] >= (uint32_t(1)));                // Size must be min 1
   assert(smem_box_shape[0] <= (uint32_t(1) << 8));           // Size must be max 2^8 = 256

--- a/test/unit/cute/hopper/CMakeLists.txt
+++ b/test/unit/cute/hopper/CMakeLists.txt
@@ -35,6 +35,7 @@ add_custom_target(
   cutlass_test_unit_cute_hopper_tma_store
   cutlass_test_unit_cute_hopper_bulk_load
   cutlass_test_unit_cute_hopper_bulk_store
+  cutlass_test_unit_cute_hopper_tma_descriptor_bounds
 )
 
 add_custom_target(
@@ -45,6 +46,7 @@ add_custom_target(
   test_unit_cute_hopper_tma_store
   test_unit_cute_hopper_bulk_load
   test_unit_cute_hopper_bulk_store
+  test_unit_cute_hopper_tma_descriptor_bounds
 )
 
 cutlass_test_unit_add_executable(
@@ -80,5 +82,10 @@ cutlass_test_unit_add_executable(
 cutlass_test_unit_add_executable(
   cutlass_test_unit_cute_hopper_bulk_store
   bulk_store.cu
+)
+
+cutlass_test_unit_add_executable(
+  cutlass_test_unit_cute_hopper_tma_descriptor_bounds
+  tma_descriptor_bounds.cu
 )
 

--- a/test/unit/cute/hopper/tma_descriptor_bounds.cu
+++ b/test/unit/cute/hopper/tma_descriptor_bounds.cu
@@ -1,0 +1,70 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+/*! \file
+    \brief Bounds of the TMA descriptor construction on the host.
+*/
+
+#include "cutlass_unit_test.h"
+
+#include <cstdlib>
+
+#include <cute/tensor.hpp>
+#include <cute/atom/copy_traits_sm90_tma.hpp>
+
+using namespace cute;
+
+namespace {
+
+// Builds a multicast TMA atom whose cluster is larger than the TMA box.
+// The box is 8 by 4, and the product of its modes is 32.
+void build_atom_with_cluster_above_box()
+{
+  auto gmem_layout = make_layout(make_shape(256, 256), GenRowMajor{});
+  auto smem_layout = make_layout(make_shape(_8{}, _4{}), GenRowMajor{});
+  Tensor gtensor = make_tensor(make_gmem_ptr<float>(nullptr), gmem_layout);
+  auto atom = make_tma_atom(SM90_TMA_LOAD_MULTICAST{}, gtensor, smem_layout,
+                            product_each(shape(smem_layout)), Int<64>{});
+  (void) atom;
+}
+
+} // namespace
+
+// The box truncation loop counts down through the TMA box modes. A cluster
+// larger than the product of those modes leaves the loop index below mode 0.
+// An unsigned index then wraps and reads smem_box_shape far outside the array.
+// The child process must complete the call and exit with the code 0.
+TEST(CuTe_Tma_Descriptor, Multicast_Cluster_Above_Box)
+{
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  EXPECT_EXIT({ build_atom_with_cluster_above_box(); std::exit(0); },
+              ::testing::ExitedWithCode(0), "");
+}


### PR DESCRIPTION
## Summary

`make_tma_copy_desc` truncates the TMA box by the multicast factor. The loop index is unsigned and the condition tests the multicast alone, so a cluster larger than the product of the box modes drives the index below mode 0, where it wraps and reads `smem_box_shape` outside its five elements.

```diff
  // include/cute/atom/copy_traits_sm90_tma.hpp:997
- for (uint32_t i = tma_dim-1, multicast = num_multicast; multicast > 1; --i) {
+ uint32_t multicast = num_multicast;
+ for (int i = tma_dim-1; i >= 0 && multicast > 1; --i) {
+ ...
+ assert(multicast <= 1 && "TMA box is too small for the requested multicast size");

  make_tma_atom(SM90_TMA_LOAD_MULTICAST{}, gtensor, (_8,_4) smem, ..., Int<N>{})
  N = 32     ok      ->  ok          32 is the product of the box modes
  N = 33     SEGV    ->  ok
  N = 64     SEGV    ->  ok
```

AddressSanitizer gives `SEGV on unknown address` inside `ceil_div` at `copy_traits_sm90_tma.hpp:999`.

Two smaller changes ride with it, in the same descriptor path.

```diff
  // include/cute/arch/copy_sm90_desc.hpp:366   an asm operand takes an input
  // constraint and the instruction writes it
- uint64_t const smem_int64_desc = 0;
- asm volatile ("cvt.u64.u32 %0, %1;" :: "l"(smem_int64_desc), "r"(smem_int_desc));
+ uint64_t smem_int64_desc = 0;
+ asm volatile ("cvt.u64.u32 %0, %1;" : "=l"(smem_int64_desc) : "r"(smem_int_desc));

  emitted PTX at sm_90a
  before   mov.u64 %rd14, 0;  cvt.u64.u32 %rd14, %r1;
  after                       cvt.u64.u32 %rd2,  %r1;

  // include/cute/atom/copy_traits_sm90_im2col.hpp:410   three arrays of five
  // elements are filled from loops bounded by the tensor rank, and nothing
  // bounds that rank
+ static_assert(num_total_modes >= 3 && num_total_modes <= 5, ...);

  detail::make_im2col_tma_copy_desc(rank 6 tensor, ...)
  stack-buffer-overflow, WRITE of size 8 at copy_traits_sm90_im2col.hpp:419
  ->  rejected at compile time
```

## Scope

The multicast defect is reachable through the public `make_tma_atom`, and a user who asks for a cluster larger than the TMA box gets a segmentation fault on the host.

_`make_im2col_tma_copy` always gives the descriptor function a rank of 2, because the caller rebuilds the tensor from the TMA basis and `smem_tma_rank` is capped at 2 at `copy_traits_sm90_im2col.hpp:635`. The overflow needs a direct call to `detail::make_im2col_tma_copy_desc`, thus the `static_assert` guards the detail function and not a path that a user reaches today._


## Cost

The asm operand is the only change inside a kernel. Measured with `-O3 -DNDEBUG`:

```
           SASS instructions      registers
           before   after         before   after
sm_75          40      40             38      38
sm_80          48      48             30      30
sm_86          48      48             38      38
sm_89          48      48             38      38
sm_90a         88      88             30      30
sm_100a        64      64             22      22
sm_120a        64      64             22      22
```

The other two changes are host side. The bounds fix adds one comparison for each loop step over at most five modes, and it runs one time for each atom.

@ccecka
