### PR TITLE
Fix grouped tile scheduler tile count when swizzle is enabled

### DIFF
--- a/include/cutlass/gemm/kernel/sm100_tile_scheduler_group.hpp
+++ b/include/cutlass/gemm/kernel/sm100_tile_scheduler_group.hpp
@@ -94,7 +94,7 @@ public:
     dim3 problem_blocks = get_tiled_cta_shape_mnl(
       problem_shapes,
       hw_info,
-      cta_shape, selected_cluster_shape);
+      cta_shape, selected_cluster_shape, args.max_swizzle_size);
 
     Params params;
     params.initialize(
@@ -142,8 +142,8 @@ public:
   template<class BlockShape, class ClusterShape>
   CUTLASS_HOST_DEVICE static
   dim3
-  get_tiled_cta_shape_mnl(GroupProblemShape const &problem_shapes, KernelHardwareInfo hw_info, BlockShape cta_shape, ClusterShape cluster_shape) {
-    return UnderlyingScheduler::get_tiled_cta_shape_mnl(problem_shapes, hw_info, cta_shape, cluster_shape);
+  get_tiled_cta_shape_mnl(GroupProblemShape const &problem_shapes, KernelHardwareInfo hw_info, BlockShape cta_shape, ClusterShape cluster_shape, int max_swizzle_size) {
+    return UnderlyingScheduler::get_tiled_cta_shape_mnl(problem_shapes, hw_info, cta_shape, cluster_shape, max_swizzle_size);
   }
 
   // Given the inputs, computes the physical grid we should launch.
@@ -161,7 +161,7 @@ public:
       problem_shapes,
       hw_info,
       cta_shape,
-      cluster_shape);
+      cluster_shape, params.params_sm90_.max_swizzle_size_);
 
     // Given device SM count, set grid size s.t. we do not launch more thread blocks than we can run concurrently
     Arguments args{};

--- a/include/cutlass/gemm/kernel/sm90_tile_scheduler_group.hpp
+++ b/include/cutlass/gemm/kernel/sm90_tile_scheduler_group.hpp
@@ -163,7 +163,7 @@ public:
     dim3 problem_blocks = get_tiled_cta_shape_mnl(
       problem_shapes,
       hw_info,
-      tile_shape, cluster_shape);
+      tile_shape, cluster_shape, arguments.max_swizzle_size);
 
     Params params;
     params.initialize(
@@ -195,7 +195,7 @@ public:
     dim3 problem_blocks = get_tiled_cta_shape_mnl(
       problem_shapes,
       hw_info,
-      tile_shape, cluster_shape);
+      tile_shape, cluster_shape, arguments.max_swizzle_size);
 
     return Params::get_grid_shape(
       problem_blocks,
@@ -212,7 +212,7 @@ public:
   template<class BlockShape, class ClusterShape>
   CUTLASS_HOST_DEVICE static
   dim3
-  get_tiled_cta_shape_mnl(GroupProblemShape const& problem_shapes, KernelHardwareInfo hw_info, BlockShape cta_shape, ClusterShape cluster_shape) {
+  get_tiled_cta_shape_mnl(GroupProblemShape const& problem_shapes, KernelHardwareInfo hw_info, BlockShape cta_shape, ClusterShape cluster_shape, int max_swizzle_size) {
     int groups = problem_shapes.groups();
     uint32_t total_ctas = 0;
     uint32_t cta_in_N_dim = 1; // We linearize the blocks across all the problems here
@@ -228,8 +228,11 @@ public:
         auto ctas_along_n = cute::size(cute::ceil_div(cute::shape<1>(problem_shapes.get_host_problem_shape(group)), cute::shape<1>(cta_shape)));
         if(ctas_along_m <= 0) ctas_along_m = 1;
         if(ctas_along_n <= 0) ctas_along_n = 1;
-        auto problem_blocks_m = round_up(ctas_along_m, cute::get<0>(cluster_shape));
-        auto problem_blocks_n = round_up(ctas_along_n, cute::get<1>(cluster_shape));
+        // Match the device-side per-group tile counts, which round each
+        // dimension up to (1 << log_swizzle_size) * cluster extent.
+        int32_t log_swizzle_size = get_log_swizzle_size(static_cast<int>(ctas_along_m), static_cast<int>(ctas_along_n), max_swizzle_size);
+        auto problem_blocks_m = round_up(ctas_along_m, (1 << log_swizzle_size) * cute::get<0>(cluster_shape));
+        auto problem_blocks_n = round_up(ctas_along_n, (1 << log_swizzle_size) * cute::get<1>(cluster_shape));
         total_ctas += problem_blocks_m * problem_blocks_n;
       }
     }
@@ -246,7 +249,7 @@ public:
   }
 
   // Calculate the log of the swizzle size based on the problem CTAs and the max swizzle size
-  CUTLASS_DEVICE
+  CUTLASS_HOST_DEVICE
   static int32_t
   get_log_swizzle_size(int problem_ctas_m, int problem_ctas_n, int max_swizzle_size) {
     int min_cta_dim = platform::min(problem_ctas_m, problem_ctas_n);

--- a/test/unit/gemm/CMakeLists.txt
+++ b/test/unit/gemm/CMakeLists.txt
@@ -29,6 +29,7 @@
 add_subdirectory(thread)
 add_subdirectory(warp)
 add_subdirectory(threadblock)
+add_subdirectory(kernel)
 add_subdirectory(device)
 
 add_custom_target(
@@ -37,6 +38,7 @@ add_custom_target(
   cutlass_test_unit_gemm_thread
   cutlass_test_unit_gemm_warp
   cutlass_test_unit_gemm_threadblock
+  cutlass_test_unit_gemm_kernel
   cutlass_test_unit_gemm_device
   )
 
@@ -46,6 +48,7 @@ add_custom_target(
   test_unit_gemm_thread
   test_unit_gemm_warp
   test_unit_gemm_threadblock
+  test_unit_gemm_kernel
   test_unit_gemm_device
   )
 

--- a/test/unit/gemm/kernel/CMakeLists.txt
+++ b/test/unit/gemm/kernel/CMakeLists.txt
@@ -1,0 +1,4 @@
+cutlass_test_unit_add_executable(
+  cutlass_test_unit_gemm_kernel
+  sm90_group_tile_scheduler.cu
+  )

--- a/test/unit/gemm/kernel/sm90_group_tile_scheduler.cu
+++ b/test/unit/gemm/kernel/sm90_group_tile_scheduler.cu
@@ -1,0 +1,137 @@
+/***************************************************************************************************
+* Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+* SPDX-License-Identifier: BSD-3-Clause
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+* contributors may be used to endorse or promote products derived from
+* this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+**************************************************************************************************/
+
+/*! \file
+    \brief Host-side checks that the SM90 grouped scheduler's tile count matches
+    the device-side per-group computation, including swizzle rounding.
+*/
+
+#include "../common/cutlass_unit_test.h"
+
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/gemm/kernel/sm90_tile_scheduler_group.hpp"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "cutlass/kernel_hardware_info.hpp"
+
+#include <cute/tensor.hpp>
+
+using namespace cute;
+
+namespace {
+
+using ProblemShape = Shape<int, int, int>;
+using GroupShapes = cutlass::gemm::GroupProblemShape<ProblemShape>;
+using Scheduler = cutlass::gemm::kernel::detail::PersistentTileSchedulerSm90Group<GroupShapes, 2>;
+
+uint64_t expected_group_tiles(int m, int n, int cta_m, int cta_n, int cluster_m, int cluster_n, int max_swizzle) {
+  int cm = (m + cta_m - 1) / cta_m; if (cm <= 0) { cm = 1; }
+  int cn = (n + cta_n - 1) / cta_n; if (cn <= 0) { cn = 1; }
+
+  int log_swizzle = Scheduler::get_log_swizzle_size(cm, cn, max_swizzle);
+  int mult = 1 << log_swizzle;
+
+  uint64_t blocks_m = ((cm + mult * cluster_m - 1) / (mult * cluster_m)) * uint64_t(mult * cluster_m);
+  uint64_t blocks_n = ((cn + mult * cluster_n - 1) / (mult * cluster_n)) * uint64_t(mult * cluster_n);
+  return blocks_m * blocks_n;
+}
+
+} // namespace
+
+// Regression test for #3497: the host-side tile count must apply the same
+// per-group swizzle rounding as the device mapping, otherwise groups after a
+// swizzled one shift past blocks_across_problem_ and their tail tiles are
+// never scheduled.
+TEST(Sm90GroupTileScheduler, host_tile_count_matches_device_formula) {
+  ProblemShape shapes[] = {{128, 128, 32}, {192, 192, 32}};   // 2x2 and 3x3 CTAs of 64
+  GroupShapes ps;
+  ps.num_groups = 2;
+  ps.host_problem_shapes = shapes;
+
+  cutlass::KernelHardwareInfo hw;
+  hw.sm_count = 148;
+
+  auto cta_shape = Shape<_64, _64, _8>{};
+  auto cluster = Shape<_1, _1, _1>{};
+
+  for (int swz : {1, 2, 4, 8}) {
+    dim3 got = Scheduler::get_tiled_cta_shape_mnl(ps, hw, cta_shape, cluster, swz);
+
+    uint64_t want = expected_group_tiles(128, 128, 64, 64, 1, 1, swz)
+                  + expected_group_tiles(192, 192, 64, 64, 1, 1, swz);
+
+    EXPECT_EQ(uint64_t(got.x) * got.y * got.z, want) << "swz=" << swz;
+  }
+}
+
+TEST(Sm90GroupTileScheduler, host_tile_count_matches_device_formula_sweep) {
+  struct Case {
+    int groups[4][2];
+    int num_groups;
+    int cluster_m, cluster_n;
+  };
+
+  Case cases[] = {
+    {{{37, 41}, {5, 130}, {64, 3}, {17, 17}}, 4, 1, 1},
+    {{{128, 64}, {96, 256}},                 2, 2, 1},
+    {{{70, 70}, {33, 200}, {8, 8}},          3, 1, 2},
+    {{{256, 256}, {1, 1}, {129, 65}, {7, 9}}, 4, 2, 2},
+  };
+
+  cutlass::KernelHardwareInfo hw;
+  hw.sm_count = 132;
+
+  for (auto const &c : cases) {
+    ProblemShape shapes[4];
+    for (int g = 0; g < c.num_groups; ++g) {
+      shapes[g] = {c.groups[g][0], c.groups[g][1], 32};
+    }
+    GroupShapes ps;
+    ps.num_groups = c.num_groups;
+    ps.host_problem_shapes = shapes;
+
+    auto cta_shape = Shape<_64, _64, _8>{};
+    auto cluster = make_shape(c.cluster_m, c.cluster_n, _1{});
+
+    for (int swz : {1, 2, 4, 8}) {
+      dim3 got = Scheduler::get_tiled_cta_shape_mnl(ps, hw, cta_shape, cluster, swz);
+
+      uint64_t want = 0;
+      for (int g = 0; g < c.num_groups; ++g) {
+        want += expected_group_tiles(c.groups[g][0], c.groups[g][1], 64, 64,
+                                     c.cluster_m, c.cluster_n, swz);
+      }
+
+      EXPECT_EQ(uint64_t(got.x) * got.y * got.z, want)
+          << "groups=" << c.num_groups << " cluster=(" << c.cluster_m << "," << c.cluster_n << ")"
+          << " swz=" << swz;
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Fixes #3497

The SM90 grouped tile scheduler computed its host-side grid size and early-exit bound by rounding each group's CTA extents to the cluster shape only, while the device-side mapping rounds each group to `(1 << log_swizzle_size) * cluster extent`. With `max_swizzle_size >= 2` and host problem shapes available, any non-final group with swizzle padding shifts every later group's device-side linear range upward past the host bound, and the tail cut in `get_current_work_for_linear_idx` drops real output tiles: those CTAs are never scheduled and the corresponding output region is silently left untouched.

`get_tiled_cta_shape_mnl` now replicates the device per-group computation including the swizzle factor. `get_log_swizzle_size` moves above it and becomes `CUTLASS_HOST_DEVICE` so both sides share one implementation (body unchanged). The SM100 group scheduler forwards through the same function; its `get_grid_shape` now passes the real `max_swizzle_size_` from the params instead of losing it.

With the default `max_swizzle_size = 1`, `log_swizzle_size == 0` makes both formulas identical, so stock behavior is unchanged.

### Test plan

Standalone host programs that mirror both computations exactly:

1. The issue's failing case (groups 2x2 and 3x3 CTAs, cluster 1x1, max_swizzle_size = 4). Before the fix the host total is 13 while the device maps 20 linear slots and two real output tiles of group 1 are cut by the early-exit bound:

```
host_total=13 dev_total=20
DROPPED REAL TILE idx=13 group=1 -> (m=2,n=1) of 3x3
DROPPED REAL TILE idx=14 group=1 -> (m=2,n=2) of 3x3
FAIL: 2 real tiles never scheduled
```

With the fixed host formula:

```
host_total=20 dev_total=20
OK
```

2. Randomized invariant sweep: 7 (cluster, swizzle) combinations x 300 random group lists each (1-6 groups, extents 1-40). The new host bound equals the sum of device per-group totals in every case and never cuts a real tile; the old bound dropped real tiles in these trials a total of 140338 times.

```
bound-mismatch or new-bound-drop failures=0 (expect 0)
old bound dropped real tiles across random cluster-1x1 trials: 140338
```


3. New unit test `test/unit/gemm/kernel/sm90_group_tile_scheduler.cu` (registered as `cutlass_test_unit_gemm_kernel`): asserts the host tile count equals the per-group device formula for the issue's 2x2+3x3 case and a sweep of four group lists across cluster shapes (1,1)/(2,1)/(1,2)/(2,2) with max_swizzle_size 1..8. Run in an nvidia/cuda:12.8.1-devel container, nvcc V12.8.93, sm_120a:

```
[==========] Running 2 tests from 1 test suite.
[ RUN      ] Sm90GroupTileScheduler.host_tile_count_matches_device_formula
[       OK ] Sm90GroupTileScheduler.host_tile_count_matches_device_formula (0 ms)
[ RUN      ] Sm90GroupTileScheduler.host_tile_count_matches_device_formula_sweep
[       OK ] Sm90GroupTileScheduler.host_tile_count_matches_device_formula_sweep (0 ms)
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
```

4. Compile check of a TU including both scheduler headers under nvcc V12.8.93 with `-arch=sm_90a` and `-arch=sm_100a`: clean.

Not covered: an end-to-end grouped GEMM run with `max_swizzle_size >= 2`. SM90 kernels cannot run on the sm_120 GPU available here, and the Blackwell CuTeDSL grouped example does not expose the tile-scheduler swizzle argument. The fix is confined to host-side index arithmetic that is mirrored exactly by the harness above.

### Notes

- When host problem shapes are unavailable the scheduler keeps the `sm_count` grid path, unchanged.
- The pre-existing inconsistency where `PersistentTileSchedulerSm100Group::get_grid_shape` builds a default `Arguments` (swizzle 1) for `Params::get_grid_shape` is left untouched to keep this change scoped; it can be revisited separately.
- Possible follow-up: grouped GEMM unit tests currently never exercise `max_swizzle_size > 1` (`MaxSwizzleSize` is unused in the ptr-array testbed while the non-group testbed sweeps {1, 4}); plumbing it through would have caught this. Happy to do that in a separate change if maintainers want it.
