### PR TITLE
Skip stale entries in the DSL shared library list

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/dsl.py
+++ b/python/CuTeDSL/cutlass/base_dsl/dsl.py
@@ -1821,15 +1821,31 @@ class BaseDSL(metaclass=DSLSingletonMeta):
 
     def get_shared_libs(self) -> list:
         shared_libs = []
+        missing_libs = []
         support_libs = self.envar.shared_libs
         if support_libs is not None:
             _libs = support_libs.split(":")
             for lib in _libs:
                 if not os.path.exists(lib):
-                    raise FileNotFoundError(
-                        errno.ENOENT, os.strerror(errno.ENOENT), lib
-                    )
+                    # Entries can be stale when the environment was built on
+                    # another machine (e.g. Slurm --export=ALL) and forwarded
+                    # here; a missing entry must not fail the whole compile
+                    # while other entries point at a usable runtime.
+                    missing_libs.append(lib)
+                    continue
                 shared_libs.append(lib)
+            if not shared_libs:
+                # Every entry is stale, so there is no usable runtime left
+                # and the compile cannot proceed.
+                raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), support_libs
+                )
+            for lib in missing_libs:
+                self.print_warning(
+                    f"Skipping {lib}: the file does not exist on this "
+                    "machine, but other entries of the shared library list "
+                    "point at a usable runtime."
+                )
         else:
             if is_cutlass_family_dsl_prefix(self.name):
                 self.print_warning(

--- a/test/python/CuTeDSL/test_shared_libs.py
+++ b/test/python/CuTeDSL/test_shared_libs.py
@@ -1,0 +1,83 @@
+#################################################################################################
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#################################################################################################
+
+"""
+Unit tests for BaseDSL.get_shared_libs handling of stale entries.
+
+The shared library list can name files from another machine when an
+environment is forwarded (e.g. Slurm --export=ALL); missing entries must be
+skipped while at least one usable runtime remains.
+"""
+
+import os
+import tempfile
+import types
+import unittest
+
+from cutlass.base_dsl.dsl import BaseDSL
+
+
+def make_dsl(shared_libs):
+    dsl = object.__new__(BaseDSL)
+    dsl.name = "TEST_DSL"
+    dsl.envar = types.SimpleNamespace(shared_libs=shared_libs, prefix="TEST_DSL")
+    dsl.warnings = []
+    dsl.print_warning = lambda message: dsl.warnings.append(message)
+    return dsl
+
+
+class TestGetSharedLibs(unittest.TestCase):
+
+  def test_missing_entries_skipped_when_others_valid(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      valid = os.path.join(tmp, "libruntime.so")
+      open(valid, "w").close()
+
+      dsl = make_dsl(f"/nonexistent/liba.so:{valid}:/nonexistent/libb.so")
+      libs = dsl.get_shared_libs()
+
+      self.assertEqual(libs, [valid])
+      self.assertEqual(len(dsl.warnings), 2)
+
+  def test_all_entries_missing_raises(self):
+    dsl = make_dsl("/nonexistent/liba.so:/nonexistent/libb.so")
+    with self.assertRaises(FileNotFoundError):
+      dsl.get_shared_libs()
+
+  def test_unset_list_returns_empty(self):
+    dsl = make_dsl(None)
+    dsl.print_warning = lambda message: None
+    self.assertEqual(dsl.get_shared_libs(), [])
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Fixes #3462 (part 2: worker-side hard failure)

`get_shared_libs` raised `FileNotFoundError` on the first missing entry of the colon-separated `{prefix}_LIBS` list. The list travels inside job environments (Slurm `sbatch` defaults to `--export=ALL`), so a worker can receive an entry pointing into the submitter's site-packages, and every compile died on it even though another entry named a usable local runtime.

This skips entries whose file does not exist on this machine and warns about them instead. It keeps raising when nothing in the list survives, since that means there is no usable runtime at all and the compile cannot proceed.

Part 1 of the issue (the import-time `CUTE_DSL_LIBS` mutation that manufactures these stale entries) is a separate mechanism in a separate file and is intentionally not bundled here.

Adds `test/python/CuTeDSL/test_shared_libs.py` (3 CPU-only tests using a stubbed DSL instance).

Test Plan:
```
$ docker run --rm python:3.12-slim ...   # editable install of python/CuTeDSL
$ CUTE_DSL_LIBS=/nonexistent/libcute_dsl_runtime.so:<valid cu12/lib/libcute_dsl_runtime.so> \
    python -c "<compile a trivial @cute.jit function>"
  unfixed: FileNotFoundError: [Errno 2] No such file or directory:
           '/nonexistent/libcute_dsl_runtime.so'
  fixed:   UserWarning: Skipping /nonexistent/libcute_dsl_runtime.so ... other
           entries ... point at a usable runtime.
           COMPILE_OK

$ CUTE_DSL_LIBS=/nonexistent/a.so:/nonexistent/b.so ...
  fixed:   FileNotFoundError: [Errno 2] No such file or directory:
           '/nonexistent/a.so:/nonexistent/b.so'

$ python test/python/CuTeDSL/test_shared_libs.py -v
  Ran 3 tests ... OK   (the mixed-entry test fails on unfixed code)
```

Known same-class gaps left out of scope: `cutlass/jax/ffi.py::find_cute_dsl_runtime_library` and `tvm_ffi_provider.py` still return the first name-matching entry without an existence check.
