### PR TITLE
[CuTeDSL] Fix "operand does not dominate this use" ICE: thread mutated call arguments out of dynamic `if`/`while` regions

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
@@ -1127,6 +1127,26 @@ class DSLPreprocessor(ast.NodeTransformer):
                     else:
                         invoked_args.add(base_name)
 
+                # Arguments passed to a call may be mutated in place by the
+                # callee (e.g. a nested @jit helper mutating a TiledMma via
+                # `.set`), exactly like the receiver of a method call above.
+                # Mark plain-name arguments as invoked so the mutated value is
+                # threaded out of the scf region instead of leaking a
+                # region-local SSA value ("operand does not dominate this use").
+                # `*args`/`**kwargs` container names are deliberately NOT
+                # marked: threading the container rebinds only the container
+                # name, silently detaching the mutated element from the
+                # variable the caller still holds, so those forms must keep
+                # failing loudly instead of miscompiling.
+                arg_exprs = list(node.args) + [
+                    kw.value for kw in node.keywords if kw.arg is not None
+                ]
+                for arg in arg_exprs:
+                    if isinstance(arg, ast.Name):
+                        if arg.id == "self" and support_pyir:
+                            continue
+                        invoked_args.add(arg.id)
+
                 self.generic_visit(node)
 
         analyzer = RegionAnalyzer()

--- a/python/CuTeDSL/cutlass/cutlass_dsl/cutlass.py
+++ b/python/CuTeDSL/cutlass/cutlass_dsl/cutlass.py
@@ -2324,13 +2324,74 @@ class KernelLauncher:
 # =============================================================================
 # Utils
 # =============================================================================
+
+# Placeholder passed as the "argument name" when filtering region RESULTS
+# (e.g. dynamic if-expression branch values) rather than named variable
+# captures. Results are always yielded out of the region, so the
+# mutability-based read-only rules for captured variables must not apply to
+# them. An invalid Python identifier is used so it can never collide with a
+# real variable name.
+REGION_RESULT_NAME = "<region result>"
+
+
+def _is_immutable_python_value(item: Any) -> bool:
+    """True if `item` is an immutable Python value that a callee cannot
+    mutate in place (so it never needs to be threaded through staged
+    control-flow regions)."""
+    import enum as _enum
+    import types as _types
+
+    if item is None or isinstance(item, (int, float, complex, str, bytes)):
+        return True
+    if isinstance(item, _enum.Enum):
+        return True
+    if isinstance(item, (tuple, frozenset)):
+        return all(_is_immutable_python_value(e) for e in item)
+    if isinstance(
+        item,
+        (
+            _types.FunctionType,
+            _types.BuiltinFunctionType,
+            _types.MethodType,
+            _types.ModuleType,
+            type,
+        ),
+    ):
+        return True
+    return False
+
+
+def _carries_mlir_values(item: Any) -> bool:
+    """True if `item` (possibly a container or dataclass) holds any MLIR SSA
+    values that staged control flow would need to thread through region
+    boundaries."""
+    try:
+        leaves, _, _ = tree_flatten(item, return_ir_values=False)
+    except Exception:
+        return False
+    return any(is_dynamic_expression(leaf) for leaf in leaves)
+
+
 def is_read_only_object(item: Any, arg_name: Optional[str] = None) -> bool:
     """
-    Check if an item is a read-only object.
+    Check if an item is a read-only object (exempt from being threaded
+    through staged control-flow regions).
 
-    A read-only object is either a frozen dataclass or a method receiver
-    (``self``) whose class does not opt in to ``self`` threading via the
-    ``_dsl_thread_self_in_staged_cf`` class attribute.
+    An item is read-only when it is:
+
+    * a frozen dataclass;
+    * a method receiver (``self``) whose class does not opt in to ``self``
+      threading via the ``_dsl_thread_self_in_staged_cf`` class attribute
+      (an opted-in receiver is always threaded);
+    * any other named variable capture (``arg_name`` is a real variable
+      name) that a callee cannot observably mutate in place: an immutable
+      Python value, or an object carrying no MLIR SSA values.
+
+    The mutability-based rules apply only to named captures: region results
+    (``arg_name`` is :data:`REGION_RESULT_NAME`) and callers providing no
+    name information are always threaded as before, since e.g. dynamic
+    if-expression branch values must be yielded even when they are plain
+    Python literals.
     """
     if is_frozen_dataclass(item):
         return True
@@ -2340,8 +2401,25 @@ def is_read_only_object(item: Any, arg_name: Optional[str] = None) -> bool:
         # SSA values, which sibling regions then read ("operand does not
         # dominate this use"). Classes that mutate state reachable through
         # `self` inside dynamic regions set the flag (e.g. task_scheduling's
-        # Task).
+        # Task). This rule takes precedence over the mutability-based rules
+        # below so an opted-in receiver stays threaded regardless of its
+        # current contents.
         return not getattr(type(item), "_dsl_thread_self_in_staged_cf", False)
+    if arg_name is not None and arg_name != REGION_RESULT_NAME:
+        if _is_immutable_python_value(item):
+            # Immutable Python values (constexpr ints, strings, enum members,
+            # tuples of such, ...) cannot be observably mutated by a callee.
+            # Threading them through staged control flow would demote them
+            # from compile-time constants to staged Numerics (breaking e.g.
+            # range_constexpr bounds), so keep them read-only.
+            return True
+        if not _carries_mlir_values(item):
+            # Threading exists solely to rebind region-defined SSA values
+            # after the region closes. An object holding no MLIR values has
+            # nothing to rebind; threading it would either demote
+            # compile-time state to staged values or fail flattening
+            # entirely (plain Python objects).
+            return True
     return False
 
 

--- a/python/CuTeDSL/cutlass/cutlass_dsl/cutlass_ast_decorators.py
+++ b/python/CuTeDSL/cutlass/cutlass_dsl/cutlass_ast_decorators.py
@@ -853,7 +853,7 @@ def _ifexp_execute_dynamic(
         op_type_name="ifexp",
         mix_iter_args=mix_iter_args,
         full_write_args_count=0,
-        mix_iter_arg_names=["unknown" for _ in mix_iter_args],
+        mix_iter_arg_names=[cutlass_dsl.REGION_RESULT_NAME for _ in mix_iter_args],
         create_op_func=create_if_op,
         region_builders=region_builders,
     )

--- a/test/python/CuTeDSL/test_call_args_in_if.py
+++ b/test/python/CuTeDSL/test_call_args_in_if.py
@@ -1,0 +1,329 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for mutable objects passed as *arguments* to nested @cute.jit
+helpers inside DSL dynamic control flow.
+
+Dynamic `if`/`while` bodies are outlined into scf regions, and any object a
+callee may mutate in place must be threaded through the region boundary
+(yielded and rebound) so uses after the region see the region result rather
+than a region-local SSA value. The region analyzer marks assignments and
+method-call receivers, and it must mark plain-name call arguments the same
+way: a nested helper such as
+
+    @cute.jit
+    def disable_accumulate(tiled_mma: cute.TiledMma):
+        tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+called inside a dynamic `if` otherwise leaves the mutated TiledMma bound to
+a value defined in the child region, and the next use of it fails MLIR
+verification with "operand #0 does not dominate this use" (NVIDIA/cutlass
+issue #3077 is the SM90 flavor of the same failure).
+
+The extra threading must stay scoped to named variable captures that can
+actually observe a mutation:
+
+* immutable Python values (e.g. constexpr ints) and plain Python objects
+  carrying no MLIR values must stay read-only, or they would be demoted to
+  staged values (breaking e.g. `cutlass.range_constexpr` bounds) or fail
+  flattening at the region boundary;
+* region *results* (dynamic if-expression branch values) must keep being
+  threaded even when they are plain Python literals, or
+  `1 if pred else 2` silently constant-folds to its then-value.
+
+The TiledMma mutation tests require a tcgen05-capable (SM 10.x) device
+because `TiledMma.set` is the canonical in-place mutator; the read-only
+guard tests are architecture-neutral, and the classification tests need no
+GPU at all.
+"""
+
+import unittest
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.base_dsl.runtime.cuda import get_compute_capability_major_minor
+from cutlass.cute.nvgpu import OperandMajorMode, tcgen05
+from cutlass.cute.typing import BFloat16, Float32, Int32
+
+try:
+    _CC_MAJOR, _ = get_compute_capability_major_minor()
+except Exception:  # no GPU / broken driver: only device-less tests can run
+    _CC_MAJOR = None
+
+try:
+    import torch
+
+    _HAS_TORCH_CUDA = torch.cuda.is_available()
+except Exception:
+    _HAS_TORCH_CUDA = False
+
+requires_tcgen05 = unittest.skipUnless(
+    _CC_MAJOR == 10,
+    "TiledMma.set tests require a tcgen05-capable (SM 10.x) device",
+)
+
+requires_gpu_runtime = unittest.skipUnless(
+    _CC_MAJOR is not None and _HAS_TORCH_CUDA,
+    "runtime check requires a CUDA device and torch",
+)
+
+
+@cute.jit
+def disable_accumulate(tiled_mma: cute.TiledMma):
+    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+
+@cute.jit
+def enable_accumulate(tiled_mma: cute.TiledMma):
+    tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+
+def make_tiled_mma() -> cute.TiledMma:
+    return sm100_utils.make_trivial_tiled_mma(
+        BFloat16,
+        BFloat16,
+        OperandMajorMode.K,
+        OperandMajorMode.K,
+        Float32,
+        tcgen05.CtaGroup.ONE,
+        (64, 32),
+    )
+
+
+class TestMutatedCallArgInDynamicIf(unittest.TestCase):
+    """A nested @cute.jit helper mutating its argument inside dynamic
+    control flow must have the mutated value threaded out of the scf
+    region."""
+
+    @requires_tcgen05
+    def test_helper_arg_mutated_inside_dynamic_if(self):
+        """Positional argument. Used to fail MLIR verification with
+        "operand #0 does not dominate this use" because the argument was
+        not threaded out of the scf.if region."""
+
+        @cute.kernel
+        def kern(tiled_mma: cute.TiledMma, flag: Int32):
+            if flag > 0:
+                disable_accumulate(tiled_mma)
+            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+        @cute.jit
+        def entry(flag: Int32):
+            tiled_mma = make_tiled_mma()
+            kern(tiled_mma, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+    @requires_tcgen05
+    def test_helper_kwarg_mutated_inside_dynamic_if(self):
+        """Same as above, with the mutated object passed as a keyword
+        argument."""
+
+        @cute.kernel
+        def kern(tiled_mma: cute.TiledMma, flag: Int32):
+            if flag > 0:
+                disable_accumulate(tiled_mma=tiled_mma)
+            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+        @cute.jit
+        def entry(flag: Int32):
+            tiled_mma = make_tiled_mma()
+            kern(tiled_mma, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+    @requires_tcgen05
+    def test_helpers_in_both_branches(self):
+        """Nested helpers mutating the argument in both branches of a
+        dynamic if/else (the NVIDIA/cutlass#3077 shape)."""
+
+        @cute.kernel
+        def kern(tiled_mma: cute.TiledMma, flag: Int32):
+            if flag > 0:
+                disable_accumulate(tiled_mma)
+            else:
+                enable_accumulate(tiled_mma)
+            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+        @cute.jit
+        def entry(flag: Int32):
+            tiled_mma = make_tiled_mma()
+            kern(tiled_mma, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+    @requires_tcgen05
+    def test_helper_arg_mutated_inside_dynamic_while(self):
+        """The same failure through the scf.while path: the loop yield is
+        the use site that referenced the region-local value."""
+
+        @cute.kernel
+        def kern(tiled_mma: cute.TiledMma, flag: Int32):
+            i = Int32(0)
+            while i < flag:
+                disable_accumulate(tiled_mma)
+                i = i + Int32(1)
+            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+        @cute.jit
+        def entry(flag: Int32):
+            tiled_mma = make_tiled_mma()
+            kern(tiled_mma, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+    @requires_tcgen05
+    def test_inline_mutation_control(self):
+        """Control: the same mutation written inline (a method call on the
+        receiver) has always been threaded and must keep compiling."""
+
+        @cute.kernel
+        def kern(tiled_mma: cute.TiledMma, flag: Int32):
+            if flag > 0:
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+        @cute.jit
+        def entry(flag: Int32):
+            tiled_mma = make_tiled_mma()
+            kern(tiled_mma, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+
+class TestReadOnlyCallArgsStayUnthreaded(unittest.TestCase):
+    """Marking call arguments must not thread objects that cannot observe a
+    mutation; threading them would demote compile-time constants to staged
+    values or fail flattening at the region boundary."""
+
+    def test_constexpr_int_arg_stays_constexpr(self):
+        """A Python int passed to a helper inside a dynamic if must remain
+        usable as a compile-time constant (e.g. as a range_constexpr
+        bound) after the if."""
+
+        @cute.jit
+        def helper(x: Int32, n: cutlass.Constexpr):
+            y = x + n
+
+        @cute.kernel
+        def kern(v: Int32, flag: Int32):
+            n = 4
+            if flag > 0:
+                helper(v, n)
+            acc = Int32(0)
+            for i in cutlass.range_constexpr(n):
+                acc = acc + v
+
+        @cute.jit
+        def entry(flag: Int32):
+            kern(flag, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+    def test_plain_python_object_arg_not_threaded(self):
+        """A plain Python object holding no MLIR values, passed to a helper
+        inside a dynamic if, must not be threaded through the region (it
+        has nothing to rebind and is not flattenable)."""
+
+        class Cfg:
+            def __init__(self):
+                self.n = 3
+
+        @cute.jit
+        def helper(x: Int32, cfg: cutlass.Constexpr):
+            y = x + cfg.n
+
+        @cute.kernel
+        def kern(v: Int32, flag: Int32):
+            cfg = Cfg()
+            if flag > 0:
+                helper(v, cfg)
+            z = v + 1
+
+        @cute.jit
+        def entry(flag: Int32):
+            kern(flag, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+    def test_list_arg_still_compiles(self):
+        """A Python list holding staged values, passed to a mutating helper
+        inside a dynamic if, keeps compiling (it is flattenable, so it may
+        be threaded)."""
+
+        @cute.jit
+        def bump(xs):
+            xs[0] = xs[0] + Int32(1)
+
+        @cute.kernel
+        def kern(flag: Int32):
+            xs = [Int32(0)]
+            if flag > 0:
+                bump(xs)
+            y = xs[0] + Int32(1)
+
+        @cute.jit
+        def entry(flag: Int32):
+            kern(flag).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+        cute.compile(entry, Int32(1))
+
+
+class TestRegionResultsAlwaysThreaded(unittest.TestCase):
+    """The mutability-based read-only rules apply only to named variable
+    captures. Region results must keep being threaded even when they are
+    immutable Python values, or dynamic if-expressions of literals would
+    silently constant-fold to the then-value."""
+
+    def test_classification_is_scoped_to_named_captures(self):
+        # Imported here: REGION_RESULT_NAME does not exist before this fix,
+        # and a module-level import would fail the whole file at collection.
+        from cutlass.cutlass_dsl.cutlass import (
+            REGION_RESULT_NAME,
+            is_read_only_object,
+        )
+
+        # Named capture: an int cannot be mutated by a callee.
+        self.assertTrue(is_read_only_object(4, "n"))
+        # Region result (dynamic ternary branch value): must be threaded.
+        self.assertFalse(is_read_only_object(4, REGION_RESULT_NAME))
+        # No name information (hand-written selector calls): pre-existing
+        # behavior, must be threaded.
+        self.assertFalse(is_read_only_object(4, None))
+
+    @requires_gpu_runtime
+    def test_dynamic_ternary_of_literals_selects_at_runtime(self):
+        """`1 if pred else 2` with a dynamic predicate must produce a
+        select, not constant-fold to the then-value."""
+        from cutlass.cute.runtime import from_dlpack
+
+        @cute.kernel
+        def kern(gA: cute.Tensor, flag: Int32):
+            y = 1 if flag > 0 else 2
+            gA[0] = y
+
+        @cute.jit
+        def entry(gA: cute.Tensor, flag: Int32):
+            kern(gA, flag).launch(grid=(1, 1, 1), block=(1, 1, 1))
+
+        a = torch.zeros(4, dtype=torch.int32, device="cuda")
+        entry(from_dlpack(a), Int32(0))
+        torch.cuda.synchronize()
+        self.assertEqual(a[0].item(), 2)
+        entry(from_dlpack(a), Int32(1))
+        torch.cuda.synchronize()
+        self.assertEqual(a[0].item(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR

Objects passed as plain **call arguments** to a nested `@cute.jit` helper inside dynamic
(runtime-valued) control flow are not threaded through the generated `scf` region, unlike
assignments and method-call receivers. If the helper mutates the argument in place (e.g.
`TiledMma.set`), the object is left bound to a region-local SSA value and the next use fails
MLIR verification with `operand #0 does not dominate this use`. This PR marks plain-name
positional/keyword call arguments as potentially mutated in the region analyzer, and scopes
the threading exemptions in `is_read_only_object` so the wider sweep neither demotes
compile-time constants nor disturbs region-result threading. Regression tests cover both
directions. This is the same bug class as #3077 (SM90, bot-closed as stale, never fixed — it
still reproduces verbatim on the 4.7.0 wheel; the repro below is its SM100 flavor).

## Symptom and minimal repro

```python
import cutlass
import cutlass.cute as cute
from cutlass.cute.nvgpu import OperandMajorMode, tcgen05
import cutlass.utils.blackwell_helpers as sm100_utils
from cutlass.cute.typing import Int32, Float32, BFloat16


@cute.jit
def inner_set(tiled_mma: cute.TiledMma):
    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)


class Repro:
    @cute.kernel
    def kern(self, tiled_mma: cute.TiledMma, flag: Int32):
        if flag > 0:                # dynamic if -> outlined into an scf.if region
            inner_set(tiled_mma)    # nested jit helper mutates the argument in place
        tiled_mma.set(tcgen05.Field.ACCUMULATE, True)   # any later use -> ICE

    @cute.jit
    def run(self, flag: Int32):
        tiled_mma = sm100_utils.make_trivial_tiled_mma(
            BFloat16, BFloat16, OperandMajorMode.K, OperandMajorMode.K,
            Float32, tcgen05.CtaGroup.ONE, (64, 32),
        )
        self.kern(tiled_mma, flag).launch(grid=(1, 1, 1), block=(32, 1, 1))


cutlass.cuda.initialize_cuda_context()
cute.compile(Repro().run, Int32(1))
```

On `nvidia-cutlass-dsl` 4.6.1 and 4.7.0 (B200, CUDA 13) this fails with:

```
error[INTERNAL]: The compiler could not build valid IR for this code.
  error: IR verification failed: error: unknown: operand #0 does not dominate this use
note: unknown: see current operation: %3 = "cute_nvgpu.atom.set_value"(%5, %2)
      <{field = #cute_nvgpu.atom_mma_field_sm100<accum_c>}> : (!cute.tiled_mma<...>, i1) -> ...
note: unknown: operand defined here (op in a child region)
```

All three ingredients are required; removing any one of them makes it compile:
1. a dynamic (non-constexpr) `if` (or `while`),
2. the mutation happening inside a **nested `@cute.jit` helper call** (inlining the
   `.set` compiles fine, because method-call receivers *are* threaded),
3. any later use of the object after the region.

## Root cause

Dynamic `if`/`while` bodies are outlined and mutated variables are threaded through the
`scf` op as region yields/results; after the op is built, the threaded Python objects are
rebound to the op results (`pack_from_irvalue`). Which variables get threaded is decided
statically by `DSLPreprocessor.analyze_region_variables` in
`python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py`:

- assignments (`x = ...`) are collected into `write_args`;
- method-call receivers are collected into `invoked_args` by `RegionAnalyzer.visit_Call`
  (`ast_preprocessor.py:1114-1131` at current main): *"Classes are mutable by default. Mark
  them as write."*;
- **plain call arguments are not collected at all** — `visit_Call` records the callee name
  but never looks at `node.args` / `node.keywords`.

A nested `@cute.jit` helper is traced inline at the current insertion point — inside the
`scf.if` child region. `TiledMma.set` mutates in place
(`self.value = _cute_nvgpu_ir.atom_set_value(...)`,
`python/CuTeDSL/cutlass/cute/nvgpu/tcgen05/mma.py:456`), so the shared Python object ends up
holding an SSA value defined in the child region. Since the object is not in the yield set,
nothing rebinds it when the region closes, and the next use references the region-local
value. The MLIR verifier correctly rejects the IR; the invalid IR is constructed entirely by
the Python frontend.

## The fix

**1. `ast_preprocessor.py`, `RegionAnalyzer.visit_Call` (+20 lines): the actual bug fix.**
Plain-name positional and keyword arguments are added to `invoked_args`, mirroring the
existing method-receiver rule (a callee can mutate an argument in place exactly like a
method can mutate its receiver). The existing `self`-under-`support_pyir` carve-out is
mirrored for consistency. `*args`/`**kwargs` container names are deliberately **not**
marked: threading the container would rebind only the container name and silently detach
the mutated element from the variable the caller still holds (verified in IR: the later use
kept consuming the pre-region value while the `scf.if` result went dead — a silent
mutation drop). Those forms keep failing loudly, exactly like current main.

**2. `cutlass_dsl/cutlass.py`, `is_read_only_object` (+85/−5 lines): scoped threading
exemptions.** `is_read_only_object` is the single choke point (`_filter_readonly_objects` /
`insert_readonly_objects` / `unpack_to_irvalue` / `pack_from_irvalue`) that exempts objects
from threading. The wider sweep makes two new object classes reachable, and threading either
one is a behavior regression; but the exemptions must not leak beyond variable captures.
Each rule is pinned by the concrete regression it prevents (all covered by the new tests):

- **Immutable Python values** (ints, floats, strings, enum members, tuples of such,
  functions, modules, types) stay read-only. A callee cannot observably mutate them, and
  threading them **demotes compile-time constants to staged Numerics** (`_tree_flatten`
  falls back to `as_numeric(x).ir_value()`). Without this rule, a Python `int` passed to a
  helper inside a dynamic `if` and later used as a `cutlass.range_constexpr` bound fails
  with `error[ARG_NON_CONSTANT]` (test: `test_constexpr_int_arg_stays_constexpr`; hit in a
  production sparse-attention kernel during validation).

- **Objects carrying no MLIR values** (no dynamic leaves under `tree_flatten`, or
  unflattenable) stay read-only. Threading exists solely to rebind region-defined SSA
  values; a plain Python config object passed to a helper inside a dynamic `if` must not be
  pushed through region flattening (test: `test_plain_python_object_arg_not_threaded`).

- **The pre-existing `self` opt-in rule keeps precedence**: an opted-in receiver
  (`_dsl_thread_self_in_staged_cf`) is always threaded regardless of its current contents.

- **Both rules apply only to named variable captures.** Region *results* flow through the
  same machinery (`_ifexp_execute_dynamic` -> `scf_execute_dynamic`) and must always be
  threaded: filtering an immutable branch value out of a dynamic if-expression produces a
  zero-result `scf.if` whose packing silently restores the then-value — `1 if flag > 0
  else 2` evaluated to `1` for `flag == 0` (caught by a runtime probe during pre-submission
  review of an earlier draft of this patch). Results are now tagged with the new
  `REGION_RESULT_NAME` placeholder (an invalid identifier, so it cannot collide with a real
  variable name) instead of `"unknown"`, and the two rules skip it; callers providing no
  name information are likewise exempt. Tests: `test_classification_is_scoped_to_named_captures`
  (unit) and `test_dynamic_ternary_of_literals_selects_at_runtime` (runtime, checks both
  branch values).

**3. `cutlass_dsl/cutlass_ast_decorators.py` (1 line):** `_ifexp_execute_dynamic` passes
`REGION_RESULT_NAME` as the placeholder argument name for ternary results.

With the fix, the minimal repro produces exactly the expected threading
(`CUTE_DSL_PRINT_IR=1`):

```mlir
%1 = scf.if %0 -> (!cute.tiled_mma<...>) {
  %3 = cute_nvgpu.atom.set_value<accum_c>(%arg0, %false) ...
  scf.yield %3 : ...
} else {
  scf.yield %arg0 : ...
}
%2 = cute_nvgpu.atom.set_value<accum_c>(%1, %true) ...   // consumes the scf.if result
```

## Validation

Everything below was run on a B200 (SM100) against the 4.7.0 wheel (whose copies of the
touched files are byte-identical to current main) with only the patched files overlaid.

| Gate | Unpatched | Patched |
|---|---|---|
| Minimal repro above | ICE | compiles |
| jit-helper `.set` in dynamic `if` + `cute.gemm` after | ICE | compiles |
| same, inside a traced `while` (yield as the use site) | ICE | compiles |
| #3077 shape (jit `.set` one branch, jit `gemm` other branch) | ICE | compiles |
| #3077 shape inside a traced `while` | ICE | compiles |
| 12-variant control ladder (inline `.set`, no-later-use, constexpr `if`, unconditional helper, ...) | compiles | compiles (unchanged) |
| New regression test file (10 tests) | 5 fail: 4 mutation shapes with the dominance ICE + 1 new-API unit test; 5 controls pass | 10 pass |
| Dynamic ternary of literals, runtime, both flag values | correct (2 / 1) | correct (2 / 1) |
| Existing `test/python/CuTeDSL/` suite | — | failure set byte-identical before/after (pre-existing wheel-vs-main drift only) |
| Sanity kernel (compile + launch + value check) | OK | OK |
| Production sparse-attention kernels, forward + backward (compile + run) | OK | OK |
| Production numerics, fixed seed, unpatched vs patched | — | 3 of 4 outputs bitwise-equal; the 4th uses non-deterministic float atomics and stays inside its run-to-run band (max abs diff 7.6e-5 vs 6.1e-5–6.9e-5 across unpatched re-runs) |

The new tests were verified in both directions with exact counts. The `TiledMma.set` tests
skip on non-SM10x devices; the guard tests are arch-neutral; the classification unit test
needs no GPU; the runtime ternary test is additionally gated on torch + CUDA availability.

## Prior art

#3077 ("TiledMMA modifier cannot be set in different jit function", SM90, filed 2026-02) is
this exact bug class. It was closed by the stale bot with no fix; the construct still
reproduces on 4.7.0. This PR fixes the underlying region-threading gap and covers that shape
in the regression tests (`test_helpers_in_both_branches`).

## Scope and limitations

- **Non-Name argument forms** (`helper(obj.attr)`, `helper(xs[0])`, literal `*`/`**`
  containers) are not marked and keep failing exactly like current main. This matches the
  name granularity of the existing analyzer (the receiver rule reduces to a base name the
  same way).
- **`*args`/`**kwargs` names** are deliberately excluded (see above): loud failure was
  preferred over silent mutation drop through the aliased element.
- **Mixed static/dynamic containers**: a container like `[dyn, 4]` passed to a helper is
  now threaded, which demotes the static leaf — a later `range_constexpr(xs[1])` fails
  loudly. This is the DSL's established semantics for threaded containers: the identical
  error already occurs on current main when the same container is threaded by assignment
  inside the region (verified). Keeping constants out of mutated containers (or
  `const_expr`) is the existing remedy.
- **Callee-changed dynamic structure**: if a helper changes which leaves of a threaded
  container are dynamic (e.g. replaces a staged value with a Python literal), compilation
  fails loudly with a structure-mismatch assertion. On current main such code only
  "compiled" because the trace-time mutation escaped region discipline entirely (the
  branch effect applied unconditionally).
- **PyIR preprocessor mode** (non-default) shares `analyze_region_variables` but threads
  values through a different mechanism; the underlying bug is not fixed for PyIR mode by
  this PR and our validation does not exercise it. The new sweep mirrors the existing
  `support_pyir` special case for `self`.
- `_carries_mlir_values` runs `tree_flatten` once per candidate object per classification
  site at trace time. If this shows up in compile-time profiles it can be cached; the patch
  was kept minimal.