### PR TITLE
Fix unsubstituted version/revision placeholders in version.h

### DIFF
--- a/include/cutlass/version.h
+++ b/include/cutlass/version.h
@@ -71,7 +71,9 @@ namespace cutlass {
 
 #if !defined(__CUDACC_RTC__)
   inline std::string getVersionString() {
-    std::string version = "@CUTLASS_VERSION@";
+    std::string version = std::to_string(getVersionMajor()) + "."
+                         + std::to_string(getVersionMinor()) + "."
+                         + std::to_string(getVersionPatch());
     if (getVersionBuild()) {
       version += "." + std::to_string(getVersionBuild());
     }
@@ -79,7 +81,7 @@ namespace cutlass {
   }
 
   inline std::string getGitRevision() {
-    return "@CUTLASS_REVISION@";
+    return CUTLASS_REVISION;
   }
 #endif // !defined(__CUDACC_RTC__)
 


### PR DESCRIPTION
Fixes #3472.

`getVersionString()` and `getGitRevision()` in `include/cutlass/version.h` return the literal, unsubstituted CMake placeholder strings `"@CUTLASS_VERSION@"` / `"@CUTLASS_REVISION@"` for every consumer, since nothing in the current build ever processes `version.h` itself as a template.

The actual CMake-substituted revision is already available a few lines above: when built via CMake, `CUTLASS_VERSIONS_GENERATED` is defined and `version_extended.h` (generated from `cmake/version_extended.h.in`) redefines `CUTLASS_REVISION` with the real git hash; otherwise it falls back to `""`. `getVersionBuild()` already correctly reads `CUTLASS_BUILD` from that same mechanism — `getGitRevision()` just needs to do the same for `CUTLASS_REVISION` instead of hardcoding the placeholder.

There's no equivalent generated macro for the version string (the `.in` template only substitutes `CUTLASS_VERSION_BUILD` and `CUTLASS_REVISION`), so `getVersionString()` now builds a `MAJOR.MINOR.PATCH[.BUILD]` string from the existing `getVersionMajor()`/`getVersionMinor()`/`getVersionPatch()`/`getVersionBuild()` accessors instead.

Header-only change, no build system changes.
