### PR TITLE
Fix leftover configure placeholders in cutlass/version.h

### DIFF
--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -45,4 +45,5 @@ cutlass_test_unit_add_executable(
   numeric_conversion_subbyte.cu
   fast_numeric_conversion.cu
   functional.cu
+  version.cu
   )

--- a/test/unit/core/version.cu
+++ b/test/unit/core/version.cu
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2017 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,61 +28,44 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **************************************************************************************************/
+/*! \file
+    \brief Unit tests for cutlass/version.h.
+*/
 
-#pragma once
+#include "../common/cutlass_unit_test.h"
 
-#if defined(__CUDACC_RTC__)
-#include CUDA_STD_HEADER(cstdint)
-#else
-#include <cstdint>
+#include "cutlass/version.h"
+
 #include <string>
-#endif
 
-#define CUTLASS_MAJOR 4
-#define CUTLASS_MINOR 7
-#define CUTLASS_PATCH 0
+/////////////////////////////////////////////////////////////////////////////////////////////////
 
-#ifdef CUTLASS_VERSIONS_GENERATED
-#include "cutlass/version_extended.h"
-#else
-#define CUTLASS_BUILD 0
-#define CUTLASS_REVISION ""
-#endif
+TEST(Version, numeric_version) {
+  EXPECT_EQ(cutlass::getVersion(), CUTLASS_VERSION);
+  EXPECT_EQ(cutlass::getVersionMajor(), uint32_t(CUTLASS_MAJOR));
+  EXPECT_EQ(cutlass::getVersionMinor(), uint32_t(CUTLASS_MINOR));
+  EXPECT_EQ(cutlass::getVersionPatch(), uint32_t(CUTLASS_PATCH));
+  EXPECT_EQ(cutlass::getVersionBuild(), uint32_t(CUTLASS_BUILD + 0));
+}
 
-#define CUTLASS_VERSION ((CUTLASS_MAJOR)*100 + (CUTLASS_MINOR)*10 + CUTLASS_PATCH)
+// getVersionString() and getGitRevision() must be derived from the version
+// macros (or version_extended.h) rather than unsubstituted "@...@" placeholders.
+TEST(Version, version_string_matches_macros) {
+  std::string const expected = std::to_string(CUTLASS_MAJOR) + "." +
+                               std::to_string(CUTLASS_MINOR) + "." +
+                               std::to_string(CUTLASS_PATCH);
 
-namespace cutlass {
+  std::string const actual = cutlass::getVersionString();
 
-  inline constexpr uint32_t getVersion() {
-    return CUTLASS_VERSION;
+  EXPECT_EQ(actual.substr(0, expected.size()), expected);
+  EXPECT_EQ(actual.find('@'), std::string::npos);
+  if (cutlass::getVersionBuild()) {
+    EXPECT_EQ(actual, expected + "." + std::to_string(cutlass::getVersionBuild()));
   }
-  inline constexpr uint32_t getVersionMajor() {
-    return CUTLASS_MAJOR;
-  }
-  inline constexpr uint32_t getVersionMinor() {
-    return CUTLASS_MINOR;
-  }
-  inline constexpr uint32_t getVersionPatch() {
-    return CUTLASS_PATCH;
-  }
-  inline constexpr uint32_t getVersionBuild() {
-    return CUTLASS_BUILD + 0;
-  }
+}
 
-#if !defined(__CUDACC_RTC__)
-  inline std::string getVersionString() {
-    std::string version = std::to_string(CUTLASS_MAJOR) + "." +
-                          std::to_string(CUTLASS_MINOR) + "." +
-                          std::to_string(CUTLASS_PATCH);
-    if (getVersionBuild()) {
-      version += "." + std::to_string(getVersionBuild());
-    }
-    return version;
-  }
+TEST(Version, git_revision_has_no_placeholders) {
+  EXPECT_EQ(cutlass::getGitRevision().find('@'), std::string::npos);
+}
 
-  inline std::string getGitRevision() {
-    return CUTLASS_REVISION;
-  }
-#endif // !defined(__CUDACC_RTC__)
-
-} // namespace cutlass
+/////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #3472

`getVersionString()` and `getGitRevision()` in `include/cutlass/version.h` returned the literal strings `@CUTLASS_VERSION@` and `@CUTLASS_REVISION@`. Those were left behind when the `configure_file` step for `version.h` was dropped in 3.4.1 (bbe579a); only `cmake/version_extended.h.in` is generated, so nothing ever substituted them, and even a full CMake build prints `CUTLASS @CUTLASS_VERSION@` in the profiler banner (`tools/profiler/src/options.cu`).

This builds `getVersionString()` from the CUTLASS_MAJOR/MINOR/PATCH macros and lets `getGitRevision()` return CUTLASS_REVISION, which is empty by default and supplied by `version_extended.h` under `CUTLASS_VERSIONS_GENERATED`. The build-number suffix behavior is unchanged.

Behavior note: the profiler banner changes from `CUTLASS @CUTLASS_VERSION@ ... commit @CUTLASS_REVISION@` to `CUTLASS 4.7.0`, with the commit clause printed only when a real revision exists. Nothing in-tree parses the old string.

Adds `test/unit/core/version.cu` (3 tests) registered in `test/unit/core/CMakeLists.txt`.

Test Plan:
```
$ docker run --rm -v .../cutlass:/src:ro nvidia/cuda:12.8.1-devel-ubuntu22.04 \
    g++ -std=c++17 -I/src/include host_check.cpp && ./host_check
  unfixed header: getVersionString=@CUTLASS_VERSION@
                  getGitRevision=@CUTLASS_REVISION@   -> 4 assertion failures
  fixed header:   getVersionString=4.7.0 getGitRevision=    -> 0 failures

$ docker run --rm nvidia/cuda:12.8.1-devel-ubuntu22.04   # nvcc V12.8.93 + googletest
$ nvcc -std=c++17 -I<include> -I<gtest include> -c test/unit/core/version.cu ...
$ g++ version.o libgtest.a libgtest_main.a -lcudart -o vt && ./vt
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.
```
Both configurations were also compiled with MSVC against a simulated generated `version_extended.h`: defaults give `"4.7.0"`/`""`, generated gives `"4.7.0.5"`/`"abc123"`.
