### PR TITLE
Soft-error swizzle composed slice when ZY projection fails

### DIFF
--- a/cutlass_compiler/cute_ir/test/Dialect/Cute/LayoutAlgebra/slice_errors.mlir
+++ b/cutlass_compiler/cute_ir/test/Dialect/Cute/LayoutAlgebra/slice_errors.mlir
@@ -123,3 +123,17 @@ func.func @kind_mismatch_composed_to_layout(
        !cute.layout<"(2):(1)">
   return
 }
+
+// -----
+
+// NVIDIA/cutlass#3454: swizzle-projection composition fails for static
+// outer (10,2):(2,1); must diagnose, not abort in cutegen static_size.
+func.func @swizzle_composed_slice_incompatible_outer(
+    %src: !cute.composed_layout<"S<3,4,3> o 0 o (10,2):(2,1)">,
+    %crd: !cute.coord<"(_,0)">) {
+  // expected-error@+1 {{unable to slice '!cute.composed_layout<"S<3,4,3> o 0 o (10,2):(2,1)">' with '!cute.coord<"(_,0)">'}}
+  %r = cute.slice(%src, %crd)
+         : !cute.composed_layout<"S<3,4,3> o 0 o (10,2):(2,1)">,
+           !cute.coord<"(_,0)">
+  return
+}

--- a/cutlass_compiler/cutegen/include/cutegen/composed_layout.hpp
+++ b/cutlass_compiler/cutegen/include/cutegen/composed_layout.hpp
@@ -652,9 +652,14 @@ auto slice_and_offset(const TCoord&                       crd,
 
     const layout_t sliced_layout = slice(crd, lay_b);
     // A layout that is a slice of a static layout is also static
-    assert(is_static(sliced_layout));
+    if(!is_static(sliced_layout) || !is_valid(sliced_layout))
+        return std::make_tuple(composed_layout_t(cg_error_t{}), offset_t(0));
+    // Composition with the swizzle Z/Y projection can fail (e.g. outer modes that
+    // do not compose with the projection). Soft-error instead of static_size assert.
+    // See NVIDIA/cutlass#3454: S<3,4,3> o 0 o (10,2):(2,1) + (_,0).
     const layout_t sliced_layout_only_zy = composition(projection_layout_only_zy, sliced_layout);
-    assert(is_static(sliced_layout_only_zy));
+    if(!is_valid(sliced_layout_only_zy) || !holds_int(size(sliced_layout_only_zy)))
+        return std::make_tuple(composed_layout_t(cg_error_t{}), offset_t(0));
 
     const auto swizzle_active_bits = sliced_layout_only_zy(static_size(sliced_layout_only_zy) - 1);
     using index_t                  = decltype(swizzle_active_bits);
@@ -667,7 +672,8 @@ auto slice_and_offset(const TCoord&                       crd,
     // sw_a. We convert that to a boolean.
     const auto intersection = scalar_bitwise_and<index_t>(swizzle_active_bits,
                                                           scalar_bitwise_not<index_t>(sw_a(swizzle_active_bits)));
-    assert(holds_int(intersection));
+    if(!holds_int(intersection))
+        return std::make_tuple(composed_layout_t(cg_error_t{}), offset_t(0));
     //const bool z_and_y_collide = swizzle_active_bits & ~sw_a(swizzle_active_bits);
     const bool z_and_y_collide = (intersection != 0);
 
@@ -675,9 +681,12 @@ auto slice_and_offset(const TCoord&                       crd,
     const TCoord   diced_crd            = dice(crd, crd);
     const layout_t diced_layout_only_zy = composition(projection_layout_only_zy, diced_layout);
     const layout_t diced_layout_anti_zy = composition(projection_layout_anti_zy, diced_layout);
+    if(!is_valid(diced_layout_only_zy) || !is_valid(diced_layout_anti_zy))
+        return std::make_tuple(composed_layout_t(cg_error_t{}), offset_t(0));
 
     const auto idx_of_diced_coord_only_zy = diced_layout_only_zy(diced_crd);
-    assert(holds_int_or_dynamic_int(idx_of_diced_coord_only_zy));
+    if(!holds_int_or_dynamic_int(idx_of_diced_coord_only_zy))
+        return std::make_tuple(composed_layout_t(cg_error_t{}), offset_t(0));
     // Assuming that idx_of_diced_coord_only_zy is not static, the following bitwise XOR creates
     // a dynamic offset. In case we can degenerate the sliced swizzled layout into an affine layout,
     // the latter is doomed to be partially dynamic. CuTe-C++ further optimizes this by tracking

--- a/cutlass_compiler/cutegen/test/cg_composed_layout_test.cpp
+++ b/cutlass_compiler/cutegen/test/cg_composed_layout_test.cpp
@@ -176,6 +176,25 @@ TEST(ComposedLayoutTest, SliceStaticSwizzledLayouts)
             EXPECT_EQ(sl.layout_b(), cg::slice(c, l.layout_b()));
         }
     }
+    {
+        // NVIDIA/cutlass#3454: swizzle-projection composition fails for (10,2):(2,1)
+        // and must soft-error instead of asserting in static_size.
+        cg::swizzle         sw(3, 4, 3);
+        cg::composed_layout bad(sw, cg::int_tuple(0),
+                                cg::layout(cg::shape(10, 2), cg::stride(2, 1)));
+        auto [sliced_bad, offset_bad] =
+            cg::slice_and_offset(cg::coord(cg::_, 0), bad);
+        EXPECT_FALSE(cg::is_valid(sliced_bad));
+        (void)offset_bad;
+
+        cg::composed_layout ok(sw, cg::int_tuple(0),
+                               cg::layout(cg::shape(8, 2), cg::stride(2, 1)));
+        auto [sliced_ok, offset_ok] = cg::slice_and_offset(cg::coord(cg::_, 0), ok);
+        EXPECT_TRUE(cg::is_valid(sliced_ok));
+        EXPECT_TRUE(sliced_ok.is_normal_layout());
+        EXPECT_EQ(cg::to_string(sliced_ok.layout_b()), std::string("(8):(2)"));
+        EXPECT_EQ(offset_ok.as_int(), 0);
+    }
 }
 
 TEST(ComposedLayoutTest, SliceAffineLayouts)


### PR DESCRIPTION
`cute.slice_` on `S<3,4,3> o 0 o (10,2):(2,1)` aborted in cutegen `static_size`.
Y/Z projection composition made an invalid layout.
Return `cg_error` instead.
`SliceOp` then emits `unable to slice`.
`(8,2)` still becomes `(8):(2)`.

Fixes #3454

Header-only: `(10,2)` invalid, no assert.
`(8,2)` and `(64,128)` still valid.
Unit test: `cg_composed_layout_test.cpp`.
`slice_errors.mlir` is in the diff. Needs `cute-opt`. Not run here.

Assisted by: Cursor
