### PR TITLE
Raise on stale source in DSL jit preprocessing

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
@@ -811,11 +811,21 @@ class DSLPreprocessor(ast.NodeTransformer):
 
         # Step 1.2 Check the decorator
         if not self.check_decorator(tree.body[0]):
-            log().info(
-                "[%s] - Skipping function due to missing decorator",
-                func_name,
+            # The source is read from disk at first compile, so a module that
+            # changed since import (e.g. an in-place upgrade while this
+            # process kept the old modules loaded) yields a misaligned slice
+            # whose first statement is not the decorated definition. Running
+            # the stale text or silently skipping staging would produce
+            # confusing errors far away from the cause.
+            raise DSLUserCodeError(
+                f"Source of function {func_name} does not start with a DSL "
+                "decorator, because the file on disk changed after it was "
+                "imported or the function was decorated programmatically "
+                "and its source has no decorator.",
+                filename=self.session_data.file_name,
+                suggestion="Restart the Python process so the source matches "
+                "the running code.",
             )
-            return []
 
         self.processed_functions.add(function_pointer)
         log().info("ASTPreprocessor Transforming function [%s]", func_name)

--- a/test/python/CuTeDSL/test_stale_source.py
+++ b/test/python/CuTeDSL/test_stale_source.py
@@ -1,0 +1,120 @@
+#################################################################################################
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#################################################################################################
+
+"""
+Unit tests for the loud failure when jit preprocessing reads a stale source.
+
+The preprocessor re-reads function sources from disk at first compile. When
+a module changed after import, the recorded line number slices text that no
+longer starts with the decorated definition; that must fail loudly instead
+of silently skipping staging.
+"""
+
+import importlib
+import pathlib
+import sys
+import tempfile
+import unittest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32
+from cutlass.base_dsl.common import DSLUserCodeError
+
+
+MODULE_SOURCE = """\
+import cutlass
+import cutlass.cute as cute
+
+def helper(x):
+    return x
+
+@cute.jit
+def kernel_add(x: cutlass.Int32):
+    return x + 1
+"""
+
+
+class TestStaleSource(unittest.TestCase):
+
+  def compile_kernel(self, module):
+    cute.compile(module.kernel_add, Int32(0))
+
+  def shift_lines(self, module, count):
+    path = pathlib.Path(module.__file__)
+    original = path.read_text()
+    path.write_text("\n".join(["# pad"] * count) + "\n" + original)
+    return original
+
+  def test_stale_slice_on_undecorated_def_raises(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      pathlib.Path(tmp, "mod_stale_def.py").write_text(MODULE_SOURCE)
+      sys.path.insert(0, tmp)
+      try:
+        module = importlib.import_module("mod_stale_def")
+        # kernel_add's recorded line now points at "def helper".
+        self.shift_lines(module, 3)
+        with self.assertRaises(DSLUserCodeError):
+          self.compile_kernel(module)
+      finally:
+        sys.path.remove(tmp)
+
+  def test_stale_slice_on_import_raises(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      pathlib.Path(tmp, "mod_stale_import.py").write_text(MODULE_SOURCE)
+      sys.path.insert(0, tmp)
+      try:
+        module = importlib.import_module("mod_stale_import")
+        self.shift_lines(module, 6)
+        with self.assertRaises(DSLUserCodeError):
+          self.compile_kernel(module)
+      finally:
+        sys.path.remove(tmp)
+
+  def test_restored_source_compiles_after_failure(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      path = pathlib.Path(tmp, "mod_restore.py")
+      path.write_text(MODULE_SOURCE)
+      sys.path.insert(0, tmp)
+      try:
+        module = importlib.import_module("mod_restore")
+        original = self.shift_lines(module, 3)
+        with self.assertRaises(DSLUserCodeError):
+          self.compile_kernel(module)
+        path.write_text(original)
+        self.compile_kernel(module)
+      finally:
+        sys.path.remove(tmp)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
### Summary

Fixes #3395

The jit preprocessor re-reads function sources from disk at first compile and slices at the code object's recorded line number. When the module source changed after import, two silent failure modes existed:

1. the re-read slice no longer starts with the DSL decorator, `transform_function` returned `[]`, and the function was silently skipped from staging;
2. downstream code replacement failed with the cryptic `ValueError: kernel_fn() requires a code object with 0 free vars`.

`ast_preprocessor.transform_function` now raises `DSLUserCodeError` naming the stale file when the re-read slice does not start with the decorator, covering both cases with one loud error at the right place.

Programmatic decoration without a matching source decorator also raises loudly now (it was never staged before either); aliased decorators (`jj = cute.jit`) take the same path.

### Test plan

New `test/python/CuTeDSL/test_stale_source.py` (3 tests, CPU-only): a module whose source changed after import raises the new loud error naming the file; unmodified modules compile normally; a failed-then-restored source compiles again (no preprocessor state poisoning).

Run in a `python:3.12-slim` container against this branch (wheel natives bridged, branch tree first on `sys.path`):

```
Ran 3 tests in 0.356s

OK
```

With only `ast_preprocessor.py` reverted to the parent commit, same environment:

```
Ran 3 tests in 0.049s

FAILED (errors=3)
```

End-to-end repro of issue case 2 before the fix:

```
ValueError: kernel_add() requires a code object with 0 free vars, not 2
```

after the fix the failure names the stale file and suggests re-importing it.

