### PR TITLE
Specialize updates to pipeline states' `index` - help compiler DCE index 

### DIFF
--- a/include/cutlass/pipeline/sm90_pipeline.hpp
+++ b/include/cutlass/pipeline/sm90_pipeline.hpp
@@ -202,7 +202,11 @@ struct PipelineState {
 
   CUTLASS_DEVICE
   void operator++() {
-    if constexpr (Stages > 0) {
+    if constexpr (Stages == 1) {
+      phase_ ^= 1;
+      ++count_;
+    }
+    else if constexpr (Stages > 0) {
       ++index_;
       ++count_;
       if (index_ == Stages) {
@@ -241,6 +245,20 @@ struct PipelineState {
       count_ += num_iterations;
     }
     return *this;
+  }
+
+  template<uint32_t NumIterations>
+  CUTLASS_DEVICE
+  PipelineState& advance() {
+    if constexpr (Stages > 0 && NumIterations == Stages) {
+      // A full traversal returns to the same stage and flips the phase once.
+      phase_ ^= 1;
+      count_ += NumIterations;
+      return *this;
+    }
+    else {
+      return advance(NumIterations);
+    }
   }
 
   CUTLASS_DEVICE


### PR DESCRIPTION
This pull request updates the `PipelineState` struct in `sm90_pipeline.hpp` (used for sm90+ arches) to improve the handling of pipeline stage advancement, especially for single-stage and multi-iteration scenarios. The main changes clarify and optimize how the pipeline state is updated.

Pipeline state advancement improvements:

* Updated the `operator++` to handle the single-stage (`Stages == 1`) case by toggling `phase_` and incrementing `count_`, ensuring correct phase handling for `Stages == 1` and maintaining the previous logic for `Stages > 0`.
* Added a templated `advance<NumIterations>()` method to efficiently advance the pipeline state by a full traversal when `NumIterations == Stages`, toggling `phase_` and updating `count_`.

In both changes skip updating index and make it easier for the compiler to DCE index for the pipeline guarding single-staged resource or multi-staged resource with index updates equal to Stages