### PR TITLE
fix(pycute): logical_product with an int tiler computed logical_divide

### DIFF
--- a/operators/cutlass/operators/fusion/pycute/layout.py
+++ b/operators/cutlass/operators/fusion/pycute/layout.py
@@ -336,7 +336,7 @@ def logical_product(layoutA, layoutB):
     if layoutB is None:
         return layoutA
     elif is_int(layoutB):
-        return logical_divide(layoutA, Layout(layoutB))
+        return logical_product(layoutA, Layout(layoutB))
     elif is_tuple(layoutB):
         assert len(layoutA) >= len(layoutB)
         return make_layout(

--- a/python/pycute/layout.py
+++ b/python/pycute/layout.py
@@ -313,7 +313,7 @@ def logical_product(layoutA, layoutB):
   if layoutB is None:
     return layoutA
   elif is_int(layoutB):
-    return logical_divide(layoutA, Layout(layoutB))
+    return logical_product(layoutA, Layout(layoutB))
   elif is_tuple(layoutB):
     assert len(layoutA) >= len(layoutB)
     return make_layout(chain((logical_product(layoutA[i], layoutB[i]) for i in range(           0,len(layoutB))),

--- a/test/python/pycute/test_product.py
+++ b/test/python/pycute/test_product.py
@@ -1,0 +1,90 @@
+#################################################################################################
+#
+# Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#################################################################################################
+
+"""
+Unit tests for pycute.logical_product
+"""
+
+import logging
+import unittest
+
+from pycute import *
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestProduct(unittest.TestCase):
+  def helper_test_logical_product(self, layoutA, layoutB):
+    layoutR = logical_product(layoutA, layoutB)
+
+    _LOGGER.debug(f"{layoutA} x {layoutB}  =>  {layoutR}")
+
+    # Post-conditions of test/unit/cute/core/logical_product.cpp
+    #   rank(layoutR) == 2
+    #   layoutA == layout<0>(layoutR)
+    #   compatible(layoutB, layout<1>(layoutR))
+    self.assertEqual(len(layoutR), 2)
+    self.assertEqual(layoutR[0], layoutA)
+    self.assertEqual(size(layoutR[1]), size(layoutB))
+
+  def test_logical_product(self):
+    self.helper_test_logical_product(Layout(1,0), Layout(1,0))
+    self.helper_test_logical_product(Layout(1,1), Layout(1,0))
+    self.helper_test_logical_product(Layout(1,0), Layout(1,1))
+    self.helper_test_logical_product(Layout(1,1), Layout(1,1))
+    self.helper_test_logical_product(Layout(3,1), Layout(4,0))
+    self.helper_test_logical_product(Layout(3,0), Layout(4,1))
+    self.helper_test_logical_product(Layout(3,0), Layout(4,0))
+    self.helper_test_logical_product(Layout(3,2), Layout(4,1))
+    self.helper_test_logical_product(Layout(3),   Layout((2,4)))
+
+  def test_logical_product_int_tiler(self):
+    # An int tiler must behave exactly like Layout(tiler), as in C++ cute
+    self.helper_test_logical_product(Layout((2,5),(5,1)), 4)
+    self.helper_test_logical_product(Layout(3,2), 4)
+
+    layoutA = Layout((2,5),(5,1))
+    self.assertEqual(logical_product(layoutA, 4), logical_product(layoutA, Layout(4)))
+
+  def test_logical_product_tuple_tiler(self):
+    layoutA = Layout((2,5),(5,1))
+    self.assertEqual(logical_product(layoutA, (4,2)),
+                     logical_product(layoutA, (Layout(4),Layout(2))))
+
+  def test_zipped_tiled_product_int_tiler(self):
+    layoutA = Layout((2,5),(5,1))
+    self.assertEqual(zipped_product(layoutA, 4), zipped_product(layoutA, Layout(4)))
+    self.assertEqual(tiled_product(layoutA, 4),  tiled_product(layoutA, Layout(4)))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Fixes #3478.

`logical_product(layout, <int>)` called `logical_divide`, so it returned a divide result. Recursing with `Layout(tiler)` reaches the correct branch, which is what the C++ reference does at `include/cute/layout.hpp:1670`.

Before:

```
product Layout(4): ((2, 5), 4):((5, 1), 10)
product int 4    : ((2, 2), 3):((5, 1), 2)
```

After:

```
product Layout(4): ((2, 5), 4):((5, 1), 10)
product int 4    : ((2, 5), 4):((5, 1), 10)
```

The tuple-tiler, `zipped_product` and `tiled_product` paths bottom out in the same branch and are fixed with it. After the change the integer path delegates to the `Layout` path, so the two forms cannot diverge again.

Adds `test/python/pycute/test_product.py`. There was no test for `logical_product` before. It ports the post-conditions from `test/unit/cute/core/logical_product.cpp` over the same cases, and pins the integer and tuple forms against their `Layout` equivalents. `run_all_tests.py` discovers it automatically; the suite goes from 10 to 14 tests.

The nine `Layout`-tiler cases in `test_logical_product` pass both before and after the fix, since a `Layout` tiler skips the integer branch. They are the control: the other three tests failing while that one stays green shows the failure is the integer path and not the test file.

The second commit applies the same one-word fix to `operators/cutlass/operators/fusion/pycute/layout.py`, a copy of the same module. It is kept separate. Say the word and I will drop it if that tree is regenerated from an internal source.
