### PR TITLE
[CuTeDSL] Add `llc{...}` compile-option token and `NvvmOptions` to pass LLVM codegen flags to the NVVM backend

### DIFF
--- a/media/docs/pythonDSL/cute_dsl_general/dsl_jit_compilation_options.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/dsl_jit_compilation_options.rst
@@ -62,6 +62,10 @@ You can provide additional compilation options as a string when calling ``cute.c
      - The options to pass to the PTX Compiler library.
      - ""
      - str
+   * - ``nvvm-options``
+     - The options to pass to the NVVM backend. LLVM codegen (llc) flags are passed as ``-Xllc <flag>`` pairs; prefer the ``llc{...}`` token below for those.
+     - ""
+     - str
    * - ``generate-line-info``
      - Generate line information for debugging.
      - False
@@ -91,6 +95,35 @@ You can use the following code to specify compilation options:
    jit_executor_with_keep_sass = cute.compile(add, 1, 2, options="--keep-sass")
    jit_executor_with_nvdisasm_options = cute.compile(add, 1, 2, options="--keep-sass --nvdisasm-options '-c'")
    jit_executor_with_ptxas_options = cute.compile(add, 1, 2, options="--ptxas-options '--opt-level=2'")
+   jit_executor_with_nvvm_options = cute.compile(add, 1, 2, options="--nvvm-options '-Xllc -aggressive-machine-cse=1'")
+
+
+Forwarding flags to LLVM codegen (``llc``)
+------------------------------------------
+
+LLVM codegen flags are reached through the NVVM backend as ``-Xllc <flag>`` pairs. The
+``llc{...}`` token composes those pairs for you and is accepted anywhere compact option
+tokens are, including the ``CUTE_DSL_COMPILER_OPT`` environment variable:
+
+.. code-block:: python
+
+   # one flag
+   jit_executor = cute.compile(add, 1, 2, options="llc{aggressive-machine-cse=1}")
+   # several flags in one token
+   jit_executor = cute.compile(add, 1, 2, options="llc{aggressive-machine-cse=1,enable-misched=0}")
+
+.. code-block:: bash
+
+   CUTE_DSL_COMPILER_OPT="llc{aggressive-machine-cse=1}" python my_kernel.py
+
+Spell each flag without its leading ``-``; names may contain letters, digits, ``_``,
+``.`` and ``-``, optionally followed by ``=<value>``. Malformed tokens are rejected when
+the options string is parsed. Flags themselves are forwarded as-is: the backend errors on
+flags it rejects and silently ignores ones it does not recognize, so these are power-user
+options tied to the LLVM version inside libNVVM, much like ``ptxas-options``.
+
+An explicit ``--nvvm-options`` value replaces flags contributed by ``llc{...}`` in the
+same options string.
 
 
 ``cute.compile`` Compilation Options as separate Python types
@@ -101,7 +134,7 @@ Compilation options can be programmatically composed using tuple and passed to `
 
 .. code-block:: python
 
-  from cutlass.cute import OptLevel, EnableAssertions, GenerateLineInfo, KeepCUBIN, KeepPTX, KeepSASS, NvdisasmOptions
+  from cutlass.cute import OptLevel, EnableAssertions, GenerateLineInfo, KeepCUBIN, KeepPTX, KeepSASS, NvdisasmOptions, NvvmOptions
 
   my_debugging_options = (OptLevel(1), EnableAssertions, GenerateLineInfo, KeepCUBIN, KeepPTX)
   compiled_kernel_1 = cute.compile[my_debugging_options](my_kernel_1, ...)
@@ -120,3 +153,4 @@ Notebly, boolean options are automatically converted to True instances of the op
    jit_executor_with_keep_sass = cute.compile[KeepSASS](add, 1, 2)
    jit_executor_with_nvdisasm_options = cute.compile[KeepSASS, NvdisasmOptions("-c")](add, 1, 2)
    jit_executor_with_ptxas_options = cute.compile[PtxasOptions("--opt-level=2")](add, 1, 2)
+   jit_executor_with_nvvm_options = cute.compile[NvvmOptions("-Xllc -aggressive-machine-cse=1")](add, 1, 2)

--- a/media/docs/pythonDSL/cute_dsl_general/dsl_jit_compilation_options.rst
+++ b/media/docs/pythonDSL/cute_dsl_general/dsl_jit_compilation_options.rst
@@ -125,6 +125,34 @@ options tied to the LLVM version inside libNVVM, much like ``ptxas-options``.
 An explicit ``--nvvm-options`` value replaces flags contributed by ``llc{...}`` in the
 same options string.
 
+Process-global flag state
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``-Xllc`` flags are parsed into LLVM's process-global option registry (``cl::opt``) by
+the in-process backend, and the registry is only re-parsed by compiles that themselves
+pass ``nvvm-options``. A flagged compile therefore leaves the flag in effect for
+**every subsequent compile in the same process** that does not pass its own
+``nvvm-options`` — the flag does not expire when the flagged compile finishes (whether
+the emitted code actually differs depends on the flag and the kernel). This is a
+limitation of the current in-process backend and cannot be scoped from Python, so treat
+``llc{...}`` as setting process state, not a per-kernel attribute.
+
+Two consequences to plan around:
+
+- **Compile caches key on the requested option string, not on inherited flag state.**
+  A cached JIT compilation performed without options while a flag is active stores
+  flag-affected code under the clean cache key — including in the persistent file
+  cache, from which it can be served to later processes. Avoid mixing ``llc{...}`` with
+  cached JIT compilation in the same process unless you have reset the flags first
+  (as of this writing, explicit ``cute.compile`` always recompiles and is unaffected).
+- **Resets are best-effort.** Running a throwaway compile that passes the flag's
+  default value explicitly (e.g. ``llc{aggressive-machine-cse=0}``) restores that flag
+  for the rest of the process. This only works for flags whose default is expressible
+  as a value, requires the compile to actually reach the backend (a compile satisfied
+  from a cache does not re-parse the registry), and does not help for flags set via
+  ``CUTE_DSL_COMPILER_OPT``, which is re-applied on every compile. Full isolation is a
+  fresh process.
+
 
 ``cute.compile`` Compilation Options as separate Python types
 -------------------------------------------------------------

--- a/python/CuTeDSL/cutlass/base_dsl/compiler.py
+++ b/python/CuTeDSL/cutlass/base_dsl/compiler.py
@@ -500,6 +500,48 @@ class PtxasOptions(StringCompileOption):
     _cli_flag = "ptxas-options"
 
 
+def _validate_nvvm_options(options: str) -> None:
+    """Reject characters that could corrupt or escape the quoted
+    ``nvvm-options='...'`` slot of the pass-pipeline string. Surrounding
+    quotes are ignored: ``serialize()`` strips them before re-quoting."""
+    if any(ch in options.strip("'") for ch in "'\"{}\\\n\r\t"):
+        raise DSLUserCodeError(
+            _diagnostics.DiagId.CONFIG_MALFORMED_COMPILE_OPTIONS,
+            options=f"nvvm-options={options}",
+        )
+
+
+@register_option
+class NvvmOptions(StringCompileOption):
+    """Options forwarded to the NVVM backend (``nvvm-options`` in the
+    ``cute-to-nvvm`` pipeline). LLVM codegen (llc) flags are passed as
+    ``-Xllc <flag>`` pairs, e.g. ``-Xllc -aggressive-machine-cse=1``. The
+    compact ``llc{...}`` token is the user-facing way to populate this
+    option. Flags are shape-validated here and forwarded as-is: the backend
+    errors on flags it rejects and silently ignores ones it does not
+    recognize.
+
+    Precedence: compact tokens are applied before the legacy string API, so
+    an explicit ``--nvvm-options <value>`` replaces any flags contributed by
+    ``llc{...}`` in the same options string, regardless of their order."""
+
+    _option_name = "nvvm-options"
+    _suppress_when_absent = True
+
+    def __init__(self, val: str = "") -> None:
+        _validate_nvvm_options(val)
+        super().__init__(val)
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    @value.setter
+    def value(self, value: str) -> None:
+        _validate_nvvm_options(value)
+        self._value = value
+
+
 @register_option
 class RDC(BooleanCompileOption):
     """Compile as relocatable device code (``ptxas -c``).
@@ -824,6 +866,7 @@ class CompileOptions:
             --debug{launch-check}            # check CUDA launch arguments
             --remarks{ptx}                   # show only ptxas remarks (spills...)
             --iket                           # enable IKET (In-Kernel Event Tracing) instrumentation
+            --llc{aggressive-machine-cse=1}  # forward flag(s) to LLVM codegen (llc)
 
         :param opt_str: Compact option string to parse.
         :raises ValueError: On malformed syntax:
@@ -861,7 +904,11 @@ class CompileOptions:
                 )
             # (2) Empty braces: name{} is ambiguous — reject unless the token
             #     takes sub-options (an empty list then just enables it).
-            if sub_str == "" and not ExtraCompilerOpts.takes_sub_options(name):
+            if (
+                sub_str == ""
+                and name != "llc"
+                and not ExtraCompilerOpts.takes_sub_options(name)
+            ):
                 raise ValueError(
                     f"Empty braces for option '{name}'; "
                     f"provide sub-options (e.g. {name}{{key=val}}) "
@@ -944,6 +991,42 @@ class CompileOptions:
                     rf = self.options[RemarkFilter]
                     have = {c for c in rf.value.split("|") if c}
                     rf.value = "|".join(sorted(have | new_cats))
+            elif name == "llc":
+                # llc{<flag>[,<flag>...]}: forward each flag to LLVM codegen
+                # (llc) as an ``-Xllc -<flag>`` pair via the ``nvvm-options``
+                # pipeline option. Flags are validated for shape only;
+                # the backend errors on flags it rejects and silently
+                # ignores ones it does not recognize.
+                if val_str is not None or sub_str is None:
+                    raise ValueError(
+                        "llc expects flag braces, e.g. llc{aggressive-machine-cse=1}"
+                    )
+                flags = [item.strip() for item in sub_str.split(",") if item.strip()]
+                if not flags:
+                    raise ValueError(
+                        "Empty braces for option 'llc'; provide one or more "
+                        "llc flags (e.g. llc{aggressive-machine-cse=1})"
+                    )
+                for flag in flags:
+                    if not re.fullmatch(r"[A-Za-z0-9][\w.-]*(?:=[\w.-]+)?", flag):
+                        raise ValueError(
+                            f"invalid llc flag {flag!r}: expected <name> or "
+                            "<name>=<value> spelled without the leading '-' "
+                            "(allowed characters: letters, digits, '_', '.', '-')"
+                        )
+                nvvm = self.options[NvvmOptions]
+                # Append, skipping flags already present: applying the same
+                # option string twice to one CompileOptions (e.g. the env var
+                # re-applied per compile) must be idempotent so the value --
+                # and hence the compile-cache key -- stays stable.
+                have = nvvm.value.split()
+                pending: "list[str]" = []
+                for flag in flags:
+                    pair = f"-Xllc -{flag}"
+                    if pair not in " ".join(have + pending):
+                        pending.append(pair)
+                if pending:
+                    nvvm.value = " ".join(have + pending).strip()
             elif name in ExtraCompilerOpts.COMPACT_FLAGS:
                 raw_opts.extend(ExtraCompilerOpts.expand(name, sub_str))
             elif sub_str is not None:
@@ -1228,8 +1311,7 @@ def _extract_compact_options(
     import shlex
 
     _COMPACT_NAMES: frozenset[str] = frozenset(
-        {"warnings", "remarks"}
-        | set(ExtraCompilerOpts.COMPACT_FLAGS)
+        {"llc", "warnings", "remarks"} | set(ExtraCompilerOpts.COMPACT_FLAGS)
     )
 
     def _is_compact(token: str) -> bool:
@@ -1300,7 +1382,7 @@ def _parse_compile_options_from_str(options: str) -> CompileOptions:
         parsed_options = _shlex.split(options) if options else []
         # Avoid parsing the ptxas-options value as a hyphen key
         for i in range(1, len(parsed_options)):
-            if parsed_options[i - 1] in ["--ptxas-options"]:
+            if parsed_options[i - 1] in ["--ptxas-options", "--nvvm-options"]:
                 parsed_options[i] = f"'{parsed_options[i]}'"
         option_dict = vars(parser.parse_args(parsed_options))
         for dest, value in option_dict.items():

--- a/python/CuTeDSL/cutlass/base_dsl/compiler.py
+++ b/python/CuTeDSL/cutlass/base_dsl/compiler.py
@@ -523,7 +523,16 @@ class NvvmOptions(StringCompileOption):
 
     Precedence: compact tokens are applied before the legacy string API, so
     an explicit ``--nvvm-options <value>`` replaces any flags contributed by
-    ``llc{...}`` in the same options string, regardless of their order."""
+    ``llc{...}`` in the same options string, regardless of their order.
+
+    Process-global state: the backend parses ``-Xllc`` flags into LLVM's
+    process-global option registry (``cl::opt``), and only compiles that
+    pass ``nvvm-options`` themselves re-parse it — a flag set here stays in
+    effect for every subsequent compile in the process that does not pass
+    its own ``nvvm-options``, and compile caches key on the requested
+    option string, not on inherited flag state. See the "Process-global
+    flag state" section of the JIT compilation options doc for the
+    consequences and a best-effort manual reset recipe."""
 
     _option_name = "nvvm-options"
     _suppress_when_absent = True

--- a/python/CuTeDSL/cutlass/base_dsl/env_manager.py
+++ b/python/CuTeDSL/cutlass/base_dsl/env_manager.py
@@ -560,10 +560,13 @@ class EnvironmentVarManager(LogEnvironmentManager):
         remarks{nvvm}               — show only nvvm (sync) remarks
         remarks{ptx}                — show ptxas perf remarks (spills, local mem)
         iket                        — enable IKET (In-Kernel Event Tracing) instrumentation
+        llc{<flag>[,<flag>...]}     — forward flag(s) to LLVM codegen (llc),
+                                      e.g. llc{aggressive-machine-cse=1}
       Examples:
         CUTE_DSL_COMPILER_OPT="warnings{nvvm}"
         CUTE_DSL_COMPILER_OPT="remarks{ptx}"
         CUTE_DSL_COMPILER_OPT="iket"
+        CUTE_DSL_COMPILER_OPT="llc{aggressive-machine-cse=1}"
       The same option strings are accepted by cute.compile(..., options=...).
 
     """

--- a/python/CuTeDSL/cutlass/cute/__init__.py
+++ b/python/CuTeDSL/cutlass/cute/__init__.py
@@ -234,6 +234,7 @@ compile_to = compile.compile_to
 OptLevel = _dsl.OptLevel
 
 PtxasOptions = _dsl.PtxasOptions
+NvvmOptions = _dsl.NvvmOptions
 EnableAssertions = _dsl.EnableAssertions
 GenerateLineInfo = _dsl.GenerateLineInfo
 KeepCUBIN = _dsl.KeepCUBIN

--- a/python/CuTeDSL/cutlass/cutlass_dsl/__init__.py
+++ b/python/CuTeDSL/cutlass/cutlass_dsl/__init__.py
@@ -47,6 +47,7 @@ from ..base_dsl.compiler import (
     CompileCallable,
     OptLevel,
     PtxasOptions,
+    NvvmOptions,
     EnableAssertions,
     GenerateLineInfo,
     KeepCUBIN,

--- a/test/python/CuTeDSL/test_compile_options_llc.py
+++ b/test/python/CuTeDSL/test_compile_options_llc.py
@@ -21,19 +21,20 @@ underlying ``CompileOptions._apply_opt_string``. ``NvvmOptions`` is the
 matching programmatic option (``cute.compile[NvvmOptions("...")]``).
 """
 
+import glob
+import os
+import subprocess
+import sys
+import tempfile
 import unittest
 
-import cutlass
 import cutlass.cute as cute
-from cutlass import Float32
 from cutlass.base_dsl.common import DSLUserCodeError
 from cutlass.base_dsl.compiler import (
     CompileOptions,
-    CompilerDiagnosticError,
     NvvmOptions,
     _parse_compile_options_from_str,
 )
-from cutlass.cute.runtime import make_fake_tensor
 
 
 class TestLlcTokenParsing(unittest.TestCase):
@@ -176,43 +177,171 @@ class TestNvvmOptionsProgrammatic(unittest.TestCase):
         self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", co.to_str())
 
 
-def _make_entry():
-    @cute.kernel
-    def k(gA: cute.Tensor):
-        tidx, _, _ = cute.arch.thread_idx()
-        gA[tidx] = gA[tidx] + Float32(1.0)
+# Every test that reaches the NVVM backend runs in a disposable subprocess:
+# an accepted -Xllc flag is parsed into LLVM's process-global option registry
+# (see TestLlcFlagStateIsProcessGlobal below) and would otherwise stay active
+# for everything compiled later in the test process. The script is written to
+# a real file because the DSL retrieves @cute.jit sources via inspect. The
+# probe kernel compiles first in every mode, so the victim is always the
+# process's second compile (identical backend warm-state across modes and its
+# PTX can be compared byte-for-byte); only in "leaked" mode does the probe
+# carry the flag.
+_SUBPROCESS_COMPILE_SCRIPT = r"""
+import sys
 
-    @cute.jit
-    def entry(gA: cute.Tensor):
-        k(gA).launch(grid=(1, 1, 1), block=(32, 1, 1))
+import cutlass.cute as cute
+from cutlass import Float32
+from cutlass.base_dsl.compiler import CompilerDiagnosticError, NvvmOptions
+from cutlass.cute.runtime import make_fake_tensor
 
-    return entry
+
+@cute.kernel
+def _kp(gA: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    gA[tidx] = gA[tidx] + Float32(1.0)
+
+
+@cute.jit
+def probe(gA: cute.Tensor):
+    _kp(gA).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+
+@cute.kernel
+def _kv(gA: cute.Tensor, gB: cute.Tensor, gC: cute.Tensor):
+    tidx, _, _ = cute.arch.thread_idx()
+    a = gA[tidx]
+    b = gB[tidx]
+    d = a / b
+    f = a * b + d
+    g = (a + b) * (a - b) + f
+    gC[tidx] = d + f + g
+
+
+@cute.jit
+def victim(gA: cute.Tensor, gB: cute.Tensor, gC: cute.Tensor):
+    _kv(gA, gB, gC).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+
+mode, flag = sys.argv[1], sys.argv[2]
+fa = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+fb = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+fc = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+try:
+    if mode == "leaked":
+        cute.compile(probe, fa, options="llc{%s}" % flag)
+    else:
+        cute.compile(probe, fa)
+    if mode == "control":
+        cute.compile(victim, fa, fb, fc, options="llc{%s}" % flag)
+    elif mode == "programmatic":
+        cute.compile[NvvmOptions("-Xllc -%s" % flag)](victim, fa, fb, fc)
+    else:  # "clean" and "leaked": the victim never passes options
+        cute.compile(victim, fa, fb, fc)
+except CompilerDiagnosticError as exc:
+    sys.stderr.write("BACKEND-REJECTED: %s\n" % (exc,))
+    sys.exit(3)
+"""
+
+
+def _run_compile_subprocess(mode, flag, work_dir):
+    """Run one compile ordering in a fresh interpreter, dumping PTX into
+    ``work_dir``. ``CUTE_DSL_COMPILER_OPT`` is stripped from the child
+    environment so an ambient ``llc{...}`` cannot contaminate the arms."""
+    env = {k: v for k, v in os.environ.items() if k != "CUTE_DSL_COMPILER_OPT"}
+    env.update(CUTE_DSL_KEEP="ptx", CUTE_DSL_DUMP_DIR=work_dir, PYTHONHASHSEED="0")
+    script = os.path.join(work_dir, "probe_script.py")
+    with open(script, "w") as f:
+        f.write(_SUBPROCESS_COMPILE_SCRIPT)
+    return subprocess.run(
+        [sys.executable, script, mode, flag],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
 
 
 class TestLlcTokenCompilation(unittest.TestCase):
     """End-to-end: the serialized option must be accepted by the
     cute-to-nvvm pipeline and reach the NVVM backend."""
 
+    def _run(self, mode, flag):
+        with tempfile.TemporaryDirectory() as tmp:
+            return _run_compile_subprocess(mode, flag, tmp)
+
     def test_compile_with_llc_flag(self):
-        gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
-        cute.compile(_make_entry(), gA, options="llc{aggressive-machine-cse=1}")
+        res = self._run("control", "aggressive-machine-cse=1")
+        self.assertEqual(res.returncode, 0, res.stderr + res.stdout)
 
     def test_compile_with_programmatic_nvvm_options(self):
-        gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
-        cute.compile[NvvmOptions("-Xllc -aggressive-machine-cse=1")](_make_entry(), gA)
+        res = self._run("programmatic", "aggressive-machine-cse=1")
+        self.assertEqual(res.returncode, 0, res.stderr + res.stdout)
 
     def test_rejected_flag_surfaces_backend_error(self):
         # Whether a given well-formed flag is accepted is libNVVM's call. What
         # this pins is that a rejection is not swallowed: it must surface as a
         # compile-time diagnostic. If this libNVVM happens to accept the flag
         # there is nothing to assert, so skip rather than fail.
-        gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
-        try:
-            cute.compile(_make_entry(), gA, options="llc{time-passes}")
-        except CompilerDiagnosticError as exc:
-            self.assertIn("NVVM", str(exc))
-        else:
+        res = self._run("control", "time-passes")
+        if res.returncode == 0:
             self.skipTest("this libNVVM accepts -time-passes; nothing to assert")
+        self.assertEqual(res.returncode, 3, res.stderr + res.stdout)
+        self.assertIn("NVVM", res.stderr)
+
+
+class TestLlcFlagStateIsProcessGlobal(unittest.TestCase):
+    """Pins the documented process-global semantics of ``-Xllc`` flags.
+
+    The backend parses ``-Xllc`` flags into LLVM's process-global option
+    registry (``cl::opt``), and only compiles that pass ``nvvm-options``
+    re-parse it: a kernel compiled with NO options after a flagged compile
+    of a different kernel comes out identical to an explicitly flagged
+    build, not to a clean one. This test discloses and pins that behavior
+    (see the "Process-global flag state" section of the compilation-options
+    doc). If it ever fails with ``leaked == clean``, the backend gained
+    per-compile scoping and the documentation should be updated.
+
+    One fresh interpreter per compile ordering: the state under test is
+    process state, so the orderings cannot be observed in one process.
+    """
+
+    # Schedule-for-registers: changes emitted PTX even on trivial kernels
+    # (unlike e.g. aggressive-machine-cse, which is a no-op on small code).
+    _PROBE_FLAG = "nvptx-sched4reg"
+
+    def _victim_ptx(self, mode, tmp):
+        out = os.path.join(tmp, mode)
+        os.makedirs(out, exist_ok=True)
+        res = _run_compile_subprocess(mode, self._PROBE_FLAG, out)
+        if res.returncode == 3 and "BACKEND-REJECTED" in res.stderr:
+            self.skipTest(
+                f"this libNVVM rejects -{self._PROBE_FLAG}; no observable "
+                "to pin the process-global behavior with"
+            )
+        self.assertEqual(res.returncode, 0, res.stderr + res.stdout)
+        paths = glob.glob(os.path.join(out, "*victim*.ptx"))
+        self.assertEqual(len(paths), 1, paths)
+        with open(paths[0], "rb") as f:
+            return f.read()
+
+    def test_unflagged_compile_inherits_earlier_llc_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            clean = self._victim_ptx("clean", tmp)
+            control = self._victim_ptx("control", tmp)
+            if control == clean:
+                self.skipTest(
+                    f"-{self._PROBE_FLAG} does not change this libNVVM's PTX; "
+                    "no observable to pin the process-global behavior with"
+                )
+            leaked = self._victim_ptx("leaked", tmp)
+            self.assertEqual(
+                leaked,
+                control,
+                "victim no longer inherits the earlier compile's -Xllc flag; "
+                "the backend appears to scope flags per compile now -- update "
+                "the process-global-state documentation",
+            )
+            self.assertNotEqual(leaked, clean)
 
 
 if __name__ == "__main__":

--- a/test/python/CuTeDSL/test_compile_options_llc.py
+++ b/test/python/CuTeDSL/test_compile_options_llc.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Unit tests for the ``llc{...}`` compile-option token and the ``NvvmOptions``
+compile option.
+
+``llc{<flag>[,<flag>...]}`` forwards each brace item to LLVM codegen (llc)
+as an ``-Xllc -<flag>`` pair via the ``nvvm-options`` option of the
+``cute-to-nvvm`` pipeline. The token is accepted everywhere compact tokens
+are: ``CUTE_DSL_COMPILER_OPT``, ``cute.compile(..., options=...)``, and the
+underlying ``CompileOptions._apply_opt_string``. ``NvvmOptions`` is the
+matching programmatic option (``cute.compile[NvvmOptions("...")]``).
+"""
+
+import unittest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32
+from cutlass.base_dsl.common import DSLUserCodeError
+from cutlass.base_dsl.compiler import (
+    CompileOptions,
+    CompilerDiagnosticError,
+    NvvmOptions,
+    _parse_compile_options_from_str,
+)
+from cutlass.cute.runtime import make_fake_tensor
+
+
+class TestLlcTokenParsing(unittest.TestCase):
+    """Parse-level tests; no GPU compilation involved."""
+
+    def test_default_has_no_nvvm_options(self):
+        # Opt-in: with no llc token the option contributes no text at all.
+        self.assertNotIn("nvvm-options", CompileOptions().to_str())
+        self.assertEqual(CompileOptions().options[NvvmOptions].serialize(), "")
+
+    def test_single_flag(self):
+        co = CompileOptions()
+        co._apply_opt_string("llc{aggressive-machine-cse=1}")
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", co.to_str())
+
+    def test_multiple_flags_one_token(self):
+        co = CompileOptions()
+        co._apply_opt_string("llc{aggressive-machine-cse=1,enable-misched=0}")
+        self.assertIn(
+            "nvvm-options='-Xllc -aggressive-machine-cse=1 -Xllc -enable-misched=0'",
+            co.to_str(),
+        )
+
+    def test_valueless_flag(self):
+        co = CompileOptions()
+        co._apply_opt_string("llc{stats}")
+        self.assertIn("nvvm-options='-Xllc -stats'", co.to_str())
+
+    def test_flags_accumulate_across_tokens(self):
+        co = CompileOptions()
+        co._apply_opt_string("llc{aggressive-machine-cse=1}")
+        co._apply_opt_string("llc{enable-misched=0}")
+        self.assertIn(
+            "nvvm-options='-Xllc -aggressive-machine-cse=1 -Xllc -enable-misched=0'",
+            co.to_str(),
+        )
+
+    def test_repeated_application_is_idempotent(self):
+        # The env var is re-applied per compile onto a reused CompileOptions,
+        # so applying the same token twice must not grow the value (which
+        # would perturb the compile-cache key).
+        co = CompileOptions()
+        for _ in range(3):
+            co._apply_opt_string("llc{aggressive-machine-cse=1}")
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", co.to_str())
+        self.assertEqual(co.options[NvvmOptions].value.count("-Xllc"), 1)
+
+    def test_explicit_nvvm_options_wins_over_token(self):
+        # Documented precedence: compact tokens are applied before the legacy
+        # string API, so an explicit --nvvm-options value replaces the flags
+        # contributed by llc{...} regardless of textual order.
+        for opts in (
+            "--nvvm-options '-Xllc -base' llc{aggressive-machine-cse=1}",
+            "llc{aggressive-machine-cse=1} --nvvm-options '-Xllc -base'",
+        ):
+            co = _parse_compile_options_from_str(opts)
+            self.assertIn("nvvm-options='-Xllc -base'", co.to_str())
+            self.assertNotIn("aggressive-machine-cse", co.to_str())
+
+    def test_string_api_pure_compact(self):
+        co = _parse_compile_options_from_str("llc{aggressive-machine-cse=1}")
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", co.to_str())
+
+    def test_string_api_mixed_with_legacy(self):
+        co = _parse_compile_options_from_str(
+            "--opt-level 2 llc{aggressive-machine-cse=1}"
+        )
+        s = co.to_str()
+        self.assertIn("opt-level=2", s)
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", s)
+
+    def test_coexists_with_other_compact_tokens(self):
+        co = CompileOptions()
+        co._apply_opt_string("warnings{nvvm} llc{aggressive-machine-cse=1}")
+        s = co.to_str()
+        self.assertIn("diagnostic=nvvm", s)
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", s)
+
+
+class TestLlcTokenRejectsMalformedInput(unittest.TestCase):
+    def _assert_rejected(self, opt_str, msg_fragment):
+        with self.assertRaises(ValueError) as ctx:
+            CompileOptions()._apply_opt_string(opt_str)
+        self.assertIn(msg_fragment, str(ctx.exception))
+
+    def test_bare_name(self):
+        self._assert_rejected("llc", "llc expects flag braces")
+
+    def test_equals_form(self):
+        self._assert_rejected("llc=1", "llc expects flag braces")
+
+    def test_empty_braces(self):
+        self._assert_rejected("llc{}", "Empty braces for option 'llc'")
+
+    def test_only_separators_in_braces(self):
+        self._assert_rejected("llc{ , }", "Empty braces for option 'llc'")
+
+    def test_unclosed_brace(self):
+        self._assert_rejected("llc{aggressive-machine-cse=1", "Unclosed")
+
+    def test_leading_dash(self):
+        self._assert_rejected("llc{-aggressive-machine-cse=1}", "invalid llc flag")
+
+    def test_embedded_space(self):
+        self._assert_rejected("llc{aggressive machine cse}", "invalid llc flag")
+
+    def test_embedded_quote(self):
+        self._assert_rejected("llc{foo'bar}", "invalid llc flag")
+
+    def test_flag_value_with_quote(self):
+        self._assert_rejected("llc{foo='1'}", "invalid llc flag")
+
+
+class TestNvvmOptionsProgrammatic(unittest.TestCase):
+    def test_exported_from_cute(self):
+        self.assertIs(cute.NvvmOptions, NvvmOptions)
+
+    def test_direct_option(self):
+        co = CompileOptions((NvvmOptions("-Xllc -aggressive-machine-cse=1"),))
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", co.to_str())
+
+    def test_rejects_quote(self):
+        with self.assertRaises(DSLUserCodeError):
+            NvvmOptions("-Xllc -foo='1'")
+
+    def test_rejects_brace(self):
+        with self.assertRaises(DSLUserCodeError):
+            NvvmOptions("-Xllc -foo} evil{")
+
+    def test_rejects_quote_on_assignment(self):
+        opt = NvvmOptions("-Xllc -aggressive-machine-cse=1")
+        with self.assertRaises(DSLUserCodeError):
+            opt.value = "-Xllc -foo='1' evil"
+
+    def test_surrounding_quotes_are_tolerated(self):
+        # serialize() strips one layer of surrounding quotes before
+        # re-quoting, so a pre-quoted value is legal (this is how the
+        # legacy --nvvm-options string path delivers values).
+        co = CompileOptions((NvvmOptions("'-Xllc -aggressive-machine-cse=1'"),))
+        self.assertIn("nvvm-options='-Xllc -aggressive-machine-cse=1'", co.to_str())
+
+
+def _make_entry():
+    @cute.kernel
+    def k(gA: cute.Tensor):
+        tidx, _, _ = cute.arch.thread_idx()
+        gA[tidx] = gA[tidx] + Float32(1.0)
+
+    @cute.jit
+    def entry(gA: cute.Tensor):
+        k(gA).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+    return entry
+
+
+class TestLlcTokenCompilation(unittest.TestCase):
+    """End-to-end: the serialized option must be accepted by the
+    cute-to-nvvm pipeline and reach the NVVM backend."""
+
+    def test_compile_with_llc_flag(self):
+        gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+        cute.compile(_make_entry(), gA, options="llc{aggressive-machine-cse=1}")
+
+    def test_compile_with_programmatic_nvvm_options(self):
+        gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+        cute.compile[NvvmOptions("-Xllc -aggressive-machine-cse=1")](_make_entry(), gA)
+
+    def test_rejected_flag_surfaces_backend_error(self):
+        # Whether a given well-formed flag is accepted is libNVVM's call. What
+        # this pins is that a rejection is not swallowed: it must surface as a
+        # compile-time diagnostic. If this libNVVM happens to accept the flag
+        # there is nothing to assert, so skip rather than fail.
+        gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+        try:
+            cute.compile(_make_entry(), gA, options="llc{time-passes}")
+        except CompilerDiagnosticError as exc:
+            self.assertIn("NVVM", str(exc))
+        else:
+            self.skipTest("this libNVVM accepts -time-passes; nothing to assert")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR

There is currently no supported way to hand an LLVM codegen (llc) flag to the DSL's JIT pipeline. This PR adds one, strictly opt-in:

```bash
CUTE_DSL_COMPILER_OPT="llc{aggressive-machine-cse=1}"
```

```python
compiled = cute.compile(fn, *args, options="llc{aggressive-machine-cse=1}")
# or programmatically:
compiled = cute.compile[NvvmOptions("-Xllc -aggressive-machine-cse=1")](fn, *args)
```

Each brace item is forwarded to LLVM codegen as an `-Xllc -<flag>` pair through the `nvvm-options` option of the `cute-to-nvvm` pipeline. Nothing is forwarded unless the user asks for it: with no `llc{...}` token the new option contributes no text to the pipeline (see Limitations for the one-space registry side effect every added option has).

## Motivation

On a large production sparse-attention backward kernel on B200 (sm_100a, CUDA 13), a single llc flag, `-aggressive-machine-cse=1`, gives a measurable, numerics-preserving win:

- **Static SASS**: −3.9% instructions on the stock kernel (5984 → 5752) and −6.4/−6.6% on a tuned variant (5984/5976 → 5592), dominated by IMAD (−45/−84) and MOV (−49/−52) dedup — the classic redundant-address-math CSE signature.
- **Runtime** (nsys pure-kernel time, i.e. kernel duration only — no wrapper/launch/sync; n=150 per arm from 3 interleaved rounds): −1.2 to −2.1% median, −1.4 to −1.7% mean, −2.0 to −2.2% min across all four pairings of {stock, tuned} × {cutlass-dsl 4.6.1, 4.7.0}. Honest headline: **~1.5–2% pure-kernel on B200 at the production shape**.
- **Numerics**: the deterministic output is bitwise-identical with the flag on vs. off in all four pairings; the fp32-atomic outputs stay inside their intrinsic run-to-run envelope. The flag only affects instruction selection/scheduling of integer/address math.

That flag is emphatically **not** a universal win, which is exactly why this has to be an opt-in knob rather than a pipeline default. A follow-up sweep of the same flag over five other production CuTe DSL kernels (B200, one toolchain pin, nsys pure-GPU medians, n=100/arm, outputs bitwise or within the fp32-atomic run-to-run envelope in all five) found effects spanning **−15.2% to +0.33%**, with sign flips:

| kernel | Δ time | notes |
| --- | --- | --- |
| sparse-attention indexer forward, fp8 | **−15.2%** | static spill ops halved (21→12 LDL / 21→12 STL); this kernel sits in a bistable codegen regime where an unrelated schedule perturbation costs +15% |
| top-k selection | −1.5% | −88 static instructions |
| mean-pool scoring | −0.8% | −208 static instructions; already compiled at `--opt-level 2` and the flag still helps on top |
| sparse-attention indexer forward, bf16 | +0.25% | at the measurement floor |
| sparse-attention indexer backward | **+0.33%** | small but reproducible regression; picks up an 8-byte stack frame and one LDL/STL pair |

So the flag is safe with respect to numerics but must be chosen per kernel with a perf gate behind it — a scoped, per-compile passthrough (what this PR adds), never a default change.

Today the only way to do this is to monkeypatch `CompileOptions.to_str` and splice `nvvm-options='-Xllc ...'` into its return value — fragile, version-dependent, and unsupported. The pipeline plumbing for it already exists (the `cute-to-nvvm` pass accepts `nvvm-options`, verified on the 4.6.1 and 4.7.0 wheels); what is missing is purely the user-facing vocabulary on the Python side.

## What this adds

1. **`NvvmOptions`** — a registered `StringCompileOption` with `_option_name = "nvvm-options"`, the exact analog of the existing `PtxasOptions` (`ptx-options`). It serializes as `nvvm-options='<value>'` into the `cute-to-nvvm{...}` brace built by `_get_pipeline` and, because `get_module_hash` hashes `CompileOptions.to_str()`, is automatically part of the compile-cache key. Exported next to `PtxasOptions` (`cute.NvvmOptions`).
2. **`llc{<flag>[,<flag>...]}`** — a compact token in `CompileOptions._apply_opt_string`, following the existing brace-token pattern (`debug{...}`, `warnings{...}`, `remarks{...}`). Each item is validated for shape (`[A-Za-z0-9][\w.-]*(?:=[\w.-]+)?`, spelled without the leading `-`) and appended to `NvvmOptions` as an `-Xllc -<flag>` pair. Multiple items, and repeated `llc{...}` tokens, accumulate. The token is accepted everywhere compact tokens already are: `CUTE_DSL_COMPILER_OPT`, `cute.compile(..., options=...)` (pure-compact and mixed compact+legacy paths), and `_apply_opt_string`.

Small enabling details:

- `NvvmOptions` sets `_suppress_when_absent`, so an absent `--nvvm-options` argparse flag on the mixed legacy path does not clobber a value set by the `llc{...}` token (this is exactly what `_suppress_when_absent` exists for).
- `--nvvm-options` joins `--ptxas-options` in the hyphen-value argparse workaround in `_parse_compile_options_from_str`.
- Appending is idempotent: a flag already present is not added again. `CUTE_DSL_COMPILER_OPT` is re-applied to the (reused) `CompileOptions` on every compile, so a non-idempotent append would grow the value — and the compile-cache key — on each compile.
- Precedence, documented in the docstring, the `.rst`, and a test: compact tokens are applied before the legacy string API, so an explicit `--nvvm-options <value>` replaces flags contributed by `llc{...}` in the same options string, regardless of order.

Docs: `media/docs/pythonDSL/cute_dsl_general/dsl_jit_compilation_options.rst` gains an `nvvm-options` table row, both string-API and Python-type examples next to the `ptxas-options` ones, and a short section on forwarding llc flags (including the env-var form).

## Injection safety

A user-supplied string ends up inside a quoted slot of the pass-pipeline spec, so both entry points validate:

- The `llc{...}` token accepts only `[A-Za-z0-9][\w.-]*(?:=[\w.-]+)?` per comma-separated item — no quotes, spaces, braces, or backslashes can get through, and the flag is composed as `-Xllc -<flag>` by the parser itself.
- `NvvmOptions` (constructor and `.value` setter) rejects any value whose quote-stripped core contains `'`, `"`, `{`, `}`, `\`, or control whitespace — i.e. anything that could terminate the `nvvm-options='...'` slot or the pipeline nesting. Surrounding quotes are tolerated because `serialize()` strips one layer before re-quoting (that is how the legacy string path delivers values).

## Error behavior (documented, matches what libNVVM actually does)

- Malformed token syntax (`llc`, `llc=1`, `llc{}`, `llc{-foo}`, `llc{a b}`, unclosed brace, embedded quote) fails at parse time with a `ValueError` carrying a targeted message.
- Well-formed flags that libNVVM rejects surface as a compile-time diagnostic (`CompilerDiagnosticError`, "NVVM backend compilation failed") — verified with `-time-passes`.
- Flags/values libNVVM does not recognize are **silently ignored** by the backend (verified empirically). The docstrings say so: shape validation happens in Python, semantic validation is the backend's.

## Tests

`test/python/CuTeDSL/test_compile_options_llc.py` (unittest, follows sibling files):

- Parse: default contributes no option text; single/multiple/valueless flags; accumulation across tokens; idempotence under repeated application; documented `--nvvm-options` precedence; pure-compact and mixed compact+legacy string API; coexistence with `warnings{...}`.
- Rejection: 9 malformed-input cases raise `ValueError` with the expected message.
- Programmatic: `NvvmOptions` direct use, export identity, quote/brace rejection on constructor and assignment, surrounding-quote tolerance.
- Compilation (end-to-end on GPU): `options="llc{aggressive-machine-cse=1}"` compiles; `cute.compile[NvvmOptions(...)]` compiles; a backend-rejected flag surfaces as `CompilerDiagnosticError` mentioning NVVM (skipped, not failed, if a future libNVVM accepts that flag).

Verified on B200 (sm_100a): 29/29 pass with the patch (backend-touching tests run in
disposable subprocesses because accepted `-Xllc` flags are process-global; the new
process-global-state test skips itself if its witness flag is invisible on a future
libNVVM); on stock, `llc{...}` is rejected with `option 'llc' does not take {...} sub-options` and `NvvmOptions` does not exist. The env-var route was additionally verified end-to-end in a fresh process, including that three successive compiles produce a stable option string. The three pre-existing test files in `test/python/CuTeDSL/` behave identically with and without the patch.

## Limitations

- **Process-global flag state (measured; documented and pinned by a test).**
  `-Xllc` flags are parsed into LLVM's process-global option registry (`cl::opt`) by
  the in-process backend, and the registry is only re-parsed by compiles that
  themselves pass an `nvvm-options` token. A compile using `llc{...}` therefore
  leaves the flag in effect for **every subsequent `cute.compile` in the same
  process** that does not pass its own `nvvm-options` — the flag does not expire with
  the compile that set it. Verified on B200: a kernel compiled with no options after
  a flagged compile of a *different* kernel is byte-identical (PTX, cubin and SASS)
  to an explicitly flagged build of itself, and differs from a never-flagged process
  (witness flag `-nvptx-sched4reg`, which is PTX-visible even on trivial kernels).
  Two follow-on hazards are documented with it: (1) compile caches key on the
  *requested* option string (`get_module_hash`), not on inherited registry state, so
  an unflagged cached JIT compilation in a flagged process can store flag-affected
  code under the clean key — including in the persistent file cache, from which it
  can be served to later processes (explicit `cute.compile` always recompiles and is
  unaffected); (2) a paired reset compile that passes the flag's default value
  explicitly is only best-effort — it needs a value-expressible default, must
  actually reach the backend (cache-served compiles do not re-parse), and cannot undo
  `CUTE_DSL_COMPILER_OPT`, which is re-applied every compile; full isolation is a
  fresh process. This is a limitation of the current in-process backend and cannot be
  scoped from Python; automatic reset semantics are unimplementable in general (the
  DSL cannot know an arbitrary flag's default, and libNVVM exposes no registry-reset
  entry point). The `.rst` gained a "Process-global flag state" section;
  `TestLlcFlagStateIsProcessGlobal` pins the behavior (one fresh interpreter per
  compile ordering, victim always the second compile so warm-state matches) and the
  pre-existing end-to-end compile tests now also run in disposable subprocesses so
  accepted flags cannot poison later compiles in a test worker.

- llc flags are inherently tied to the LLVM version inside libNVVM; this is a power-user escape hatch (same contract as `ptxas-options` / nvcc `-Xptxas`), not a stable API. Opt-in only: with no `llc{...}` token, `NvvmOptions` serializes to nothing.
- Registering a new option adds one separator space to the default serialized option string (`to_str` appends a space per option, including empty ones), so default compile-cache keys change once, as they do whenever an option is added — the DSL's own default string went from 88 to 106 bytes between 4.6.1 and 4.7.0. The extra whitespace is inert in the pass-pipeline string.
- The backend silently ignores unrecognized flags (libNVVM behavior, not controllable from Python), so a typo in a flag name does not error; flags the backend rejects do error.
- No SASS-diff regression test: on toy kernels `-aggressive-machine-cse=1` is a no-op (small kernels get re-CSEd downstream regardless), so an instruction-count assertion would be fragile. The compile-success and backend-rejection tests pin the passthrough contract instead.