### PR TITLE
Bound the SM120 CTA tile and widen the sparse batch stride

### DIFF
--- a/include/cutlass/gemm/collective/builders/sm120_blockwise_mma_builder.inl
+++ b/include/cutlass/gemm/collective/builders/sm120_blockwise_mma_builder.inl
@@ -133,6 +133,7 @@ struct CollectiveBuilder<
                 "SM120 TmaWarpSpecialized blockwise scaling builder currently only supports F8F6F4 MMA.");
   static_assert(cute::is_static_v<TileShape_MNK>, "TileShape has to be static");
   static_assert(cute::is_static_v<ClusterShape_MNK>, "Cluster has to be static");
+  static_assert(cute::size(ClusterShape_MNK{}) == Int<1>{}, "no programmatic multicast on this arch");
 
   using GmemLayoutATag   = cute::remove_cvref_t<decltype(get<0>(GmemLayoutATagPair{}))>;
   using GmemLayoutSFATag = cute::remove_cvref_t<decltype(get<1>(GmemLayoutATagPair{}))>;

--- a/include/cutlass/gemm/collective/builders/sm120_mma_builder.inl
+++ b/include/cutlass/gemm/collective/builders/sm120_mma_builder.inl
@@ -110,6 +110,15 @@ struct CollectiveBuilder<
     Tile<PermTileM, PermTileN, _32>{}
   ));
 
+  // The mainloop steps the TiledMma across the CTA tile with a ceiling division. A mode that
+  // does not divide makes the mainloop read past the shared memory tile.
+  static_assert(size<0>(TileShape_MNK{}) % size<0>(cute::tile_shape(TiledMma{})) == 0,
+                "TileShape M must be a multiple of the TiledMma tile shape along M.");
+  static_assert(size<1>(TileShape_MNK{}) % size<1>(cute::tile_shape(TiledMma{})) == 0,
+                "TileShape N must be a multiple of the TiledMma tile shape along N.");
+  static_assert(size<2>(TileShape_MNK{}) % size<2>(cute::tile_shape(TiledMma{})) == 0,
+                "TileShape K must be a multiple of the TiledMma tile shape along K.");
+
   // DType check
   static constexpr bool UseF8f6f4 = detail::is_sm120_f8f6f4<TiledMma, ElementA, ElementB>();
   static_assert(UseF8f6f4, "Non-blockscaled collective builder only supports F8F6F4 MMA.\n");

--- a/include/cutlass/gemm/collective/builders/sm1xx_sparse_config.inl
+++ b/include/cutlass/gemm/collective/builders/sm1xx_sparse_config.inl
@@ -266,7 +266,7 @@ struct Sm1xxGemmSparseConfig {
                    int32_t(L)),
         make_stride(int64_t(K_AlignedAC),
                     make_stride(_1{}, ElementASparsity{}),
-                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC * K_AlignedAC))
+                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC) * int64_t(K_AlignedAC))
       );
     }
     else {
@@ -276,7 +276,7 @@ struct Sm1xxGemmSparseConfig {
                    int32_t(L)),
         make_stride(ElementASparsity{},
                     make_stride(_1{}, int64_t(M_AlignedAC) * ElementASparsity{}),
-                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC * K_AlignedAC))
+                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC) * int64_t(K_AlignedAC))
       );
     }
   }
@@ -302,8 +302,8 @@ struct Sm1xxGemmSparseConfig {
                  make_shape(shape<1>(TensorEAtom{}), int32_t(K_AlignedE / TensorEAtomK{})),
                  int32_t(L)),
       make_stride(make_stride(stride<0>(TensorEAtom{}), cute::Int<cute::cosize(TensorEAtom{})>{}),
-                  make_stride(stride<1>(TensorEAtom{}), int64_t(M_AlignedE * TensorEAtomK{})),
-                  (L == 1) ? int64_t(0) : int64_t(M_AlignedE * K_AlignedE))
+                  make_stride(stride<1>(TensorEAtom{}), int64_t(M_AlignedE) * int64_t(TensorEAtomK{})),
+                  (L == 1) ? int64_t(0) : int64_t(M_AlignedE) * int64_t(K_AlignedE))
     );
   }
 };

--- a/include/cutlass/gemm/collective/builders/sm90_sparse_config.inl
+++ b/include/cutlass/gemm/collective/builders/sm90_sparse_config.inl
@@ -224,7 +224,7 @@ struct Sm90GemmSparseConfig {
                    int32_t(L)),
         make_stride(ElementASparsity{},
                     make_stride(_1{}, int64_t(M_AlignedAC) * ElementASparsity{}),
-                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC * K_AlignedAC))
+                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC) * int64_t(K_AlignedAC))
       );
     }
     else {
@@ -234,7 +234,7 @@ struct Sm90GemmSparseConfig {
                    int32_t(L)),
         make_stride(int64_t(K_AlignedAC),
                     make_stride(_1{}, ElementASparsity{}),
-                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC * K_AlignedAC))
+                    (L == 1) ? int64_t(0) : int64_t(M_AlignedAC) * int64_t(K_AlignedAC))
       );
     }
   }
@@ -259,8 +259,8 @@ struct Sm90GemmSparseConfig {
                  make_shape(shape<1>(TensorEAtom{}), int32_t(K_AlignedE / TensorEAtomK{})),
                  int32_t(L)),
       make_stride(make_stride(stride<0>(TensorEAtom{}), cute::Int<cute::cosize(TensorEAtom{})>{}),
-                  make_stride(stride<1>(TensorEAtom{}), int64_t(M_AlignedE * TensorEAtomK{})),
-                  (L == 1) ? int64_t(0) : int64_t(M_AlignedE * K_AlignedE))
+                  make_stride(stride<1>(TensorEAtom{}), int64_t(M_AlignedE) * int64_t(TensorEAtomK{})),
+                  (L == 1) ? int64_t(0) : int64_t(M_AlignedE) * int64_t(K_AlignedE))
     );
   }
 };

--- a/test/unit/transform/device/CMakeLists.txt
+++ b/test/unit/transform/device/CMakeLists.txt
@@ -30,6 +30,12 @@
 # Compress Kernel
 #
 
+cutlass_test_unit_add_executable(
+    cutlass_test_unit_sparse_config_batch_stride
+
+    sparse_config_batch_stride.cu
+)
+
 add_custom_target(
     cutlass_test_unit_sm90_structured_sparse_gemm_compressor
     DEPENDS

--- a/test/unit/transform/device/sparse_config_batch_stride.cu
+++ b/test/unit/transform/device/sparse_config_batch_stride.cu
@@ -1,0 +1,76 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#include "../../common/cutlass_unit_test.h"
+
+#include "cute/atom/mma_traits_sm90_gmma.hpp"                      // cute::GMMA::Major
+#include "cutlass/gemm/collective/builders/sm90_sparse_config.inl" // Sm90GemmSparseConfig
+#include "cutlass/gemm/collective/builders/sm1xx_sparse_config.inl"// Sm1xxGemmSparseConfig
+#include "cutlass/layout/matrix.h"                                 // RowMajor
+#include "cutlass/numeric_types.h"                                 // float_e4m3_t
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+// The batch stride is the product of two aligned extents. Both are int, thus the product
+// overflows for a large problem and the cast to int64_t widens a value that already wrapped.
+template <class Config>
+void check_batch_stride(int M, int K, int64_t expect_a, int64_t expect_e) {
+  auto layout_a = Config::fill_layoutA(cute::make_shape(M, 128, K, 2));
+  auto layout_e = Config::fill_layoutE(cute::make_shape(M, 128, K, 2));
+  EXPECT_EQ(int64_t(cute::stride<2>(layout_a)), expect_a) << "M " << M << " K " << K;
+  EXPECT_EQ(int64_t(cute::stride<2>(layout_e)), expect_e) << "M " << M << " K " << K;
+}
+
+} // namespace
+
+TEST(Sparse_Config, sm90_batch_stride_wider_than_32_bits) {
+  using ElementAMma = cute::sparse_elem<2, cutlass::float_e4m3_t>;
+  using ElementEMma = cute::sparse_elem<8, uint8_t>;
+  using Config = cutlass::Sm90GemmSparseConfig<ElementAMma, cute::GMMA::Major::K,
+                                               ElementEMma, cute::Int<64>>;
+
+  check_batch_stride<Config>(49152, 65536, 3221225472LL, 3221225472LL);
+  check_batch_stride<Config>(65536, 65536, 4294967296LL, 4294967296LL);
+}
+
+TEST(Sparse_Config, sm1xx_batch_stride_wider_than_32_bits) {
+  using ElementAMma = cute::sparse_elem<2, cutlass::float_e4m3_t>;
+  using ElementEMma = cute::sparse_elem<8, uint8_t>;
+  using Config = cutlass::Sm1xxGemmSparseConfig<ElementAMma, cutlass::layout::RowMajor,
+                                                ElementEMma>;
+
+  check_batch_stride<Config>(49152, 65536, 3221225472LL, 3221225472LL);
+  check_batch_stride<Config>(65536, 65536, 4294967296LL, 4294967296LL);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/unit/transform/device/sparse_config_batch_stride.cu
+++ b/test/unit/transform/device/sparse_config_batch_stride.cu
@@ -59,7 +59,7 @@ TEST(Sparse_Config, sm90_batch_stride_wider_than_32_bits) {
   using Config = cutlass::Sm90GemmSparseConfig<ElementAMma, cute::GMMA::Major::K,
                                                ElementEMma, cute::Int<64>>;
 
-  check_batch_stride<Config>(49152, 65536, 3221225472LL, 3221225472LL);
+  check_batch_stride<Config>(49153, 65537, 3222863904LL, 3228569600LL);
   check_batch_stride<Config>(65536, 65536, 4294967296LL, 4294967296LL);
 }
 
@@ -69,7 +69,7 @@ TEST(Sparse_Config, sm1xx_batch_stride_wider_than_32_bits) {
   using Config = cutlass::Sm1xxGemmSparseConfig<ElementAMma, cutlass::layout::RowMajor,
                                                 ElementEMma>;
 
-  check_batch_stride<Config>(49152, 65536, 3221225472LL, 3221225472LL);
+  check_batch_stride<Config>(49153, 65537, 3222863904LL, 3235921920LL);
   check_batch_stride<Config>(65536, 65536, 4294967296LL, 4294967296LL);
 }
 


### PR DESCRIPTION
## Summary

The SM120 dense builder does not check that the CTA tile is a multiple of the MMA tiler. The mainloop steps the tiled MMA with a ceiling division. A K mode that is not a multiple of 32 makes the mainloop read past the shared memory tile.

```diff
  // include/cutlass/gemm/collective/builders/sm120_mma_builder.inl:120
+ static_assert(size<2>(TileShape_MNK{}) % size<2>(cute::tile_shape(TiledMma{})) == 0, ...);

  // tile 128x64x48, problem 512x256x288, e4m3, sm_120a, A and B all 1.0
  before   compute-sanitizer: Invalid __shared__ read of size 16 bytes,
           Access to 0xb480 is out of bounds        then abort, rc 134
  after    rejected at compile time
```

The same file does not check the M mode or the N mode. This change adds an assert for each of the three modes.

```diff
  // include/cutlass/gemm/collective/builders/sm120_blockwise_mma_builder.inl:136
+ static_assert(cute::size(ClusterShape_MNK{}) == Int<1>{}, "no programmatic multicast on this arch");
```

The blockwise builder is the only one of the six SM120 mainloop builders without a cluster bound. 
The five other builders hold the same line at `sm120_mma_builder.inl:84`, `sm120_array_mma_builder.inl:87`, `sm120_blockscaled_mma_builder.inl:104`, `sm120_blockscaled_sparse_mma_builder.inl:179` and `sm120_sparse_mma_builder.inl:163`.

The sparse batch stride multiplies two `int` extents. The product overflows, and the cast to `int64_t` then widens a value that is already wrong. There are eight sites, four in each configuration header.

```diff
- (L == 1) ? int64_t(0) : int64_t(M_AlignedAC * K_AlignedAC)
+ (L == 1) ? int64_t(0) : int64_t(M_AlignedAC) * int64_t(K_AlignedAC)

  e4m3, L = 2, batch stride of E
  Sm90GemmSparseConfig    M 49153  K 65537   -1066397696  ->  3228569600
  Sm1xxGemmSparseConfig   M 49153  K 65537   -1059045376  ->  3235921920
  Sm90GemmSparseConfig    M 65536  K 65536             0  ->  4294967296

sm90   E layout = ((_64,769),(_64,1025),2)      atom 64 x 64
       M: 49153 -> 49216  (64 x 769)
       K: 65537 -> 65600  (64 x 1025)      49216 x 65600 = 3228569600

sm1xx  E layout = ((_128,385),(_128,513),2)     atom 128 x 128
       M: 49153 -> 49280  (128 x 385)
       K: 65537 -> 65664  (128 x 513)      49280 x 65664 = 3235921920
```

https://github.com/NVIDIA/cutlass/issues/3269 reports the same overflow in `packed_stride.hpp`, and https://github.com/NVIDIA/cutlass/pull/3307 holds a fix for the two sites in that file.
https://github.com/NVIDIA/cutlass/issues/3393 asks for a `static_assert` in place of a template backtrace on the SM120 sparse block-scaled collective, and https://github.com/NVIDIA/cutlass/pull/3427 added one there.

A kernel that calls `fill_layoutA` and `fill_layoutE`, at `-O3 -DNDEBUG`:

```
           SASS instructions      registers
           before   after         before   after
sm_120a        48      40             10      12
```

@depaulmillz
