### PR TITLE
Fix incorrect high product in umul128 portable fallback

### DIFF
--- a/include/cutlass/uint128.h
+++ b/include/cutlass/uint128.h
@@ -82,9 +82,9 @@ uint64_t umul128(
   uint64_t p_hl = a_hi * b_lo;
   uint64_t p_hh = a_hi * b_hi;
 
-  uint64_t p_mid = (p_ll >> 32) + (p_lh & mask) + (p_hl & mask);
-  uint64_t r_lo = (p_ll & mask) + (p_mid << 32);
-  uint64_t r_hi = (p_lh & mask) + (p_hl & mask) + p_hh;
+  uint64_t mid = (p_ll >> 32) + (p_lh & mask) + (p_hl & mask);
+  uint64_t r_lo = (p_ll & mask) | (mid << 32);
+  uint64_t r_hi = p_hh + (p_lh >> 32) + (p_hl >> 32) + (mid >> 32);
 
   *high_product = r_hi;
   return r_lo;

--- a/test/unit/core/uint128.cu
+++ b/test/unit/core/uint128.cu
@@ -34,6 +34,8 @@
 
 #include "../common/cutlass_unit_test.h"
 
+#include <vector>
+
 #include "cutlass/array.h"
 #include "cutlass/layout/matrix.h"
 #include "cutlass/numeric_types.h"
@@ -66,7 +68,7 @@ TEST(uint128_t, host_arithmetic) {
     }
   }
 
-  // carry overflow for low uint64_t 
+  // carry overflow for low uint64_t
   {
     for (uint64_t i = 0; i < 1024; ++i) {
       T x = static_cast<uint64_t>(0xFFFFFFFFFFFFFFFF);
@@ -77,6 +79,78 @@ TEST(uint128_t, host_arithmetic) {
       EXPECT_EQ(z.hilo_.hi, static_cast<uint64_t>(0x1));
       EXPECT_EQ(z.hilo_.lo, i);
     }
+  }
+}
+
+namespace {
+
+// 16b-limb schoolbook reference, independent of uint128.h's decomposition
+void reference_umul128(uint64_t a, uint64_t b, uint64_t &hi, uint64_t &lo) {
+  uint16_t const a_limb[4] = {uint16_t(a), uint16_t(a >> 16), uint16_t(a >> 32), uint16_t(a >> 48)};
+  uint16_t const b_limb[4] = {uint16_t(b), uint16_t(b >> 16), uint16_t(b >> 32), uint16_t(b >> 48)};
+
+  uint64_t column[8] = {0};
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      column[i + j] += uint64_t(a_limb[i]) * b_limb[j];
+    }
+  }
+
+  hi = lo = 0;
+  uint64_t carry = 0;
+  for (int c = 0; c < 8; ++c) {
+    uint64_t v = column[c] + carry;
+    if (c < 4) {
+      lo |= (v & 0xFFFFull) << (16 * c);
+    } else {
+      hi |= (v & 0xFFFFull) << (16 * (c - 4));
+    }
+    carry = v >> 16;
+  }
+}
+
+uint32_t xorshift(uint32_t &state) {
+  state ^= state << 13;
+  state ^= state >> 17;
+  state ^= state << 5;
+  return state;
+}
+
+} // namespace
+
+TEST(uint128_t, host_umul128_high_product) {
+  static uint64_t const edges[] = {
+    0x0ull, 0x1ull, 0x2ull, 0xFFFFFFFFull, 0x100000000ull,
+    0xFFFFFFFFFFFFFFFFull, 0x8000000000000000ull, 0x123456789ABCDEF0ull
+  };
+  int const kEdges = int(sizeof(edges) / sizeof(edges[0]));
+
+  for (int i = 0; i < kEdges; ++i) {
+    for (int j = 0; j < kEdges; ++j) {
+      uint64_t got_hi = 0, got_lo = 0, want_hi = 0, want_lo = 0;
+      got_lo = umul128(edges[i], edges[j], &got_hi);
+      reference_umul128(edges[i], edges[j], want_hi, want_lo);
+
+      EXPECT_EQ(got_lo, want_lo) << "a=" << edges[i] << " b=" << edges[j];
+      EXPECT_EQ(got_hi, want_hi) << "a=" << edges[i] << " b=" << edges[j];
+    }
+  }
+
+  uint32_t state = 0x9E3779B9u;
+  for (int i = 0; i < 4096; ++i) {
+    uint64_t a = (uint64_t(xorshift(state)) << 32) | xorshift(state);
+    uint64_t b = (uint64_t(xorshift(state)) << 32) | xorshift(state);
+    if (i % 4 == 0) {
+      a &= 0xFFFFFFFF00000000ull;
+      b &= 0x1FFFFFFFFull;
+    }
+
+    uint64_t got_hi = 0, got_lo = 0, want_hi = 0, want_lo = 0;
+    got_lo = umul128(a, b, &got_hi);
+    reference_umul128(a, b, want_hi, want_lo);
+
+    EXPECT_EQ(got_lo, want_lo) << "iter=" << i;
+    EXPECT_EQ(got_hi, want_hi) << "iter=" << i;
   }
 }
 
@@ -122,5 +196,67 @@ TEST(uint128_t, device_arithmetic) {
 
     EXPECT_EQ(got.hilo_.hi, expected_hi);
     EXPECT_EQ(got.hilo_.lo, expected_lo);
+  }
+}
+
+__global__ void uint128_umul_operator(int count, uint64_t const *a_values, uint64_t const *b_values,
+                                      uint64_t *hi_out, uint64_t *lo_out) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid < count) {
+    lo_out[tid] = umul128(a_values[tid], b_values[tid], &hi_out[tid]);
+  }
+}
+
+TEST(uint128_t, device_umul128_high_product) {
+
+  static uint64_t const edges[] = {
+    0x0ull, 0x1ull, 0x2ull, 0xFFFFFFFFull, 0x100000000ull,
+    0xFFFFFFFFFFFFFFFFull, 0x8000000000000000ull, 0x123456789ABCDEF0ull
+  };
+  int const kEdges = int(sizeof(edges) / sizeof(edges[0]));
+  int const kRandom = 1008;
+  int const kCount = kEdges * kEdges + kRandom;
+
+  std::vector<uint64_t> a_values(kCount), b_values(kCount), hi_want(kCount), lo_want(kCount);
+
+  int idx = 0;
+  for (int i = 0; i < kEdges; ++i) {
+    for (int j = 0; j < kEdges; ++j) {
+      a_values[idx] = edges[i];
+      b_values[idx] = edges[j];
+      reference_umul128(edges[i], edges[j], hi_want[idx], lo_want[idx]);
+      ++idx;
+    }
+  }
+
+  uint32_t state = 0xDEADBEEFu;
+  for (; idx < kCount; ++idx) {
+    uint64_t a = (uint64_t(xorshift(state)) << 32) | xorshift(state);
+    uint64_t b = (uint64_t(xorshift(state)) << 32) | xorshift(state);
+    a_values[idx] = a;
+    b_values[idx] = b;
+    reference_umul128(a, b, hi_want[idx], lo_want[idx]);
+  }
+
+  cutlass::device_memory::allocation<uint64_t> a_dev(kCount);
+  cutlass::device_memory::allocation<uint64_t> b_dev(kCount);
+  cutlass::device_memory::allocation<uint64_t> hi_dev(kCount);
+  cutlass::device_memory::allocation<uint64_t> lo_dev(kCount);
+
+  a_dev.copy_from_host(a_values.data());
+  b_dev.copy_from_host(b_values.data());
+
+  uint128_umul_operator<<< dim3((kCount + 127) / 128), dim3(128) >>>(
+    kCount, a_dev.get(), b_dev.get(), hi_dev.get(), lo_dev.get());
+
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "Kernel launch error.";
+
+  std::vector<uint64_t> hi_got(kCount), lo_got(kCount);
+  hi_dev.copy_to_host(hi_got.data());
+  lo_dev.copy_to_host(lo_got.data());
+
+  for (int i = 0; i < kCount; ++i) {
+    EXPECT_EQ(lo_got[i], lo_want[i]) << "iter=" << i;
+    EXPECT_EQ(hi_got[i], hi_want[i]) << "iter=" << i;
   }
 }


### PR DESCRIPTION
### Summary

Fixes #3492

The portable fallback of `umul128()` in `include/cutlass/uint128.h` computed an incorrect high product. In the schoolbook decomposition the code added the low 32 bits of both cross products (`p_lh & mask`, `p_hl & mask`) into `r_hi` where the high 32 bits (`>> 32`) belong, double-counting bits that were already consumed at bit position 32 via the mid sum, and it dropped the carry out of the mid sum entirely.

Before / after:

```cpp
// before
uint64_t p_mid = (p_ll >> 32) + (p_lh & mask) + (p_hl & mask);
uint64_t r_lo  = (p_ll & mask) + (p_mid << 32);
uint64_t r_hi  = (p_lh & mask) + (p_hl & mask) + p_hh;

// after
uint64_t mid  = (p_ll >> 32) + (p_lh & mask) + (p_hl & mask);
uint64_t r_lo = (p_ll & mask) | (mid << 32);
uint64_t r_hi = p_hh + (p_lh >> 32) + (p_hl >> 32) + (mid >> 32);
```

Minimal repro before the fix: `umul128(0xFFFFFFFFull, 0x100000000ull, &hi)` leaves `hi = 0xFFFFFFFF` although the exact product `0x00000000FFFFFFFF00000000` has a zero high word.

### Test plan

New tests in `test/unit/core/uint128.cu` (`host_umul128_high_product`, `device_umul128_high_product`) compare `umul128` against an independent 16-bit-limb schoolbook reference over edge combinations (0, 1, 2, 0xFFFFFFFF, 0x100000000, 2^64-1, 2^63, 0x123456789ABCDEF0 crossed with each other) plus deterministic xorshift random pairs, host and device.

Full run on the fixed code, nvidia/cuda:12.8.1-devel container, nvcc V12.8.93, `-DCUTLASS_NVCC_ARCHS=120a`, RTX 5060 Ti (sm_120a):

```
Note: Google Test filter = uint128_t.*
[==========] Running 4 tests from 1 test suite.
[----------] 4 tests from uint128_t
[ RUN      ] uint128_t.host_arithmetic
[       OK ] uint128_t.host_arithmetic (4 ms)
[ RUN      ] uint128_t.host_umul128_high_product
[       OK ] uint128_t.host_umul128_high_product (0 ms)
[ RUN      ] uint128_t.device_arithmetic
[       OK ] uint128_t.device_arithmetic (233 ms)
[ RUN      ] uint128_t.device_umul128_high_product
[       OK ] uint128_t.device_umul128_high_product (1 ms)
[----------] 4 tests from uint128_t (239 ms total)
[==========] 4 tests from 1 test suite ran. (239 ms total)
[  PASSED  ] 4 tests.
```

Fail-first evidence, header fix reverted with these tests present:

- Replaying the exact host test input streams against the old formula: the random stream mismatches on 4096/4096 iterations and the edge grid on 36/64 pairs (smallest failing case: a=1, b=2^32, where hi must be 0 but the old code returns 1).
- A standalone randomized differential against `unsigned __int128` over 2,000,000 uniformly random 64-bit pairs: old implementation wrong high word on all 2,000,000 pairs, fixed implementation on none.

### Notes

- The pre-existing tests in this file only multiply values below 1024 and check the result truncated to 64 bits, which is why the defect was never caught.
- No in-tree caller exercises `umul128` today (`FastDivmodU64` uses `operator/` only), so the fix changes no existing behavior.
- Scope note: this portable path is what every nvcc device compile uses on all host OSes (`CUTLASS_INT128_ARITHMETIC` is host-MSVC-x64 only), plus gcc/clang hosts on x86-64/aarch64 where the native `__int128` path covers `uint128_t::operator*` but not `umul128` itself.
