### PR TITLE
fix(tvm-ffi): env stream detection for tuple parameters

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/tvm_ffi_builder/tvm_ffi_builder.py
+++ b/python/CuTeDSL/cutlass/base_dsl/tvm_ffi_builder/tvm_ffi_builder.py
@@ -2440,6 +2440,10 @@ class TVMFFIFunctionBuilder(TVMFFIBuilder):
                     op_bundle_sizes=[],
                     op_bundle_operands=[],
                 )
+            elif isinstance(param, spec.TupleParam):
+                stream = self.find_env_stream(param.params)
+                if stream is not None:
+                    return stream
         return None
 
     def get_expected_num_args(self, params: list[spec.Param]) -> int:

--- a/test/examples/CuTeDSL/test_tvm_ffi_env_stream.py
+++ b/test/examples/CuTeDSL/test_tvm_ffi_env_stream.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import cuda.bindings.driver as cuda
+import torch
+
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+
+N = 128
+
+
+@cute.kernel
+def _add_one_kernel(src: cute.Tensor, dst: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    dst[tidx] = src[tidx] + 1.0
+
+
+@cute.jit
+def _add_one_nested(tensors: tuple, stream: cuda.CUstream):
+    src, dst = tensors
+    _add_one_kernel(src, dst).launch(
+        grid=[1, 1, 1], block=[N, 1, 1], stream=stream
+    )
+
+
+def test_env_stream_detected_from_nested_tuple():
+    src_torch = torch.arange(N, dtype=torch.float32, device="cuda")
+    dst_torch = torch.zeros(N, dtype=torch.float32, device="cuda")
+    src = from_dlpack(
+        src_torch, assumed_align=16, enable_tvm_ffi=True
+    ).mark_layout_dynamic()
+    dst = from_dlpack(
+        dst_torch, assumed_align=16, enable_tvm_ffi=True
+    ).mark_layout_dynamic()
+    env_stream = make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    compiled = cute.compile(
+        _add_one_nested,
+        (src, dst),
+        env_stream,
+        options="--enable-tvm-ffi",
+    )
+
+    torch.cuda.synchronize()
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        compiled((src_torch, dst_torch))
+    stream.synchronize()
+
+    assert torch.equal(dst_torch, src_torch + 1)


### PR DESCRIPTION
## Summary

- recursively search `spec.TupleParam.params` when detecting the TVM-FFI environment stream
- preserve the existing left-to-right selection of the first non-CPU tensor
- add a regression test using tuple-nested tensors and a non-default PyTorch stream

Fixes #3444.

## Root cause

`TVMFFIFunctionBuilder.find_env_stream()` only inspected top-level parameters. When every GPU tensor was contained by a `spec.TupleParam`, the search returned `None` and wrapper construction raised `EnvStream cannot be detected` even though the parameter tree contained GPU tensors.

## Validation

Tested on an NVIDIA GeForce RTX 4070 Ti SUPER (SM89) against commit `564d267e4c`.

### Base

```text
python -m pytest test/examples/CuTeDSL/test_tvm_ffi_env_stream.py -q --runtime-sm 89
1 failed in 0.70s
```

The test failed during `cute.compile()` with the expected `EnvStream cannot be detected` error.

### Patched

```text
python -m pytest test/examples/CuTeDSL/test_tvm_ffi_env_stream.py -q --runtime-sm 89
1 passed in 0.42s
```

### Neighboring tests

```text
python -m pytest \
  test/examples/CuTeDSL/test_dataclasses.py \
  test/examples/CuTeDSL/test_for_control_flow.py \
  test/examples/CuTeDSL/test_math.py \
  -q --runtime-sm 89
5 passed in 0.42s
```

The local editable environment used the preparation-script change from #3417; that unrelated file is not included in this pull request.
