### PR TITLE
[CuTeDSL] Fix TMEM struct scalar pointer access

### DIFF
--- a/python/CuTeDSL/cutlass/cute/arch/tmem.py
+++ b/python/CuTeDSL/cutlass/cute/arch/tmem.py
@@ -19,6 +19,7 @@ from cutlass._mlir import ir
 import cutlass._mlir.dialects.cute as _cute_ir
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
 
+from ..core import struct
 from ..typing import Pointer, Int, Int32, Numeric, NumericMeta
 
 SM100_TMEM_CAPACITY_COLUMNS = (
@@ -106,7 +107,11 @@ def retrieve_tmem_ptr(
     res_ty = _cute_ir.PtrType.get(element_type.mlir_type, AddressSpace.tmem, alignment)
     return _cute_nvgpu_ir.arch_sm100_retrieve_tmem_ptr(
         res_ty,
-        ptr_to_buffer_holding_addr.value,
+        (
+            ptr_to_buffer_holding_addr.ptr.value
+            if isinstance(ptr_to_buffer_holding_addr, struct._ScalarData)
+            else ptr_to_buffer_holding_addr.value
+        ),
         loc=loc,
         ip=ip,
     )
@@ -151,7 +156,11 @@ def alloc_tmem(
 
     _cute_nvgpu_ir.arch_sm100_alloc_tmem(
         Int32(num_columns).ir_value(loc=loc, ip=ip),
-        smem_ptr_to_write_address.value,
+        (
+            smem_ptr_to_write_address.ptr.value
+            if isinstance(smem_ptr_to_write_address, struct._ScalarData)
+            else smem_ptr_to_write_address.value
+        ),
         is_two_cta=is_two_cta,
         loc=loc,
         ip=ip,


### PR DESCRIPTION
fix: [#3451](https://github.com/NVIDIA/cutlass/issues/3451) TMEM helpers accessed struct scalar pointers through the deprecated `.value` property. Use the explicit `.ptr.value` path for struct scalar wrappers while preserving ordinary `Pointer` handling.