### PR TITLE
[CuTeDSL] Skip consecutive re-emission of the same compiler-opt fragment batch

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/compiler.py
+++ b/python/CuTeDSL/cutlass/base_dsl/compiler.py
@@ -789,6 +789,7 @@ class CompileOptions:
         }
         self._ptxas_diagnostics_enabled = False
         self._debug_selectors: set[str] = set()
+        self._last_raw_opt_batch: "str | None" = None
 
         if options is not None:
             self._update(options)
@@ -971,9 +972,30 @@ class CompileOptions:
                     raw_opts.append(f"{key}={'true' if not val else val}")
 
         if raw_opts:
-            existing = self.options[ExtraCompilerOpts].value
-            combined = (existing + " " + " ".join(raw_opts)).strip()
-            self.options[ExtraCompilerOpts].value = combined
+            # Skip consecutive re-emissions of the same fragment batch.
+            # CUTE_DSL_COMPILER_OPT is re-applied on EVERY compilation
+            # (``apply_envar_settings``), and the public ``cute.compile``
+            # entrypoint is a long-lived CompileCallable whose CompileOptions
+            # outlives individual compiles (``post_compilation_cleanup`` only
+            # swaps the DSL attribute reference), so an unconditional append
+            # grows the serialized pipeline string on every compile and,
+            # since ``to_str`` feeds the module cache key, the same kernel
+            # can hash differently at different points in the process
+            # lifetime.  Re-appending a batch is only semantically meaningful
+            # if a DIFFERENT batch landed after it (pipeline options are
+            # last-wins), which is exactly when the incoming batch differs
+            # from the last one applied: a single application stays
+            # byte-identical (including order-sensitive repeats such as
+            # ``foo=1 foo=2 foo=1``), alternating batches keep re-asserting
+            # last-wins exactly as before, and named options above remain
+            # re-applied per compile (their per-compile reset is
+            # load-bearing, e.g. ``link-libraries``).
+            batch = " ".join(raw_opts)
+            if batch != self._last_raw_opt_batch:
+                self._last_raw_opt_batch = batch
+                existing = self.options[ExtraCompilerOpts].value
+                combined = (existing + " " + batch).strip()
+                self.options[ExtraCompilerOpts].value = combined
 
     def apply_envar_settings(
         self, envar: EnvironmentVarManager, function_name: str

--- a/test/python/CuTeDSL/test_compile_options_env_idempotent.py
+++ b/test/python/CuTeDSL/test_compile_options_env_idempotent.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""
+Regression tests: re-applying the same compiler-option string to one
+``CompileOptions`` object must not grow ``ExtraCompilerOpts``.
+
+``apply_envar_settings`` runs on every compilation, and the public
+``cute.compile`` entrypoint is a module-global ``CompileCallable`` whose
+``CompileOptions`` outlives individual compiles.  Re-applying the env-var
+option string appended its emitted raw fragments to ``ExtraCompilerOpts``
+again on every compile, so the serialized pass-pipeline string grew without
+bound and, because ``CompileOptions.to_str()`` is hashed into the module
+cache key, the same kernel could map to different cache keys at different
+points in the process lifetime.
+
+The fix skips only *consecutive* re-emissions of the same fragment batch.
+A single application stays byte-identical (including order-sensitive inputs
+such as ``foo=1 foo=2 foo=1``), alternating batches keep re-asserting
+last-wins exactly as before, different option strings keep accumulating, and
+named options are still re-applied per compile (their per-compile reset is
+load-bearing, e.g. ``link-libraries``).
+"""
+
+import hashlib
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+
+from cutlass.base_dsl.compiler import (
+    CompileOptions,
+    ExtraCompilerOpts,
+)
+from cutlass.base_dsl.env_manager import EnvironmentVarManager
+
+
+def _make_envar(compiler_opt):
+    """An EnvironmentVarManager with a fixed option string and no dependence
+    on ambient ``CUTE_DSL_*`` variables.
+
+    Env reads are lru_cached module-level helpers, so the constructor runs
+    under a scrubbed environment with cleared caches (constructor side
+    effects such as the keep-SASS nvdisasm probe must not see ambient
+    settings), and the caches are cleared again afterwards so later reads
+    observe the real environment.  The settings consumed by
+    apply_envar_settings are then pinned directly.
+    """
+    from unittest import mock
+
+    from cutlass.base_dsl import env_manager
+
+    def _clear_env_caches():
+        for helper in (
+            env_manager.get_str_env_var,
+            env_manager.get_bool_env_var,
+            env_manager.get_int_env_var,
+            env_manager.get_int_or_none_env_var,
+            env_manager.has_env_var,
+        ):
+            helper.cache_clear()
+
+    with mock.patch.dict(os.environ):
+        for key in list(os.environ):
+            if key.startswith("CUTE_DSL_") and key != "CUTE_DSL_LIBS":
+                del os.environ[key]
+        _clear_env_caches()
+        envar = EnvironmentVarManager("CUTE_DSL")
+    _clear_env_caches()
+    envar.compiler_opt = compiler_opt
+    envar.debug = False
+    envar.remarks = ""
+    envar.keep_ptx = envar.keep_cubin = envar.keep_sass = False
+    envar.enable_pyir = False
+    envar.enable_assertions = False
+    envar.lineinfo = False
+    envar.enable_tvm_ffi = False
+    return envar
+
+
+class TestEnvarReapplicationIsIdempotent(unittest.TestCase):
+    """apply_envar_settings re-runs per compile; re-emitting the same raw
+    fragment batch must not grow the options.  No GPU compilation involved."""
+
+    def _extra(self, co):
+        return co.options[ExtraCompilerOpts].value
+
+    def _apply_n(self, compiler_opt, n=3):
+        envar = _make_envar(compiler_opt)
+        co = CompileOptions()
+        seen = []
+        for _ in range(n):
+            co.apply_envar_settings(envar, "fn")
+            seen.append(self._extra(co))
+        return co, seen
+
+    def test_compact_token_stable_across_three_compiles(self):
+        co, seen = self._apply_n("iket")
+        self.assertEqual(
+            seen,
+            ["enable-iket=true"] * 3,
+            f"ExtraCompilerOpts grew across re-applications: {seen}",
+        )
+
+    def test_raw_flag_stable_across_three_compiles(self):
+        # Unknown names fall through to raw pipeline fragments; those must
+        # not accumulate either.
+        co, seen = self._apply_n("my-flag=1")
+        self.assertEqual(seen, ["my-flag=1"] * 3)
+
+    def test_serialization_and_cache_key_input_stable(self):
+        # to_str() builds the pass-pipeline string and feeds the module
+        # cache key; it must not change across compiles.
+        envar = _make_envar("iket")
+        co = CompileOptions()
+        strs = []
+        for _ in range(3):
+            co.apply_envar_settings(envar, "fn")
+            strs.append(co.to_str())
+        digests = {hashlib.sha256(s.encode()).hexdigest() for s in strs}
+        self.assertEqual(
+            len(set(strs)),
+            1,
+            f"serialized options changed across compiles: {strs}",
+        )
+        self.assertEqual(len(digests), 1)
+
+    def test_mixed_diagnostics_stable_with_per_compile_serialization(self):
+        # warnings/remarks emit diagnostic= fragments, and to_str() (called
+        # once per real compile) canonicalizes the first one in place via
+        # _ensure_compiler_diagnostic_selector.  Re-application after that
+        # mutation must not append further fragments (which could flip the
+        # effective last-wins selector between compiles).
+        envar = _make_envar("warnings{nvvm} remarks{ptx}")
+        co = CompileOptions()
+        strs = []
+        for _ in range(3):
+            co.apply_envar_settings(envar, "fn")
+            strs.append(co.to_str())
+        self.assertEqual(
+            len(set(strs)),
+            1,
+            f"serialized options changed across compiles: {strs}",
+        )
+        # Effective semantics must match the historical first cycle: the
+        # canonicalized selector followed by the ptx fragment (last-wins
+        # selector stays ptx).
+        self.assertIn("diagnostic=nvvm,ptx diagnostic=ptx", strs[0])
+
+    def test_single_application_preserves_order_and_duplicates(self):
+        # A single application must stay byte-identical to the historical
+        # behavior, including repeated keys and repeated identical
+        # fragments: downstream pipeline options are last-wins, so
+        # "foo=1 foo=2 foo=1" must keep all three fragments in order.
+        co, seen = self._apply_n("foo=1 foo=2 foo=1")
+        self.assertEqual(seen, ["foo=1 foo=2 foo=1"] * 3)
+
+    def test_distinct_applications_still_accumulate(self):
+        # Only consecutive re-emission of the same batch is skipped;
+        # different option strings applied to the same object keep
+        # accumulating.
+        co = CompileOptions()
+        co._apply_opt_string("foo=1")
+        co._apply_opt_string("bar=2")
+        self.assertEqual(self._extra(co), "foo=1 bar=2")
+
+    def test_alternating_batches_reassert_last_wins(self):
+        # A batch that was applied before but has since been superseded by a
+        # different batch MUST be re-appended: pipeline options are
+        # last-wins, and the persistent options object can serve DSLs with
+        # different env namespaces whose option strings alternate (e.g.
+        # CUTE_DSL_COMPILER_OPT=iket vs
+        # CUTE_EXPERIMENTAL_DSL_COMPILER_OPT=enable-iket=false).
+        co = CompileOptions()
+        co.apply_envar_settings(_make_envar("iket"), "fn")
+        co.apply_envar_settings(_make_envar("enable-iket=false"), "fn")
+        co.apply_envar_settings(_make_envar("iket"), "fn")
+        self.assertEqual(
+            self._extra(co),
+            "enable-iket=true enable-iket=false enable-iket=true",
+        )
+        # ... and re-applying the (now last) batch again must not grow it.
+        co.apply_envar_settings(_make_envar("iket"), "fn")
+        self.assertEqual(
+            self._extra(co),
+            "enable-iket=true enable-iket=false enable-iket=true",
+        )
+
+    def test_named_options_are_still_reapplied_per_compile(self):
+        # The guard covers only the raw-fragment append.  Named options must
+        # keep their per-compile replace semantics: the persistent options
+        # object can serve DSLs with different env namespaces
+        # (CUTE_DSL_* / CUTE_EXPERIMENTAL_DSL_*), whose option strings must
+        # keep overriding each other.
+        from cutlass.base_dsl.compiler import OptLevel
+
+        co = CompileOptions()
+        co.apply_envar_settings(_make_envar("opt-level=1"), "fn")
+        self.assertEqual(str(co.options[OptLevel].value), "1")
+        co.apply_envar_settings(_make_envar("opt-level=2"), "fn")
+        self.assertEqual(str(co.options[OptLevel].value), "2")
+        co.apply_envar_settings(_make_envar("opt-level=1"), "fn")
+        self.assertEqual(str(co.options[OptLevel].value), "1")
+
+    def test_link_libraries_reset_per_compile_is_preserved(self):
+        # The compiler appends FFI bitcode sources to LinkLibraries during
+        # each compilation; on the persistent options object it is the
+        # env-string re-application that resets the list.  The guard must
+        # not break that (otherwise per-kernel bitcode accumulates and leaks
+        # into later kernels).
+        from cutlass.base_dsl.compiler import LinkLibraries
+
+        envar = _make_envar("link-libraries=base.bc")
+        co = CompileOptions()
+        co.apply_envar_settings(envar, "fn")
+        self.assertEqual(co.options[LinkLibraries].value, "base.bc")
+        # Simulate the per-compile FFI append done in generate_mlir.
+        co.options[LinkLibraries] = LinkLibraries("base.bc,ffi_kernel_a.bc")
+        co.apply_envar_settings(envar, "fn")
+        self.assertEqual(co.options[LinkLibraries].value, "base.bc")
+
+
+class TestEnvOptCompilationLifetime(unittest.TestCase):
+    """End-to-end: the persistent ``cute.compile`` options object must not
+    accumulate env-var fragments across real compilations.
+
+    Runs in a subprocess so ``CUTE_DSL_COMPILER_OPT`` is set before DSL
+    initialization, exactly as a user would hit this.
+    """
+
+    def test_three_compiles_do_not_grow_options(self):
+        import tempfile
+
+        script = textwrap.dedent(
+            """
+            import os
+            import sys
+
+            # Import the same `cutlass` package as the parent test process
+            # (an installed wheel may inject its own path entries via .pth
+            # hooks ahead of PYTHONPATH).
+            sys.path.insert(0, os.environ["_TEST_CUTLASS_PKG_ROOT"])
+
+            import cutlass
+            import cutlass.cute as cute
+            from cutlass import Float32
+            from cutlass.base_dsl.compiler import ExtraCompilerOpts
+            from cutlass.cute.runtime import make_fake_tensor
+
+            @cute.kernel
+            def k(gA: cute.Tensor):
+                tidx, _, _ = cute.arch.thread_idx()
+                gA[tidx] = gA[tidx] + Float32(1.0)
+
+            @cute.jit
+            def entry(gA: cute.Tensor):
+                k(gA).launch(grid=(1, 1, 1), block=(32, 1, 1))
+
+            gA = make_fake_tensor(Float32, (128,), stride=(1,), assumed_align=4)
+            seen = []
+            for _ in range(3):
+                cute.compile(entry, gA)
+                seen.append(
+                    cute.compile._compile_options.options[ExtraCompilerOpts].value
+                )
+            for i, s in enumerate(seen, 1):
+                print(f"after compile {i}: {s!r}")
+            if seen != ["enable-iket=true"] * 3:
+                raise SystemExit(f"options object grew across compiles: {seen}")
+            """
+        )
+        import cutlass
+
+        # Import the same cutlass package in the subprocess, and drop
+        # ambient settings that would perturb the exact expected fragment
+        # (other CUTE_DSL_* variables, e.g. CUTE_DSL_LIBS, must survive).
+        pkg_root = os.path.dirname(os.path.dirname(os.path.abspath(cutlass.__file__)))
+        scrub = {
+            "CUTE_DSL_COMPILER_OPT",
+            "CUTE_DSL_DEBUG",
+            "CUTE_DSL_REMARKS",
+            "CUTE_DSL_KEEP",
+            "CUTE_DSL_KEEP_IR",
+            "CUTE_DSL_KEEP_PTX",
+            "CUTE_DSL_KEEP_CUBIN",
+            "CUTE_DSL_KEEP_SASS",
+            "CUTE_DSL_LINEINFO",
+            "CUTE_DSL_ENABLE_ASSERTIONS",
+            "CUTE_DSL_ENABLE_PYIR",
+            "CUTE_DSL_ENABLE_TVM_FFI",
+            "PYTHONOPTIMIZE",
+        }
+        env = {k: v for k, v in os.environ.items() if k not in scrub}
+        env["CUTE_DSL_COMPILER_OPT"] = "iket"
+        env["_TEST_CUTLASS_PKG_ROOT"] = pkg_root
+        # The DSL re-parses jit function sources, so the script must live in
+        # a real file (``python -c`` has no retrievable source).
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+            f.write(script)
+            script_path = f.name
+        try:
+            proc = subprocess.run(
+                [sys.executable, script_path],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            os.unlink(script_path)
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Symptom

`CUTE_DSL_COMPILER_OPT` compact tokens are re-applied on **every** compilation, and each
re-application appends its emitted raw pipeline fragments again. With
`CUTE_DSL_COMPILER_OPT=iket`, compiling the same `@cute.jit` kernel three times in one
process yields (verbatim, `ExtraCompilerOpts.value` of the persistent `cute.compile`
options object after each compile):

```
after compile 1: 'enable-iket=true'
after compile 2: 'enable-iket=true enable-iket=true'
after compile 3: 'enable-iket=true enable-iket=true enable-iket=true'
```

The full serialized option string — which becomes part of the pass-pipeline string of
every compile — grows the same way:

```
opt-level=3 enable-pyir=false  enable-iket=true  rdc=false enable-assertions=false preserve-line-info=false
opt-level=3 enable-pyir=false  enable-iket=true enable-iket=true  rdc=false enable-assertions=false preserve-line-info=false
opt-level=3 enable-pyir=false  enable-iket=true enable-iket=true enable-iket=true  rdc=false enable-assertions=false preserve-line-info=false
```

With `warnings{...}`/`remarks{...}` tokens the growth also interleaves with the in-place
`diagnostic=` canonicalization done at serialization time, e.g.
`CUTE_DSL_COMPILER_OPT="warnings{nvvm} remarks{ptx}"` over three compiles:

```
... diagnostic=nvvm,ptx diagnostic=ptx ...
... diagnostic=nvvm,ptx diagnostic=ptx diagnostic=nvvm diagnostic=ptx ...
... diagnostic=nvvm,ptx diagnostic=ptx diagnostic=nvvm diagnostic=ptx diagnostic=nvvm diagnostic=ptx ...
```

## Root cause

- `cute.compile` is a module-global `CompileCallable`
  (`python/CuTeDSL/cutlass/cute/__init__.py:232`) whose `CompileOptions` outlives
  individual compiles; `CompileCallable._compile` installs that same persistent object
  as the DSL's `compile_options` on each call (bracket callables reused across compiles
  have the same lifetime).
- Every compilation calls `apply_envar_settings` (`base_dsl/dsl.py:2890`), which
  re-applies `CUTE_DSL_COMPILER_OPT` via `_apply_opt_string`
  (`base_dsl/compiler.py:991`), whose `raw_opts` flush appends to
  `ExtraCompilerOpts.value` unconditionally (`base_dsl/compiler.py:973`).
- `post_compilation_cleanup` (`base_dsl/dsl.py:2372`) only swaps the DSL's *reference*
  to a fresh `CompileOptions`; the persistent `cute.compile` object keeps the mutated
  one and re-installs it on the next compile.

## Consequences

1. The pass-pipeline string consumed by every compile grows without bound. Today this
   is semantically silent only because the affected flags are boolean-idempotent and
   MLIR pipeline options are last-wins (`enable-iket=true` twice means the same thing
   as once).
2. `CompileOptions.to_str()` is hashed into the module cache key (`get_module_hash`,
   `base_dsl/dsl.py:1863`). The public `cute.compile` path currently forces
   `no_cache=True`, so on stock paths this manifests as serialized-option instability
   rather than an end-to-end cache miss — but any consumer that reuses a
   `CompileOptions` object with caching enabled gets a **different cache key for the
   same kernel at different points in the process lifetime** (spurious recompiles,
   broken cross-process file-cache reuse). Observed cache-key-input digests across
   three applications of the same option string:

```
6ffadda2bce977a7c757e816775cbef543bafb0944230abbb9a0085875955886
937feeb8a00dfe46d546cd31029048a96259388b8c45f870457a7ad65f157af0
26eabbc60dbcc86108ad2f42ecca73cdd03b94d24c01c1989f28563e7df45981
```

## Fix

Track the last raw fragment batch applied to a given `CompileOptions` object
(`_last_raw_opt_batch`) and skip **only a consecutive re-emission of that same batch**
in the `raw_opts` flush. Re-appending a batch is only semantically meaningful if a
*different* batch landed after it (pipeline options are last-wins) — which is exactly
when the incoming batch differs from the last one applied. This is deliberately the
narrowest contract change:

- A single application stays **byte-identical** to the previous behavior — including
  order-sensitive repeats such as `foo=1 foo=2 foo=1`, whose last-wins order must
  survive verbatim.
- Alternating option strings keep re-asserting last-wins exactly as before. The
  persistent options object can serve DSLs with different env namespaces
  (`CUTE_DSL_*` / `CUTE_EXPERIMENTAL_DSL_*`): e.g. `iket` alternating with
  `enable-iket=false` still restores effective `enable-iket=true` on the third
  application.
- Named options are **not** gated and keep their per-compile replace semantics. That
  re-application is load-bearing on the persistent object: `link-libraries=` must be
  reset every compile because the compiler appends per-kernel FFI bitcode sources to it
  between applications (`base_dsl/dsl.py:2480`).
- The in-place `diagnostic=` canonicalization performed by
  `_ensure_compiler_diagnostic_selector` at serialization time cannot defeat the guard,
  because batches are keyed by what was emitted, not by membership in the (mutated)
  current value.

Both narrower and broader alternatives were rejected after review: fragment-level
first-occurrence dedupe collapses intentional repetition within one option string
(flipping last-wins of `foo=1 foo=2 foo=1`) and re-appends stale `diagnostic=`
fragments after canonicalization; whole-string or ever-seen apply-once semantics
suppress the legitimate re-application that alternating env namespaces and
`link-libraries` reset rely on.

## Tests

`test/python/CuTeDSL/test_compile_options_env_idempotent.py`:

- 3x `apply_envar_settings` stability for a compact token (`iket`) and a raw
  `key=value` fragment.
- Mixed `warnings{nvvm} remarks{ptx}` with `to_str()` called per cycle (the
  `diagnostic=` canonicalization case): serialized string identical across compiles,
  with the historical cycle-1 content (`diagnostic=nvvm,ptx diagnostic=ptx`).
- Cache-key-input stability: sha256 of `to_str()` constant across re-applications.
- Byte-exact single-application semantics: `foo=1 foo=2 foo=1` keeps all three
  fragments in order; distinct applications still accumulate.
- Alternating batches re-assert last-wins (`iket` / `enable-iket=false` / `iket`
  serializes all three fragments), and a further consecutive repeat does not grow.
- Named options still re-applied per compile (`opt-level` override chain) and
  `link-libraries` reset preserved against the per-compile FFI append.
- End-to-end: a subprocess with `CUTE_DSL_COMPILER_OPT=iket` compiles a kernel three
  times and asserts the persistent `cute.compile` options object does not grow.

On stock, the seven idempotency tests fail with the verbatim growth shown above (the
three semantics-preservation tests pass unchanged); with the fix all ten pass.
Pre-existing CuTeDSL test files (`test_struct_in_if.py`, `test_numeric_construction.py`,
`test_export_c_header_shape_type.py`) have identical outcomes with and without the
patch.

## Relationship to PR #3498

PR #3498 (`llc{...}` token) independently guards its own token against this same
re-application pattern with a local dedupe on `NvvmOptions`. The two changes are
textually and semantically independent (clean merges verified in both orders, combined
test suites green). If both land, the local guard in #3498 becomes redundant but
harmless. This PR does not depend on and does not close #3498.