### PR TITLE
[SM90] Support MXFP4A8 Group Gemm for the SM90 mixed-input.

### DIFF
--- a/include/cutlass/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_mixed_input.hpp
+++ b/include/cutlass/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_mixed_input.hpp
@@ -258,6 +258,23 @@ public:
                                         KernelConversionMode == ConversionMode::ConvertAndScaleWithZero;
   static constexpr bool UseScaleLookupTable = KernelConversionMode == ConversionMode::ConvertAndScale &&
                                               cutlass::detail::is_Array_v<ElementScale>;
+  static constexpr bool EnableActBlockScale = ModeHasScales &&
+                                              cute::is_same_v<RealSwappedElementA, cutlass::float_e2m1_t>;
+  static constexpr int MxScalePackedNum = [] {
+    if constexpr (EnableActBlockScale && cutlass::detail::is_Array_v<ElementScale>) {
+      return static_cast<int>(NonVoidElementScale::kElements);
+    }
+    else {
+      return 1;
+    }
+  }();
+  static constexpr int MxGroupSize = ModeHasScales ? (static_cast<int>(cute::size<2>(TileShape{})) / MxScalePackedNum) :
+                                                    static_cast<int>(cute::size<2>(TileShape{}));
+  using SmemLayoutAtomActScale = Layout<Shape<decltype(cute::shape<1>(TileShape{})), cute::Int<1>>>;
+  using ActScaleTileShape = decltype(make_shape(shape<1>(TileShape{}), shape<1>(SmemLayoutAtomActScale{})));
+  using SmemLayoutActScale = decltype(make_layout(
+    append(shape(SmemLayoutAtomActScale{}), Int<Stages>{}),
+    append(stride(SmemLayoutAtomActScale{}), size(filter_zeros(SmemLayoutAtomActScale{})))));
   static constexpr size_t SmemAlignmentA = cutlass::detail::alignment_for_swizzle(SmemLayoutA{});
   static constexpr size_t SmemAlignmentB = cutlass::detail::alignment_for_swizzle(SmemLayoutB{});
   static constexpr size_t SmemAlignmentScale = cute::max(SmemAlignmentA, SmemAlignmentB);
@@ -267,11 +284,13 @@ public:
   struct SharedStorage {
     static constexpr int scale_elements = Utils::elements_per_smem_scale();
     static constexpr int zero_elements = Utils::elements_per_smem_zero();
+    static constexpr int act_scale_elements = EnableActBlockScale ? cute::cosize_v<SmemLayoutActScale> : 0;
     struct TensorStorage {
       CUTE_ALIGNAS(SmemAlignmentA) cute::ArrayEngine<RealSwappedElementA, cute::cosize_v<SmemLayoutA>> smem_A;
       CUTE_ALIGNAS(SmemAlignmentB) cute::ArrayEngine<typename TiledMma::ValTypeB, cute::cosize_v<SmemLayoutB>> smem_B;
       cute::ArrayEngine<NonVoidElementScale, scale_elements> smem_scale;
       cute::ArrayEngine<NonVoidElementZero, zero_elements> smem_zero;
+      CUTE_ALIGNAS(SmemAlignmentScale) cute::ArrayEngine<NonVoidElementScale, act_scale_elements> smem_act_scale;
     } tensors;
 
     struct TensorMapStorage {
@@ -279,6 +298,7 @@ public:
       cute::TmaDescriptor smem_tensormap_B;
       cute::TmaDescriptor smem_tensormap_scale;
       cute::TmaDescriptor smem_tensormap_zero;
+      cute::TmaDescriptor smem_tensormap_act_scale;
     };
 
     using PipelineStorage = typename MainloopPipeline::SharedStorage;
@@ -300,6 +320,8 @@ public:
     NonVoidStrideScale const* dS{};
     int chunk_size = 0;
     ElementZero const** ptr_Z = nullptr;
+    NonVoidElementScale const** ptr_AS = nullptr;
+    NonVoidStrideScale const* dAS = nullptr;
   };
 
   // Device side kernel params
@@ -336,11 +358,19 @@ public:
         ScaleTileShape{},
         _1{}));  // mcast along N mode for this M load, if any. Scale is ALWAYS loaded with A for RF kernel
 
+    using TMA_ActScale = decltype(make_tma_copy<TmaElementScale>(
+        GmemTiledCopyScale{},
+        make_tensor(detail::get_logical_ptr(static_cast<NonVoidElementScale const*>(nullptr)), repeat_like(NonVoidStrideScale{}, int32_t(0)), NonVoidStrideScale{}),
+        SmemLayoutActScale{}(_,_,cute::Int<0>{}),
+        ActScaleTileShape{},
+        _1{}));
+
     TMA_A tma_load_a;
     TMA_B tma_load_b;
     uint32_t tma_transaction_bytes = TmaTransactionBytes;
     TMA_Scale tma_load_scale;
     TMA_Zero tma_load_zero;
+    TMA_ActScale tma_load_act_scale;
     void* tensormaps;
     SwappedElementA const** ptr_A;
     SwappedStrideA ptr_dA;
@@ -349,6 +379,8 @@ public:
     NonVoidElementScale const** ptr_S;
     NonVoidStrideScale const* dS;
     NonVoidElementZero const** ptr_Z;
+    NonVoidElementScale const** ptr_AS;
+    NonVoidStrideScale const* dAS;
     int64_t scale_k;
     int chunk_size;
     int reload_factor = (chunk_size + size<2>(TileShape{}) - 1) / size<2>(TileShape{});
@@ -459,6 +491,7 @@ public:
         size<0>(ClusterShape{})); // mcast along M mode for this N load, if any
     typename Params::TMA_Scale tma_load_scale{};
     typename Params::TMA_Zero tma_load_zero{};
+    typename Params::TMA_ActScale tma_load_act_scale{};
 
     void* tensormaps = workspace;
     auto args_setup = [&](auto ptr_A, auto ptr_B, int64_t scale_k = 0, int chunk_size = 0, int reload_factor = 1) -> Params {
@@ -468,6 +501,7 @@ public:
           TmaTransactionBytes,
           tma_load_scale,
           tma_load_zero,
+          tma_load_act_scale,
           tensormaps,
           reinterpret_cast<SwappedElementA const**>(ptr_A),
           ptr_dA,
@@ -476,6 +510,8 @@ public:
           reinterpret_cast<NonVoidElementScale const**>(args.ptr_S),
           args.dS,
           reinterpret_cast<NonVoidElementZero const**>(args.ptr_Z),
+          reinterpret_cast<NonVoidElementScale const**>(args.ptr_AS),
+          args.dAS,
           scale_k,
           chunk_size,
           reload_factor,
@@ -499,6 +535,18 @@ public:
           SmemLayoutScale{}(_,_,cute::Int<0>{}),
           ScaleTileShape{},
           _1{}); // mcast along N mode for this M load, if any
+
+      if constexpr (EnableActBlockScale) {
+        NonVoidElementScale const* ptr_AS = reinterpret_cast<NonVoidElementScale const*>(args.ptr_AS);
+        StrideScale dAS{};
+        Tensor tensor_act_scale = make_tensor(detail::get_logical_ptr(ptr_AS), make_layout(make_shape(init_N,scale_k,mock_L), dAS));
+        tma_load_act_scale = make_tma_copy<TmaElementScale>(
+            GmemTiledCopyScale{},
+            tensor_act_scale,
+            SmemLayoutActScale{}(_,_,cute::Int<0>{}),
+            ActScaleTileShape{},
+            _1{});
+      }
 
       if constexpr(KernelConversionMode == ConversionMode::ConvertAndScale) {
         return SwapAB ? args_setup(args.ptr_B, args.ptr_A, scale_k, args.chunk_size, (args.chunk_size + size<2>(TileShape{}) - 1) / size<2>(TileShape{}))
@@ -542,7 +590,7 @@ public:
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       // Allocate gmem space for input tensormaps per each SM, A tensormap copies followed by B tensormap copies, followed by scale tensormap copies
-      return calculate_workspace_size(3);
+      return calculate_workspace_size(EnableActBlockScale ? 4 : 3);
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       // Allocate gmem space for input tensormaps per each SM, A tensormap copies followed by B tensormap copies, followed by scale and zeros tensormap copies
@@ -601,6 +649,10 @@ public:
           implementable = implementable && (args.ptr_S != nullptr);
           if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
             implementable = implementable && (args.ptr_Z == nullptr);
+            if constexpr (EnableActBlockScale) {
+              implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_scale>(cute::make_shape(N,scale_k,L), StrideScale{});
+              implementable = implementable && (args.ptr_AS != nullptr);
+            }
           }
           else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
             constexpr int min_tma_aligned_elements_zero = tma_alignment_bits / cutlass::sizeof_bits<ElementZero>::value;
@@ -628,7 +680,11 @@ public:
   static constexpr uint32_t TmaTransactionBytesMK = Utils::compute_tma_transaction_bytes_mk();
   static constexpr uint32_t TmaTransactionBytesNK = Utils::compute_tma_transaction_bytes_nk();
   static constexpr uint32_t TmaTransactionBytesExtra = Utils::compute_tma_transaction_bytes_extra();
-  static constexpr uint32_t TmaTransactionBytes = TmaTransactionBytesMK + TmaTransactionBytesNK + TmaTransactionBytesExtra;
+  static constexpr uint32_t TmaTransactionBytesActScale = EnableActBlockScale ? cutlass::bits_to_bytes(
+      size<0>(SmemLayoutActScale{}) * size<1>(SmemLayoutActScale{}) *
+      static_cast<uint32_t>(cute::sizeof_bits_v<NonVoidElementScale>)) : 0;
+  static constexpr uint32_t TmaTransactionBytes = TmaTransactionBytesMK + TmaTransactionBytesNK + TmaTransactionBytesExtra +
+                                                 TmaTransactionBytesActScale;
 
   // Set up the data needed by this collective for load and mma.
   // Returns a tuple of tensors. The collective and the kernel layer have the contract that the
@@ -658,11 +714,18 @@ public:
     }
     else if constexpr (ModeHasScales) {
       const int scale_mn = SwapAB ? N : M;
-      auto scale_k = mainloop_params.scale_k;
+      auto scale_k = K / MxGroupSize;
       Tensor mS_mkl = mainloop_params.tma_load_scale.get_tma_tensor(make_shape(scale_mn,scale_k,L));
       Tensor gS_mkl = local_tile(mS_mkl, ScaleTileShape{}, make_coord(_,_));       // (BLK_M,BLK_Scale_K,m,scale_k,l)
       if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-        return cute::make_tuple(gA_mkl, gB_nkl, gS_mkl);
+        if constexpr (EnableActBlockScale) {
+          Tensor mAS_nkl = mainloop_params.tma_load_act_scale.get_tma_tensor(make_shape(N,scale_k,L));
+          Tensor gAS_nkl = local_tile(mAS_nkl, ActScaleTileShape{}, make_coord(_,_));       // (BLK_N,BLK_Scale_K,n,scale_k,l)
+          return cute::make_tuple(gA_mkl, gB_nkl, gS_mkl, gAS_nkl);
+        }
+        else {
+          return cute::make_tuple(gA_mkl, gB_nkl, gS_mkl);
+        }
       }
       else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
         Tensor mZ_mkl = mainloop_params.tma_load_zero.get_tma_tensor(make_shape(scale_mn,scale_k,L));
@@ -703,8 +766,14 @@ public:
       static_assert(sizeof... (TMs) == 2, "Direct convert needs two tensormaps");
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      static_assert(sizeof... (Ts) == 3, "Scaled convert needs three inputs");
-      static_assert(sizeof... (TMs) == 3, "Scaled convert needs three tensormaps");
+      if constexpr (EnableActBlockScale) {
+        static_assert(sizeof... (Ts) == 4, "Scaled convert needs four inputs");
+        static_assert(sizeof... (TMs) == 4, "Scaled convert needs four tensormaps");
+      }
+      else {
+        static_assert(sizeof... (Ts) == 3, "Scaled convert needs three inputs");
+        static_assert(sizeof... (TMs) == 3, "Scaled convert needs three tensormaps");
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       static_assert(sizeof... (Ts) == 4, "Scaled and zero convert needs four inputs");
@@ -802,7 +871,17 @@ public:
         }
 
         if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-          // Nothing extra to do
+          if constexpr (EnableActBlockScale) {
+            Tensor sAS = make_tensor(make_smem_ptr(shared_tensors.smem_act_scale.begin()), SmemLayoutActScale{});  // (BLK_N,BLK_K,PIPE)
+            Tensor gAS_nkl = get<3>(load_inputs);
+            auto block_tma_as = mainloop_params.tma_load_act_scale.get_slice(cluster_local_block_id.x);
+            Tensor gAS = gAS_nkl(_,_,n_coord,_,l_coord);                                                     // (BLK_N,BLK_K,k)
+            Tensor tASgAS = block_tma_as.partition_S(gAS);                                                 // (TMA,TMA_N,TMA_K,k)
+            Tensor tASsAS = block_tma_as.partition_D(sAS);                                              // (TMA,TMA_N,TMA_K,PIPE)
+            if (cute::elect_one_sync()) {
+              copy(mainloop_params.tma_load_act_scale.with(get<3>(input_tensormaps), *tma_barrier, mcast_mask_s), tASgAS(_,_,_,scale_load_k), tASsAS(_,_,_,write_stage));
+            }
+          }
         }
         else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
           auto tZgZ = get<2>(extra_input_partitions);
@@ -854,6 +933,7 @@ public:
       int thread_idx,
       TensorStorage& shared_tensors,
       Params const& mainloop_params) {
+    if constexpr (!EnableActBlockScale) {
 
     static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
     static_assert(cute::rank(SmemLayoutA{}) == 3, "Smem layout must be rank 3.");
@@ -1101,6 +1181,387 @@ public:
     }
 
     warpgroup_fence_operand(accum);
+
+    }
+    else {
+
+    static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
+    static_assert(cute::rank(SmemLayoutA{}) == 3, "Smem layout must be rank 3.");
+    static_assert(cute::rank(SmemLayoutB{}) == 3, "Smem layout must be rank 3.");
+    static_assert(cute::rank(SwappedSmemLayoutAtomA{}) == 2, "SwappedSmemLayoutAtomA must be rank 2.");
+    static_assert(cute::rank(SwappedSmemLayoutAtomB{}) == 2, "SwappedSmemLayoutAtomB must be rank 2.");
+    static_assert(!cute::is_void_v<SwappedSmemCopyAtomA>,
+      "SM90 GMMA mainloops must specify a non-void copy atom for smem sourced instructions.");
+    static_assert(cute::is_void_v<SwappedSmemCopyAtomB>,
+      "SM90 GMMA mainloops cannot have a non-void copy atom for smem sourced instructions.");
+
+    // Obtain warp index
+    int warp_idx = canonical_warp_idx_sync();
+    [[maybe_unused]] int warp_group_thread_idx = thread_idx % 128;
+
+
+    Tensor sA_ = make_tensor(make_smem_ptr(shared_tensors.smem_A.begin()), SmemLayoutA{});        // (BLK_M,BLK_K,PIPE)
+    Tensor sA = as_position_independent_swizzle_tensor(sA_);                                      // (BLK_M,BLK_K,PIPE)
+
+    Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()), SmemLayoutB{});         // (BLK_N,BLK_K,PIPE)
+
+
+    //
+    // Define C accumulators and A/B partitioning
+    //
+
+    // Layout of warp group to thread mapping
+
+    static_assert(stride<0>(typename TiledMma::BLayout{}) == 0 and
+                  size<0>(typename TiledMma::BLayout{}) == NumThreadsPerWarpGroup,
+                  "Stride of the first mode must be 0 and the size of the mode must be NumThreadsPerWarpGroup");
+
+    constexpr int MmaWarpGroups = size(TiledMma{}) / NumThreadsPerWarpGroup;
+    Layout warp_group_thread_layout = make_layout(Int<MmaWarpGroups>{},
+                                                  Int<NumThreadsPerWarpGroup>{});
+
+    int warp_group_idx = __shfl_sync(0xFFFFFFFF, thread_idx / NumThreadsPerWarpGroup, 0);
+
+    TiledMma tiled_mma;
+    auto mma_thread_slice = tiled_mma.get_thread_slice(thread_idx);
+    Tensor tCsA = mma_thread_slice.partition_A(sA);
+    auto mma_warpgroup_slice = tiled_mma.get_slice(warp_group_thread_layout(warp_group_idx));
+
+    // Allocate fragments and descriptors
+    Tensor tCrA_mma = mma_thread_slice.partition_fragment_A(sA(_,_,Int<0>{}));                // (MMA,MMA_M,MMA_K,PIPE)
+    Tensor tCrA_load = [&]{
+      if constexpr (not is_layout<InternalSwappedStrideA>::value) {
+        // Make register tensor with MMA layout
+        return make_fragment_like<RealSwappedElementA>(tCrA_mma);
+      }
+      else {
+        // Make register tensor matching smem layout, converter will take care of de-swizzling
+        return make_tensor_like<RealSwappedElementA>(tCsA(_,_,_,Int<0>{}));
+      }
+    }();
+    Tensor tCsB = mma_warpgroup_slice.partition_B(sB);                                        // (MMA,MMA_N,MMA_K,PIPE)
+    Tensor tCrB = mma_warpgroup_slice.make_fragment_B(tCsB);                                  // (MMA,MMA_N,MMA_K,PIPE)
+
+    //
+    // Copy Atom A retiling
+    //
+    auto smem_tiled_copy_A = make_tiled_copy_A(SwappedSmemCopyAtomA{}, tiled_mma);
+    auto smem_thr_copy_A   = smem_tiled_copy_A.get_thread_slice(warp_group_thread_idx);
+
+    Tensor tCrA_copy_view  = smem_thr_copy_A.retile_D(tCrA_load);                                  // (CPY,CPY_M,CPY_K)
+
+    // Partition of thread -> shared and thread -> RF
+    auto partitioned_extra_info = Utils::partition_extra_mma_info(mma_thread_slice, shared_tensors);
+    auto copy_partitions_extra_info = Utils::retile_extra_mma_info(tiled_mma, partitioned_extra_info, warp_group_thread_idx);
+
+    CUTE_STATIC_ASSERT_V(size<1>(tCsA) == size<1>(tCrA_copy_view));                                            // CPY_M
+    CUTE_STATIC_ASSERT_V(size<2>(tCsA) == size<2>(tCrA_copy_view));                                            // CPY_K
+    CUTE_STATIC_ASSERT_V(size<1>(tCrA_mma) == size<1>(accum));                                                 // MMA_M
+    CUTE_STATIC_ASSERT_V(size<1>(tCsB) == size<2>(accum));                                                         // N
+    CUTE_STATIC_ASSERT_V(size<2>(tCsA) == size<2>(tCsB));                                                          // K
+    CUTE_STATIC_ASSERT_V(size<3>(tCsA) == size<3>(tCsB));                                                       // PIPE
+    CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<2>(sA));                                         // PIPE
+    CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<2>(sB));                                         // PIPE
+
+    //
+    // PIPELINED MAIN LOOP
+    //
+
+    // We release buffers to producer warps(dma load) with some mmas in flight
+    PipelineState smem_pipe_release = smem_pipe_read;
+
+    multiply_add<ElementAccumulator> fma;
+
+    constexpr int NumMMAsPerChunk = MxGroupSize / cute::get<0,1>(tCsB.shape())();
+    constexpr int NumChunksPerTileK = cute::size<1>(sA.shape())() / MxGroupSize;
+    cute::array<decltype(make_fragment_like(accum)), NumChunksPerTileK> intermediate_array;
+
+    constexpr int K_BLOCK_MAX = size<2>(tCrA_load);
+    constexpr int K_WAIT_MAX = cute::min(K_BLOCK_MAX - 1, 7);
+    static_assert(K_BLOCK_MAX >= 4, "Consider increasing TileShapeK");
+
+    auto thr_mma_c = tiled_mma.get_slice(thread_idx);
+    auto sAS_bcast = [&]() {
+      if constexpr (EnableActBlockScale) {
+        return make_tensor(
+            make_smem_ptr(shared_tensors.smem_act_scale.begin()),
+            make_layout(
+                make_shape(size<0>(TileShape{}), size<1>(TileShape{}), Int<DispatchPolicy::Stages>{}),
+                make_stride(_0{}, stride<0>(SmemLayoutActScale{}), stride<2>(SmemLayoutActScale{}))));
+      } else {
+        return 0;
+      }
+    }();
+    auto tCsAS = [&]() {
+      if constexpr (EnableActBlockScale) {
+        return thr_mma_c.partition_C(sAS_bcast);
+      } else {
+        return 0;
+      }
+    }();
+    auto tCcAS = [&]() {
+      if constexpr (EnableActBlockScale) {
+        return thr_mma_c.partition_C(make_identity_tensor(make_shape(size<0>(TileShape{}), size<1>(TileShape{}))));
+      } else {
+        return 0;
+      }
+    }();
+    auto tCrAS = [&]() {
+      if constexpr (EnableActBlockScale) {
+        return make_tensor_like<NonVoidElementScale>(tCsAS(_,_,_,Int<0>{}));
+      } else {
+        return 0;
+      }
+    }();
+    auto load_act_scale = [&](int stage) {
+      if constexpr (EnableActBlockScale) {
+        auto const* raw = reinterpret_cast<typename NonVoidElementScale::Element const*>(shared_tensors.smem_act_scale.begin());
+        const int stage_off = stage * static_cast<int>(cute::size<0>(SmemLayoutActScale{})) *
+                              static_cast<int>(NonVoidElementScale::kElements);
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < cute::size(tCrAS); ++i) {
+          const int tok = static_cast<int>(cute::get<1>(tCcAS(i)));
+          const int base = stage_off + tok * static_cast<int>(NonVoidElementScale::kElements);
+          CUTLASS_PRAGMA_UNROLL
+          for (int c = 0; c < static_cast<int>(NonVoidElementScale::kElements); ++c) {
+            tCrAS(i)[c] = raw[base + c];
+          }
+        }
+      }
+    };
+
+    ConsumerToken barrier_token = {BarrierStatus::WaitAgain};
+    // first k tile
+    {
+      barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
+      pipeline.consumer_wait(smem_pipe_read, barrier_token);
+
+      int read_stage = smem_pipe_read.index();
+
+      ++smem_pipe_read;
+      barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
+
+      // copy smem->rmem for A operand
+
+      Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+        partitioned_extra_info, copy_partitions_extra_info, 0, read_stage);
+      if (K_BLOCK_MAX > 1) {
+        Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+          partitioned_extra_info, copy_partitions_extra_info, 1, read_stage);
+      }
+
+      Utils::dequantize_A_kblock(tCrA_load, tCrA_mma, partitioned_extra_info, 0);
+
+      // Unroll the K mode manually to set scale D to 1
+      CUTLASS_PRAGMA_UNROLL
+      for (int chunk_id = 0; chunk_id < NumChunksPerTileK; ++chunk_id) {
+        tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int mma_id = 0; mma_id < NumMMAsPerChunk; ++mma_id) {
+          int k_block = chunk_id * NumMMAsPerChunk + mma_id;
+
+          warpgroup_arrive();
+          cute::gemm(tiled_mma, tCrA_mma(_,_,k_block), tCrB(_,_,k_block,read_stage), intermediate_array[chunk_id]);
+          tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+          warpgroup_commit_batch();
+
+          if (k_block < K_BLOCK_MAX - 2) {
+            Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+              partitioned_extra_info, copy_partitions_extra_info, k_block + 2, read_stage);
+          }
+          if (k_block < K_BLOCK_MAX - 1) {
+            Utils::dequantize_A_kblock(tCrA_load, tCrA_mma, partitioned_extra_info, k_block + 1);
+          }
+        }
+      }
+
+      warpgroup_wait<0>();
+
+      load_act_scale(read_stage);
+      CUTLASS_PRAGMA_UNROLL
+      for (int chunk_id_ = 0; chunk_id_ < NumChunksPerTileK; ++chunk_id_) {
+        warpgroup_fence_operand(intermediate_array[chunk_id_]);
+
+        auto tCrS = cute::get<1>(partitioned_extra_info);
+        for (int mma_m = 0; mma_m < size<1>(accum); mma_m++) {
+          for (int m = 0; m < size<0,1>(accum); m++) {
+            for (int n = 0; n < size<0,2>(accum); n++) {
+              for (int e = 0; e < size<0,0>(accum); e++) {
+                auto accum_coord = make_coord(make_tuple(e,m,n), mma_m, 0);
+                auto scale_coord = make_coord(make_tuple(0,m,0), mma_m, 0);
+
+                float gscale = static_cast<float>(tCrS(scale_coord)[chunk_id_]);
+                if constexpr (EnableActBlockScale) {
+                  gscale *= static_cast<float>(tCrAS(accum_coord)[chunk_id_]);
+                }
+                if (chunk_id_ == 0) {
+                  accum(accum_coord) = intermediate_array[chunk_id_](accum_coord) * gscale;
+                } else {
+                  accum(accum_coord) = fma(intermediate_array[chunk_id_](accum_coord), gscale, accum(accum_coord));
+                }
+              }
+            }
+          }
+        }
+      }
+
+      --k_tile_count;
+      if (k_tile_count > 0) {
+        pipeline.consumer_wait(smem_pipe_read, barrier_token);
+
+        Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+          partitioned_extra_info, copy_partitions_extra_info, 0, smem_pipe_read.index());
+
+        Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+          partitioned_extra_info, copy_partitions_extra_info, 1, smem_pipe_read.index());
+
+        Utils::dequantize_A_kblock(tCrA_load, tCrA_mma, partitioned_extra_info, 0);
+      }
+    }
+
+    if (k_tile_count == 0) {
+      return;
+    }
+
+    // Mainloop GMMAs
+    CUTLASS_PRAGMA_NO_UNROLL
+    for ( ; k_tile_count > 1; --k_tile_count) {
+
+      //
+      // Compute on k_tile
+      //
+
+      int read_stage = smem_pipe_read.index();
+      ++smem_pipe_read;
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int chunk_id = 0; chunk_id < NumChunksPerTileK; ++chunk_id) {
+        tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int mma_id = 0; mma_id < NumMMAsPerChunk; ++mma_id) {
+          int k_block = chunk_id * NumMMAsPerChunk + mma_id;
+
+          warpgroup_arrive();
+          cute::gemm(tiled_mma, tCrA_mma(_,_,k_block), tCrB(_,_,k_block,read_stage), intermediate_array[chunk_id]);
+          tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+          warpgroup_commit_batch();
+
+          if (k_block == K_BLOCK_MAX - 1) {
+            pipeline.consumer_release(smem_pipe_release);             // UNLOCK smem_pipe_release, done _computing_ on it
+            ++smem_pipe_release;
+          }
+
+          if (k_block == 0) {
+            barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
+          }
+
+          if (k_block == K_BLOCK_MAX - 1) {
+            warpgroup_wait<0>();
+
+            load_act_scale(read_stage);
+            CUTLASS_PRAGMA_UNROLL
+            for (int chunk_id_ = 0; chunk_id_ < NumChunksPerTileK; ++chunk_id_) {
+              warpgroup_fence_operand(intermediate_array[chunk_id_]);
+
+              auto tCrS = cute::get<1>(partitioned_extra_info);
+              for (int mma_m = 0; mma_m < size<1>(accum); mma_m++) {
+                for (int m = 0; m < size<0,1>(accum); m++) {
+                  for (int n = 0; n < size<0,2>(accum); n++) {
+                    for (int e = 0; e < size<0,0>(accum); e++) {
+                      auto accum_coord = make_coord(make_tuple(e,m,n), mma_m, 0);
+                      auto scale_coord = make_coord(make_tuple(0,m,0), mma_m, 0);
+
+                      float gscale = static_cast<float>(tCrS(scale_coord)[chunk_id_]);
+                      if constexpr (EnableActBlockScale) {
+                        gscale *= static_cast<float>(tCrAS(accum_coord)[chunk_id_]);
+                      }
+                      accum(accum_coord) = fma(intermediate_array[chunk_id_](accum_coord), gscale, accum(accum_coord));
+                    }
+                  }
+                }
+              }
+            }
+
+            pipeline.consumer_wait(smem_pipe_read, barrier_token);
+            Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+              partitioned_extra_info, copy_partitions_extra_info, 0, smem_pipe_read.index());
+
+            Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+              partitioned_extra_info, copy_partitions_extra_info, 1, smem_pipe_read.index());
+            Utils::dequantize_A_kblock(tCrA_load, tCrA_mma, partitioned_extra_info, 0);
+          }
+          else {
+            if (k_block < K_BLOCK_MAX - 2) {
+              Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+                partitioned_extra_info, copy_partitions_extra_info, k_block + 2, read_stage);
+            }
+            Utils::dequantize_A_kblock(tCrA_load, tCrA_mma, partitioned_extra_info, k_block + 1);
+          }
+        }
+      }
+    }
+
+    {
+      Tensor intermediate = make_fragment_like(accum);
+
+      int read_stage = smem_pipe_read.index();
+
+      load_act_scale(read_stage);
+      tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int k_block = 0; k_block < K_BLOCK_MAX; ++k_block) {
+
+        warpgroup_arrive();
+        cute::gemm(tiled_mma, tCrA_mma(_,_,k_block), tCrB(_,_,k_block,read_stage), intermediate);
+        tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+        warpgroup_commit_batch();
+
+        if (k_block == K_BLOCK_MAX - 1) {
+          // release prior barrier
+          pipeline.consumer_release(smem_pipe_release);             // UNLOCK smem_pipe_release, done _computing_ on it
+          ++smem_pipe_release;
+        }
+
+        if (k_block < K_BLOCK_MAX - 2) {
+          Utils::copy_tensors_MK(smem_tiled_copy_A, tCsA, tCrA_copy_view,
+            partitioned_extra_info, copy_partitions_extra_info, k_block + 2, read_stage);
+        }
+        if (k_block < K_BLOCK_MAX - 1) {
+          Utils::dequantize_A_kblock(tCrA_load, tCrA_mma, partitioned_extra_info, k_block + 1);
+        }
+
+        if ((k_block + 1) % NumMMAsPerChunk == 0) {
+          tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+
+          warpgroup_wait<0>();
+          warpgroup_fence_operand(intermediate);
+
+          auto tCrS = cute::get<1>(partitioned_extra_info);
+          for (int mma_m = 0; mma_m < size<1>(accum); mma_m++) {
+            for (int m = 0; m < size<0,1>(accum); m++) {
+              for (int n = 0; n < size<0,2>(accum); n++) {
+                for (int e = 0; e < size<0,0>(accum); e++) {
+                  auto accum_coord = make_coord(make_tuple(e,m,n), mma_m, 0);
+                  auto scale_coord = make_coord(make_tuple(0,m,0), mma_m, 0);
+                  int scale_idx = k_block / NumMMAsPerChunk;
+
+                  float gscale = static_cast<float>(tCrS(scale_coord)[scale_idx]);
+                  if constexpr (EnableActBlockScale) {
+                    gscale *= static_cast<float>(tCrAS(accum_coord)[scale_idx]);
+                  }
+                  accum(accum_coord) = fma(intermediate(accum_coord), gscale, accum(accum_coord));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    }
   }
 
   /// Perform a Consumer Epilogue to release all buffers
@@ -1136,6 +1597,7 @@ public:
     cute::TmaDescriptor* tma_desc_b = &gmem_tensormap[sm_idx + sm_count];
     cute::TmaDescriptor* tma_desc_scale = &gmem_tensormap[sm_idx + 2*sm_count];
     cute::TmaDescriptor* tma_desc_zero = &gmem_tensormap[sm_idx + 3*sm_count];
+    cute::TmaDescriptor* tma_desc_act_scale = &gmem_tensormap[sm_idx + 3*sm_count];
 
     // Bringing tensormaps from params to smem for modification later
     Tensor pA_tensormap = make_tensor(mainloop_params.tma_load_a.get_tma_descriptor(), Int<1>{}, Int<1>{});
@@ -1153,6 +1615,13 @@ public:
       Tensor sS_tensormap = make_tensor(make_smem_ptr(&shared_tensormaps.smem_tensormap_scale), Int<1>{}, Int<1>{});
       if (cute::elect_one_sync()) {
         copy(recast<uint128_t>(pS_tensormap), recast<uint128_t>(sS_tensormap));
+      }
+      if constexpr (EnableActBlockScale) {
+        Tensor pAS_tensormap = make_tensor(mainloop_params.tma_load_act_scale.get_tma_descriptor(), Int<1>{}, Int<1>{});
+        Tensor sAS_tensormap = make_tensor(make_smem_ptr(&shared_tensormaps.smem_tensormap_act_scale), Int<1>{}, Int<1>{});
+        if (cute::elect_one_sync()) {
+          copy(recast<uint128_t>(pAS_tensormap), recast<uint128_t>(sAS_tensormap));
+        }
       }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
@@ -1172,7 +1641,12 @@ public:
       return cute::make_tuple(tma_desc_a, tma_desc_b);
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
-      return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scale);
+      if constexpr (EnableActBlockScale) {
+        return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scale, tma_desc_act_scale);
+      }
+      else {
+        return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scale);
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       return cute::make_tuple(tma_desc_a, tma_desc_b, tma_desc_scale, tma_desc_zero);
@@ -1197,6 +1671,10 @@ public:
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       cute::tma_descriptor_replace_addr_in_shared_mem(shared_tensormaps.smem_tensormap_scale,
                                                     mainloop_params.ptr_S[next_batch]);
+      if constexpr (EnableActBlockScale) {
+        cute::tma_descriptor_replace_addr_in_shared_mem(shared_tensormaps.smem_tensormap_act_scale,
+                                                    mainloop_params.ptr_AS[next_batch]);
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       cute::tma_descriptor_replace_addr_in_shared_mem(shared_tensormaps.smem_tensormap_zero,
@@ -1230,6 +1708,8 @@ public:
     cute::array<uint64_t, MaxTensorRank> prob_stride_scale = {0,0,0,0,0};
     cute::array<uint32_t, MaxTensorRank> prob_shape_zero   = {1,1,1,1,1};
     cute::array<uint64_t, MaxTensorRank> prob_stride_zero  = {0,0,0,0,0};
+    cute::array<uint32_t, MaxTensorRank> prob_shape_act_scale  = {1,1,1,1,1};
+    cute::array<uint64_t, MaxTensorRank> prob_stride_act_scale = {0,0,0,0,0};
 
     SwappedElementA const* ptr_A = nullptr;
     Tensor tensor_a = make_tensor(ptr_A, detail::get_gmem_layout(make_shape(M,K,Int<1>{}), mainloop_params.ptr_dA[next_group]));
@@ -1248,6 +1728,12 @@ public:
       Tensor tensor_scale = make_tensor(detail::get_logical_ptr(ptr_S), make_shape(M,scale_k,Int<1>{}), mainloop_params.dS[next_group]);
       cute::detail::fill_tma_gmem_shape_stride(mainloop_params.tma_load_scale, tensor_scale,
                                              prob_shape_scale, prob_stride_scale);
+      if constexpr (EnableActBlockScale) {
+        NonVoidElementScale const* ptr_AS = nullptr;
+        Tensor tensor_act_scale = make_tensor(detail::get_logical_ptr(ptr_AS), make_shape(N,scale_k,Int<1>{}), mainloop_params.dAS[next_group]);
+        cute::detail::fill_tma_gmem_shape_stride(mainloop_params.tma_load_act_scale, tensor_act_scale,
+                                               prob_shape_act_scale, prob_stride_act_scale);
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       ElementZero const* ptr_Z = nullptr;
@@ -1273,6 +1759,9 @@ public:
     for (uint64_t& stride : prob_stride_zero) {
       stride = (stride * sizeof_bits_v<NonVoidElementScale>) / 8;
     }
+    for (uint64_t& stride : prob_stride_act_scale) {
+      stride = (stride * sizeof_bits_v<NonVoidElementScale>) / 8;
+    }
 
 
     cute::tma_descriptor_replace_dims_strides_in_shared_mem(shared_tensormaps.smem_tensormap_A,
@@ -1286,6 +1775,11 @@ public:
       cute::tma_descriptor_replace_dims_strides_in_shared_mem(shared_tensormaps.smem_tensormap_scale,
                                                             prob_shape_scale,
                                                             prob_stride_scale);
+      if constexpr (EnableActBlockScale) {
+        cute::tma_descriptor_replace_dims_strides_in_shared_mem(shared_tensormaps.smem_tensormap_act_scale,
+                                                              prob_shape_act_scale,
+                                                              prob_stride_act_scale);
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       cute::tma_descriptor_replace_dims_strides_in_shared_mem(shared_tensormaps.smem_tensormap_zero,
@@ -1333,6 +1827,9 @@ public:
     tma_descriptor_cp_fence_release(get<1>(input_tensormaps), shared_tensormaps.smem_tensormap_B);
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       tma_descriptor_cp_fence_release(get<2>(input_tensormaps), shared_tensormaps.smem_tensormap_scale);
+      if constexpr (EnableActBlockScale) {
+        tma_descriptor_cp_fence_release(get<3>(input_tensormaps), shared_tensormaps.smem_tensormap_act_scale);
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       tma_descriptor_cp_fence_release(get<3>(input_tensormaps), shared_tensormaps.smem_tensormap_zero);
@@ -1351,6 +1848,9 @@ public:
     cute::tma_descriptor_fence_acquire(get<1>(input_tensormaps));
     if constexpr (KernelConversionMode == ConversionMode::ConvertAndScale) {
       cute::tma_descriptor_fence_acquire(get<2>(input_tensormaps));
+      if constexpr (EnableActBlockScale) {
+        cute::tma_descriptor_fence_acquire(get<3>(input_tensormaps));
+      }
     }
     else if constexpr (KernelConversionMode == ConversionMode::ConvertAndScaleWithZero) {
       cute::tma_descriptor_fence_acquire(get<3>(input_tensormaps));

--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -43,6 +43,7 @@ cutlass_test_unit_add_executable(
   matrix_coord.cu
   numeric_conversion.cu
   numeric_conversion_subbyte.cu
+  mxfp4_numeric_conversion.cu
   fast_numeric_conversion.cu
   functional.cu
   )

--- a/test/unit/core/mxfp4_numeric_conversion.cu
+++ b/test/unit/core/mxfp4_numeric_conversion.cu
@@ -1,0 +1,100 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Unit tests for MXFP4 numeric conversion operators.
+*/
+
+#include "../common/cutlass_unit_test.h"
+
+#include "cutlass/numeric_conversion.h"
+
+#include "cutlass/layout/matrix.h"
+#include "cutlass/util/host_tensor.h"
+
+namespace {
+
+template <int N>
+__global__ void convert_e2m1_to_e4m3_kernel(uint8_t* dst, uint8_t const* src) {
+  cutlass::Array<cutlass::float_e2m1_t, N> input;
+
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    input[i] = cutlass::float_e2m1_t::bitcast(src[i] & 0xf);
+  }
+
+  cutlass::NumericArrayConverter<cutlass::float_e4m3_t, cutlass::float_e2m1_t, N> converter;
+  cutlass::Array<cutlass::float_e4m3_t, N> output = converter(input);
+
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    cutlass::float_e4m3_t value = output[i];
+    dst[i] = value.raw();
+  }
+}
+
+template <int N>
+void run_e2m1_to_e4m3_test() {
+  uint8_t const input_values[16] = {
+      0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+      0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf};
+  uint8_t const expected_values[16] = {
+      0x00, 0x30, 0x38, 0x3c, 0x40, 0x44, 0x48, 0x4c,
+      0x80, 0xb0, 0xb8, 0xbc, 0xc0, 0xc4, 0xc8, 0xcc};
+
+  cutlass::HostTensor<uint8_t, cutlass::layout::RowMajor> src({N, 1});
+  cutlass::HostTensor<uint8_t, cutlass::layout::RowMajor> dst({N, 1});
+
+  for (int i = 0; i < N; ++i) {
+    src.at({i, 0}) = input_values[i];
+  }
+
+  src.sync_device();
+
+  convert_e2m1_to_e4m3_kernel<N><<<dim3(1,1), dim3(1,1)>>>(dst.device_data(), src.device_data());
+
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "Kernel launch error.";
+
+  dst.sync_host();
+
+  for (int i = 0; i < N; ++i) {
+    EXPECT_EQ(dst.at({i, 0}), expected_values[i]) << "index = " << i;
+  }
+}
+
+}  // namespace
+
+TEST(Mxfp4NumericConversion, E2m1ToE4m3Packed4) {
+  run_e2m1_to_e4m3_test<4>();
+}
+
+TEST(Mxfp4NumericConversion, E2m1ToE4m3Packed8) {
+  run_e2m1_to_e4m3_test<8>();
+}

--- a/test/unit/gemm/device/sm90_gemm_f8_f8_f32_tensor_op_f32_rs_cluster_warpspecialized_cooperative.cu
+++ b/test/unit/gemm/device/sm90_gemm_f8_f8_f32_tensor_op_f32_rs_cluster_warpspecialized_cooperative.cu
@@ -130,6 +130,67 @@ TEST(SM90_Device_Gemm_e4m3t_e4m3n_f32n_tensor_op_gmma_f32_cooperative, 128x128x1
   EXPECT_TRUE(test::gemm::device::TestAllBiasElementwise<Gemm>());
 }
 
+TEST(SM90_Device_Gemm_MixedInput_RS, Int4a8AndMxfp4a8StaticProperties) {
+  using ElementA = cutlass::float_e4m3_t;
+  using LayoutA  = cutlass::layout::RowMajor;
+  using LayoutB  = cutlass::layout::ColumnMajor;
+  using ElementC = float;
+  using LayoutC  = cutlass::layout::ColumnMajor;
+  using ElementAccumulator = float;
+
+  using TileShape_MNK = Shape<_128,_128,_128>;
+  using ClusterShape_MNK = Shape<_1,_1,_1>;
+
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecializedCooperative;
+  using FusionOperation = cutlass::epilogue::fusion::ScaledLinCombPerRowBiasEltAct<
+      cutlass::epilogue::thread::Identity, ElementC, ElementAccumulator, ElementAccumulator>;
+
+  using EpilogueOp = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      TileShape_MNK, ClusterShape_MNK,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      ElementAccumulator, ElementAccumulator,
+      ElementC, LayoutC, 16 / sizeof(ElementC),
+      ElementC, LayoutC, 16 / sizeof(ElementC),
+      EpilogueSchedule,
+      FusionOperation
+    >::CollectiveOp;
+
+  using StageCountType = cutlass::gemm::collective::StageCountAutoCarveout<sizeof(typename EpilogueOp::SharedStorage)>;
+  using KernelScheduleType = cutlass::gemm::KernelPtrArrayTmaWarpSpecializedCooperative;
+
+  using Int4a8Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      ElementA, LayoutA, 16,
+      cute::tuple<cutlass::int4b_t, cutlass::Array<cutlass::float_e4m3_t, 8>>, LayoutB, 32,
+      ElementAccumulator,
+      TileShape_MNK, ClusterShape_MNK,
+      StageCountType,
+      KernelScheduleType
+    >::CollectiveOp;
+
+  using Mxfp4a8Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      ElementA, LayoutA, 16,
+      cute::tuple<cutlass::float_e2m1_t, cutlass::Array<cutlass::bfloat16_t, 4>>, LayoutB, 32,
+      ElementAccumulator,
+      TileShape_MNK, ClusterShape_MNK,
+      StageCountType,
+      KernelScheduleType
+    >::CollectiveOp;
+
+  static_assert(Int4a8Mainloop::MxGroupSize == 128);
+  static_assert(!Int4a8Mainloop::EnableActBlockScale);
+  static_assert(Int4a8Mainloop::TmaTransactionBytesActScale == 0);
+  static_assert(Int4a8Mainloop::SharedStorage::act_scale_elements == 0);
+  static_assert(Mxfp4a8Mainloop::MxGroupSize == 32);
+  static_assert(Mxfp4a8Mainloop::EnableActBlockScale);
+  static_assert(Mxfp4a8Mainloop::TmaTransactionBytesActScale > 0);
+  static_assert(Mxfp4a8Mainloop::SharedStorage::act_scale_elements > 0);
+
+  EXPECT_TRUE(true);
+}
+
 TEST(SM90_Device_Gemm_e4m3t_e4m3n_f32n_tensor_op_gmma_f32_cooperative, 128x128x128_2x1x1) {
   using ElementA = cutlass::float_e4m3_t;
   using LayoutA  = cutlass::layout::RowMajor;


### PR DESCRIPTION
Since the SM90 devices gained support for the int4 * fp8 computation pipeline, it has been widely adopted in inference frameworks such as SGLang and vLLM and delivered remarkable performance. 

However, with the evolution of large‑language models (LLMs), an increasing number of models employ higher‑precision parameters like MXFP4. Unfortunately, a large number of SM90 devices lack native support for this data type. Similar to the earlier int4 scenario, runtime dequantization is required for adaptation. Most existing schemes dequantize weights to BF16 for inference, which covers the vast majority of use cases. Nevertheless, this is clearly a fallback solution for SM90‑class devices that natively support FP8 GEMM operations. 

Accordingly, I have implemented the MXFP4‑to‑FP8 GEMM pipeline. Building upon existing work on WINT4A8, I realized dynamic scale retrieval and the corresponding GEMM computation logic, and removed the traditional fixed‑block‑size‑128 limitation of INT4A8. The implementation has been validated on SGLang. Results show that WMXFP4A8 outperforms existing pipelines in most scenarios.

## Summary

This PR adds MXFP4A8 activation block scaling support to the SM90 mixed-input ptr-array mainloop while preserving the existing int4a8 execution path.

The implementation gates the new activation-scale TMA, shared memory, and chunked accumulation logic behind the MXFP4A8-specific `EnableActBlockScale` condition. Non-MXFP4A8 paths, including int4a8, keep the original mainloop behavior.

## Changes

- Added activation block scale TMA descriptor, shared storage, and load path for MXFP4A8.
- Added chunked accumulation with activation scale application for MXFP4A8.
- Preserved the original `mma()` mainloop for non-act-block-scale paths.
- Added E2M1 to E4M3 numeric conversion coverage.
- Added static tests for int4a8 and MXFP4A8 path separation.

## Validation

Tested on machine H20 / SM90, CUDA `12.4.131`.

### Unit tests

```bash
./test/unit/core/cutlass_test_unit_core \
  --gtest_filter="*Mxfp4*:*MXFP4*:*mxfp4*"
```

Result:

```text
[  PASSED  ] 2 tests.
```

```bash
./test/unit/gemm/device/cutlass_test_unit_gemm_device_tensorop_gmma_rs_warpspecialized_sm90 \
  --gtest_filter="SM90_Device_Gemm_MixedInput_RS.Int4a8AndMxfp4a8StaticProperties"
```

Result:

```text
[  PASSED  ] 1 test.
```

### int4a8 benchmark

Benchmark target:

```text
examples/69_hopper_mixed_dtype_grouped_gemm/69_hopper_int4_fp8_grouped_gemm
```

Small shape:

```bash
--m=512 --n=2048 --k=2048 --groups=8 --c=512 --mode=1 --warmup=3 --iterations=20 --alpha=1 --beta=0
```

| Version | Avg runtime |
|---|---:|
| baseline | `0.317806 ms` |
| patched | `0.317676 ms` |

Delta: `-0.041%`

Large shape:

```bash
--m=2048 --n=5120 --k=8192 --groups=16 --c=512 --mode=1 --warmup=5 --iterations=50 --alpha=1 --beta=0
```

| Version | Avg runtime |
|---|---:|
| baseline | `70.65475 ms` |
| patched | `70.65260 ms` |

Delta: `-0.003%`

Both benchmark runs passed correctness checks. int4a8 performance is unchanged within measurement noise.

### int4a8 MNK coverage

The existing CUTLASS int4/fp8 grouped GEMM example was also run on a small shape, a large-group shape, and a large prefill-like shape:

```text
examples/69_hopper_mixed_dtype_grouped_gemm/69_hopper_int4_fp8_grouped_gemm
```

| Shape | Groups | Avg runtime | GFLOPS | Result |
|---|---:|---:|---:|---|
| `m=256, n=128, k=512` | 6 | `0.016672 ms` | `12075.7` | Passed |
| `m=128, n=128, k=512` | 100 | `0.043360 ms` | `38692.8` | Passed |
| `m=2048, n=5120, k=8192` | 16 | `69.4398 ms` | `39585.0` | Passed |

This supplements the static int4a8 path-separation test with runtime MNK coverage from the existing CUTLASS example.

### MXFP4A8 correctness

MXFP4A8 correctness was validated through a temporary SGLang `cutlass_mxfp4a8_moe_mm` single-GEMM test on the same H20 machine. The test compares the kernel output against a BF16 dequantized golden reference and exercises:

- activation scale = one identity path;
- full MXFP8 activation path with per-token, per-block activation scales;
- single-expert shapes: `m=4/8/16/128`, `k=256/512/1024`, `n=512/1024/2048`;
- multi-expert grouped GEMM with uneven token counts: `[4,4,4,4]`, `[3,5,4,8]`, `[16,8,32,8]`;
- uniform multi-expert counts from 2 to 32 tokens per expert.

Observed relative mean error was `0.0000` for all tested cases.

### MXFP4A8 microbenchmark

The following single-GEMM MXFP4A8 benchmark uses `sgl_kernel.cutlass_mxfp4a8_moe_mm` with full activation block scaling enabled. For this single-GEMM synthetic benchmark, `topk=1` is the clean kernel-level setting; end-to-end MoE top-k behavior is covered separately by full MoE benchmarks.

| Shape | Avg runtime | P50 runtime | GFLOPS |
|---|---:|---:|---:|
| `m=256, n=128, k=512` | `0.016179 ms` | `0.016320 ms` | `2074.01` |
| `m=128, n=128, k=512` | `0.015639 ms` | `0.015648 ms` | `1072.78` |
| `m=1024, n=2048, k=4096` | `0.164708 ms` | `0.164752 ms` | `104304.70` |
| `m=2048, n=5120, k=8192` | `1.023284 ms` | `1.024608 ms` | `167889.58` |
| `m=4096, n=5120, k=8192` | `1.975428 ms` | `1.978080 ms` | `173935.68` |

For reference, using `topk=6/8` in the same single-expert synthetic setup adds non-representative scheduling overhead and should not be used as the single-GEMM microbenchmark number.
