### PR TITLE
Tolerate stride-0 broadcast modes in pycute idx2crd

### DIFF
--- a/python/pycute/int_tuple.py
+++ b/python/pycute/int_tuple.py
@@ -154,6 +154,11 @@ def idx2crd(idx, shape, stride=None):
       assert len(shape) == len(stride)
       return tuple(idx2crd(idx, s, d) for s,d in zip(shape,stride))
     else:                              # "int" "int" "int"
+      # A size-1 mode contributes coordinate 0 regardless of its stride;
+      # C++ skips the division for this case (include/cute/stride.hpp), so
+      # stride-0 broadcast modes are tolerated instead of raising.
+      if shape == 1:
+        return 0
       return (idx // stride) % shape
 
 

--- a/test/python/pycute/test_int_tuple.py
+++ b/test/python/pycute/test_int_tuple.py
@@ -77,4 +77,10 @@ class TestIntTuple(unittest.TestCase):
     self.assertEqual(prefix_product(((2,3),(2, 1, 2),( 5,  2,  1))),
                                     ((1,2),(6,12,12),(24,120,240)))
 
-
+  def test_idx2crd_shape1_stride0(self):
+    # A size-1 mode contributes coordinate 0 regardless of its stride;
+    # C++ skips the division for this case, so stride-0 broadcast modes
+    # must not raise.
+    self.assertEqual(idx2crd(7, (1,(2,2)), (0,(1,2))), (0,(1,1)))
+    self.assertEqual(idx2crd(5, 1, 0), 0)
+    self.assertEqual(idx2crd(6, (4,6), (1,4)), (2,1))


### PR DESCRIPTION
`pycute.idx2crd` computed `(idx // stride) % shape` for every leaf mode. For a size-1 mode the coordinate is always 0, but the division still runs, so a size-1 mode with stride 0 (a broadcast mode, e.g. produced by `complement` when the codomain is below the extent) raised `ZeroDivisionError`:

```python
>>> idx2crd(7, (1,(2,2)), (0,(1,2)))
ZeroDivisionError
```

The C++ implementation skips the division for size-1 modes (`include/cute/stride.hpp`, returning 0 without touching the stride), and returns `(0,(1,1))` for exactly this input. This change mirrors that: the leaf returns 0 whenever `shape == 1`, so broadcast modes are tolerated instead of raising.

Adds regression cases to `test/python/pycute/test_int_tuple.py`.

Test Plan:
```
$ PYTHONPATH=python python test/python/pycute/run_all_tests.py
Ran 11 tests ... OK    (the new case errors on unfixed code)
$ PYTHONPATH=python python -c "from pycute import *; print(idx2crd(7, (1,(2,2)), (0,(1,2))))"
(0, (1, 1))            # identical to compiled C++
```
