### PR TITLE
[CuTeDSL] Skip unusable CUTE_DSL_LIBS entries instead of failing the compile

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/dsl.py
+++ b/python/CuTeDSL/cutlass/base_dsl/dsl.py
@@ -54,7 +54,12 @@ import warnings
 import threading
 
 from . import typing as t
-from .env_manager import EnvironmentVarManager, dump_sass, is_cutlass_family_dsl_prefix
+from .env_manager import (
+    EnvironmentVarManager,
+    discover_dsl_libs,
+    dump_sass,
+    is_cutlass_family_dsl_prefix,
+)
 from .compiler import CompileOptions, CompilerDiagnosticError, LinkLibraries
 from .ast_helpers import DSLOptimizationWarning
 from .common import DSLRuntimeError, active_env_manager
@@ -1823,13 +1828,35 @@ class BaseDSL(metaclass=DSLSingletonMeta):
         shared_libs = []
         support_libs = self.envar.shared_libs
         if support_libs is not None:
-            _libs = support_libs.split(":")
-            for lib in _libs:
-                if not os.path.exists(lib):
+            missing = []
+            for lib in support_libs.split(":"):
+                if not lib:
+                    continue
+                if os.path.exists(lib):
+                    shared_libs.append(lib)
+                else:
+                    missing.append(lib)
+
+            if missing and not shared_libs:
+                # Every entry is stale. This happens when {prefix}_LIBS is
+                # inherited from a machine that does not share this
+                # filesystem, e.g. Slurm's default --export=ALL. Retry
+                # auto-discovery so a valid local runtime is still found.
+                discovered = discover_dsl_libs(self.name)
+                if discovered:
+                    shared_libs = [
+                        lib for lib in discovered.split(":") if os.path.exists(lib)
+                    ]
+
+            if missing:
+                if not shared_libs:
                     raise FileNotFoundError(
-                        errno.ENOENT, os.strerror(errno.ENOENT), lib
+                        errno.ENOENT, os.strerror(errno.ENOENT), missing[0]
                     )
-                shared_libs.append(lib)
+                self.print_warning(
+                    f"Ignoring missing {self.name}_LIBS entries: "
+                    f"{', '.join(missing)}. Using {':'.join(shared_libs)}."
+                )
         else:
             if is_cutlass_family_dsl_prefix(self.name):
                 self.print_warning(

--- a/python/CuTeDSL/cutlass/base_dsl/env_manager.py
+++ b/python/CuTeDSL/cutlass/base_dsl/env_manager.py
@@ -415,17 +415,12 @@ def dump_sass(
         subprocess.run(tokens, stdout=sys.stderr, check=True)
 
 
-def get_prefix_dsl_libs(prefix: str) -> str | None:
+def discover_dsl_libs(prefix: str) -> str | None:
     """
-    Returns get_str_env_var('{prefix}_LIBS') if set.
-    Otherwise, attempts to discover libs based on heuristics and return
+    Attempts to discover libs based on heuristics, ignoring '{prefix}_LIBS'.
     If not found, return None.
     """
-    # Check if the environment variable is already set, if so, return it immediately.
     try:
-        prefix_libs_existing = get_str_env_var(f"{prefix}_LIBS")
-        if prefix_libs_existing:
-            return prefix_libs_existing
 
         def get_libs_cand(start: str | Path) -> str | None:
             target_dsl_runtime_libs = {
@@ -472,8 +467,22 @@ def get_prefix_dsl_libs(prefix: str) -> str | None:
         return None
 
     except Exception as e:
-        log().info("default_env: exception on get_prefix_dsl_libs", e)
+        log().info("default_env: exception on discover_dsl_libs", e)
     return None
+
+
+def get_prefix_dsl_libs(prefix: str) -> str | None:
+    """
+    Returns get_str_env_var('{prefix}_LIBS') if set.
+    Otherwise, attempts to discover libs based on heuristics and return
+    If not found, return None.
+    """
+    # Check if the environment variable is already set, if so, return it immediately.
+    prefix_libs_existing = get_str_env_var(f"{prefix}_LIBS")
+    if prefix_libs_existing:
+        return prefix_libs_existing
+
+    return discover_dsl_libs(prefix)
 
 
 class LogEnvironmentManager:

--- a/test/python/CuTeDSL/test_shared_libs_env.py
+++ b/test/python/CuTeDSL/test_shared_libs_env.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for resolving the DSL runtime libraries from CUTE_DSL_LIBS.
+
+CUTE_DSL_LIBS is a colon separated list and is routinely inherited by
+processes that never set it themselves, for example under Slurm, whose
+sbatch defaults to --export=ALL. An entry that names a path on the
+submitting machine must not prevent a valid local runtime from being
+used; only the complete absence of a usable runtime is an error.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import cutlass
+from cutlass.cutlass_dsl.cutlass import CuTeDSL
+
+
+class TestSharedLibsFromEnv(unittest.TestCase):
+    def setUp(self):
+        self.dsl = CuTeDSL._get_dsl()
+        self._saved = self.dsl.envar.shared_libs
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.valid = os.path.join(tmpdir.name, "libcute_dsl_runtime.so")
+        with open(self.valid, "w"):
+            pass
+        self.stale = "/nonexistent/submitter/libcute_dsl_runtime.so"
+
+    def tearDown(self):
+        self.dsl.envar.shared_libs = self._saved
+
+    def test_valid_entries_are_returned_unchanged(self):
+        self.dsl.envar.shared_libs = self.valid
+        self.assertEqual(self.dsl.get_shared_libs(), [self.valid])
+
+    def test_stale_entry_is_skipped_when_a_valid_one_remains(self):
+        """A path inherited from another machine must not mask the local
+        runtime that sits next to it in the same list."""
+        self.dsl.envar.shared_libs = f"{self.valid}:{self.stale}"
+        with self.assertWarns(UserWarning) as caught:
+            self.assertEqual(self.dsl.get_shared_libs(), [self.valid])
+        self.assertIn(self.stale, str(caught.warning))
+
+    def test_all_entries_stale_falls_back_to_auto_discovery(self):
+        self.dsl.envar.shared_libs = self.stale
+        with mock.patch(
+            "cutlass.base_dsl.dsl.discover_dsl_libs", return_value=self.valid
+        ) as discover:
+            with self.assertWarns(UserWarning):
+                self.assertEqual(self.dsl.get_shared_libs(), [self.valid])
+        discover.assert_called_once_with(self.dsl.name)
+
+    def test_raises_when_no_usable_runtime_is_found(self):
+        """Preserves the hard failure of issue #3329: a missing runtime is
+        still reported at compile time rather than deferred to a confusing
+        downstream symbol error."""
+        self.dsl.envar.shared_libs = self.stale
+        with mock.patch("cutlass.base_dsl.dsl.discover_dsl_libs", return_value=None):
+            with self.assertRaises(FileNotFoundError) as caught:
+                self.dsl.get_shared_libs()
+        self.assertEqual(caught.exception.filename, self.stale)
+
+    def test_empty_entries_are_ignored(self):
+        """A trailing separator, as produced by joining onto an empty
+        CUTE_DSL_LIBS, is not a missing library."""
+        self.dsl.envar.shared_libs = f"{self.valid}:"
+        self.assertEqual(self.dsl.get_shared_libs(), [self.valid])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`get_shared_libs` raises on the first missing entry of `CUTE_DSL_LIBS`, so one stale path fails the compile even when a valid runtime sits earlier in the same list. Reported by @sshleifer in #3462.

@anakinxc said on that issue that a fix is already in progress, so this may well duplicate work already done. It covers only the part that lives in this repository, and I am glad to close it if it overlaps with yours. The test may still be worth keeping either way.

Partial fix for #3462.

## Root cause

`get_prefix_dsl_libs` returns `{prefix}_LIBS` verbatim whenever it is set, which also means auto-discovery never runs. `get_shared_libs` then treats that list as all or nothing, so any single unusable entry is fatal.

## Change

Missing entries are skipped with a warning. If no entry is usable, auto-discovery is retried before giving up, and `FileNotFoundError` is raised only when that also finds nothing.

To make the retry possible the discovery block is split out of `get_prefix_dsl_libs` into `discover_dsl_libs`, which does not consult the environment. `get_prefix_dsl_libs` keeps its previous behaviour and signature.

The hard failure added for #3329 is preserved. When no runtime can be found, the same `FileNotFoundError` is raised from the same place with a concrete path, rather than deferring to a downstream symbol error. `test_raises_when_no_usable_runtime_is_found` pins that.

## Reproduction

CPU-only container, no GPU:

```
docker run -d --name cutlass-repro --platform linux/arm64 -v $PWD:/repo -w /work python:3.12-slim sleep infinity
docker exec cutlass-repro pip install nvidia-cutlass-dsl==4.7.0
```

`repro.py` imports cutlass with a stale value already in the environment, as a Slurm worker would inherit it, then compiles a trivial jit function. `import cutlass` prepends the worker's own valid runtime, so a good path is first in the list.

Before:

```
CUTE_DSL_LIBS seen by compile = /usr/local/.../cu12/lib/libcute_dsl_runtime.so:/nonexistent/submitter-venv/libcute_dsl_runtime.so
  exists=True  /usr/local/.../cu12/lib/libcute_dsl_runtime.so
  exists=False /nonexistent/submitter-venv/libcute_dsl_runtime.so
RESULT: FileNotFoundError: [Errno 2] No such file or directory: '/nonexistent/submitter-venv/libcute_dsl_runtime.so'
```

After:

```
UserWarning: Ignoring missing CUTE_DSL_LIBS entries: /nonexistent/submitter-venv/libcute_dsl_runtime.so. Using /usr/local/.../cu12/lib/libcute_dsl_runtime.so.
RESULT: compiled OK
```

An unset or fully valid `CUTE_DSL_LIBS` is unaffected.

## Tests

`test/python/CuTeDSL/test_shared_libs_env.py`, five cases, following `test_struct_in_if.py` in the same directory.

```
python -m unittest discover -s test/python/CuTeDSL -p 'test_*.py'
Ran 11 tests in 0.252s

OK
```

That count includes the existing `test_struct_in_if.py`. Reverting only the two source files and keeping the test leaves 4 of the 5 failing, including `test_stale_entry_is_skipped_when_a_valid_one_remains` with the production `FileNotFoundError`. `test_valid_entries_are_returned_unchanged` passes either way and guards against regressing the normal path.

## What this does not fix

The other half of #3462 is the import-time write in `_select_and_load_cutlass_ir_toolkit`, which prepends an absolute site-packages path into `os.environ["CUTE_DSL_LIBS"]`. That code is in `cutlass/_mlir/_mlir_libs/__init__.py`, which is not in this repository and never has been. `git log --all -- python/CuTeDSL/cutlass/_mlir` is empty, and `prep_editable_install.py` obtains the directory by downloading and unpacking the published wheel. I confirmed the write is present in the installed 4.7.0 wheel but had no way to change it here.

So a launcher that imports cutlass still exports a submitter-local path to its workers. This change stops that from being fatal on the receiving side, which is the part that takes jobs down.

## Notes

Tested in a CPU-only linux/arm64 container, so no GPU execution path was exercised. `cute.compile` does run without a device, so the failure and the fix are both reachable end to end through the documented reproduction rather than only at unit level. `get_shared_libs` itself is path handling and does not touch the driver.

The installed `base_dsl/dsl.py` and `base_dsl/env_manager.py` in the 4.7.0 wheel are byte identical to the ones in this tree, so the container exercises these sources.

`black` leaves the changed regions alone. It does want to reformat other parts of both files, but it wants the identical hunks at `HEAD`, so I left those alone.
