### PR TITLE
Fix pycute Swizzle recursion on zero shift

### DIFF
--- a/operators/cutlass/operators/fusion/pycute/swizzle.py
+++ b/operators/cutlass/operators/fusion/pycute/swizzle.py
@@ -38,11 +38,11 @@ from .layout import *
 
 
 def shiftr(a, s):
-    return a >> s if s > 0 else shiftl(a, -s)
+    return a >> s if s >= 0 else shiftl(a, -s)
 
 
 def shiftl(a, s):
-    return a << s if s > 0 else shiftr(a, -s)
+    return a << s if s >= 0 else shiftr(a, -s)
 
 
 ## A generic Swizzle functor

--- a/python/pycute/swizzle.py
+++ b/python/pycute/swizzle.py
@@ -38,11 +38,11 @@ from .layout import *
 
 
 def shiftr(a, s):
-  return a >> s if s > 0 else shiftl(a, -s)
+  return a >> s if s >= 0 else shiftl(a, -s)
 
 
 def shiftl(a, s):
-  return a << s if s > 0 else shiftr(a, -s)
+  return a << s if s >= 0 else shiftr(a, -s)
 
 
 ## A generic Swizzle functor

--- a/test/python/pycute/test_swizzle.py
+++ b/test/python/pycute/test_swizzle.py
@@ -1,0 +1,77 @@
+#################################################################################################
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#################################################################################################
+
+"""
+Unit tests for pycute.Swizzle
+
+Expected tables were cross-checked against cute::Swizzle in
+include/cute/swizzle.hpp compiled host-side.
+"""
+
+import unittest
+
+from pycute import *
+
+PROBE_POINTS = [0, 1, 2, 7, 8, 9, 15, 16, 63, 64, 255, 256]
+
+
+class TestSwizzle(unittest.TestCase):
+
+  def test_shift_zero_is_identity(self):
+    # A zero-shift swizzle is legal in C++ (Swizzle<0,4,0>) and must not
+    # recurse; it applies as the identity.
+    sw = Swizzle(0, 4, 0)
+    for x in PROBE_POINTS:
+      self.assertEqual(sw(x), x)
+
+  def test_patterns_match_cpp(self):
+    cases = [
+      (Swizzle(2, 3, -3),  [0, 1, 2, 7, 72, 73, 79, 144, 255, 64, 63, 256]),
+      (Swizzle(1, 0, 1),   [0, 1, 3, 6, 8, 9, 14, 16, 62, 64, 254, 256]),
+      (Swizzle(3, 2, 3),   [0, 1, 2, 7, 8, 9, 15, 16, 59, 72, 227, 256]),
+      (Swizzle(2, 1, -2),  [0, 1, 10, 31, 8, 9, 23, 16, 39, 64, 231, 256]),
+    ]
+    for sw, expected in cases:
+      self.assertEqual([sw(x) for x in PROBE_POINTS], expected)
+
+  def test_involutivity(self):
+    # Every legal Swizzle is its own inverse on its whole domain; the
+    # tested patterns have domain size at most 2**(B+M+abs(S)) <= 256.
+    for sw in [Swizzle(0, 4, 0), Swizzle(2, 3, -3), Swizzle(1, 0, 1),
+               Swizzle(3, 2, 3), Swizzle(2, 1, -2)]:
+      domain = 1 << (sw.base + sw.bits + abs(sw.shift))
+      for x in range(domain):
+        self.assertEqual(sw(sw(x)), x)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
`pycute.shiftr`/`shiftl` guarded on `s > 0` and delegated the else case to each other with a negated shift, so shift 0 ping-ponged between them until `RecursionError`. `Swizzle(0, M, 0)` passes the constructor assert (`abs(0) >= 0`), is legal in C++ where `Swizzle<0,4,3>` is literally the default swizzle, and applies as the identity; in pycute it was unusable:

```python
>>> Swizzle(0, 4, 0)(123)
RecursionError: maximum recursion depth exceeded
```

This uses `s >= 0` like the C++ reference in `include/cute/numeric/math.hpp` (`shiftl`/`shiftr`). The same two lines exist in the vendored copy under `operators/cutlass/operators/fusion/pycute` and are fixed there too.

Adds `test/python/pycute/test_swizzle.py`: shift-zero identity, application tables for four patterns cross-checked against compiled `cute::Swizzle` (host-side g++ against include/cute/swizzle.hpp), and full-domain involutivity checks.

Test Plan:
```
$ PYTHONPATH=python python test/python/pycute/test_swizzle.py
Ran 3 tests ... OK          (RecursionError x2 on unfixed code)
$ PYTHONPATH=python python test/python/pycute/run_all_tests.py
Ran 13 tests ... OK
```
C++ golden check (docker g++, include/cute/swizzle.hpp):
```
S0_4_0 : 0 1 2 7 8 9 15 16 63 64 255 256
SW23_3 : 0 1 2 7 72 73 79 144 255 64 63 256
SW101  : 0 1 3 6 8 9 14 16 62 64 254 256
SW323  : 0 1 2 7 8 9 15 16 59 72 227 256
SW212_ : 0 1 10 31 8 9 23 16 39 64 231 256
```
identical to the fixed Python implementation on every probe point.
