### PR TITLE
Fix dilated Conv2d/Conv3d output size calculation

### DIFF
--- a/include/cutlass/conv/conv2d_problem_size.h
+++ b/include/cutlass/conv/conv2d_problem_size.h
@@ -172,8 +172,8 @@ public:
     dilation_h(dilation.row()), dilation_w(dilation.column()),
     mode(mode), split_k_slices(split_k_slices), groups(groups) {
       // set output P and Q
-      P = ((H + pad_h + padding[1] - R * dilation_h) / stride_h) + 1;
-      Q = ((W + pad_w + padding[3] - S * dilation_w) / stride_w) + 1;
+      P = ((H + pad_h + padding[1] - ((R - 1) * dilation_h + 1)) / stride_h) + 1;
+      Q = ((W + pad_w + padding[3] - ((S - 1) * dilation_w + 1)) / stride_w) + 1;
     }
 
   /// Constructs convolution problem size from cutlass Tensor4DCoord and MatrixCoord 

--- a/include/cutlass/conv/conv3d_problem_size.h
+++ b/include/cutlass/conv/conv3d_problem_size.h
@@ -193,7 +193,7 @@ public:
     pad_d(padding[0]), stride_d(stride[0]), dilation_d(dilation[0])
     {
       // set output Z
-      Z = ((D + pad_d * 2 - T * dilation_d) / stride_d) + 1;
+      Z = ((D + pad_d * 2 - ((T - 1) * dilation_d + 1)) / stride_d) + 1;
     }
 
   /// Constructs convolution problem size from cutlass Tensor5DCoord, Coord3D
@@ -221,7 +221,8 @@ public:
     pad_d(CUTLASS_STL_NAMESPACE::get<0>(padding)[0]), stride_d(stride[0]), dilation_d(dilation[0])
     {
       // set output Z
-      Z = ((D + pad_d + CUTLASS_STL_NAMESPACE::get<1>(padding)[0] - T * dilation_d) / stride_d) + 1;
+      Z = ((D + pad_d + CUTLASS_STL_NAMESPACE::get<1>(padding)[0] -
+            ((T - 1) * dilation_d + 1)) / stride_d) + 1;
     }
 
   /// Equality operator (ignores mode and split_k_slice)

--- a/test/unit/conv/CMakeLists.txt
+++ b/test/unit/conv/CMakeLists.txt
@@ -29,6 +29,15 @@
 add_custom_target(cutlass_test_unit_conv)
 add_custom_target(test_unit_conv)
 
+cutlass_test_unit_add_executable(
+  cutlass_test_unit_conv_problem_size
+  WITHOUT_CUDA
+  problem_size.cpp
+  )
+
+add_dependencies(cutlass_test_unit_conv cutlass_test_unit_conv_problem_size)
+add_dependencies(test_unit_conv cutlass_test_unit_conv_problem_size)
+
 set(CUTLASS_CONV_TEST_UNIT_REFERENCE_DEVICE_ENABLED ON CACHE BOOL
   "Enable/Disable convolution device reference for conv unit tests.")
 

--- a/test/unit/conv/problem_size.cpp
+++ b/test/unit/conv/problem_size.cpp
@@ -1,0 +1,104 @@
+/***************************************************************************************************
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#include "cutlass/conv/conv2d_problem_size.h"
+#include "cutlass/conv/conv3d_problem_size.h"
+
+#include "gtest/gtest.h"
+
+TEST(Conv2dProblemSize, ComputesDilatedOutputSize) {
+  cutlass::conv::Conv2dProblemSize problem(
+      cutlass::Tensor4DCoord{1, 8, 9, 4},
+      cutlass::Tensor4DCoord{16, 3, 2, 4},
+      cutlass::Tensor4DCoord{0, 0, 0, 0},
+      cutlass::MatrixCoord{1, 1},
+      cutlass::MatrixCoord{2, 3});
+
+  EXPECT_EQ(problem.P, 4);
+  EXPECT_EQ(problem.Q, 6);
+}
+
+TEST(Conv2dProblemSize, AccountsForAsymmetricPaddingAndStride) {
+  cutlass::conv::Conv2dProblemSize problem(
+      cutlass::Tensor4DCoord{1, 18, 21, 4},
+      cutlass::Tensor4DCoord{16, 3, 4, 4},
+      cutlass::Tensor4DCoord{1, 2, 3, 1},
+      cutlass::MatrixCoord{2, 3},
+      cutlass::MatrixCoord{2, 2});
+
+  EXPECT_EQ(problem.P, 9);
+  EXPECT_EQ(problem.Q, 7);
+}
+
+TEST(Conv2dProblemSize, UnitFilterIsUnaffectedByDilation) {
+  cutlass::conv::Conv2dProblemSize problem(
+      cutlass::Tensor4DCoord{1, 7, 11, 4},
+      cutlass::Tensor4DCoord{16, 1, 1, 4},
+      cutlass::Tensor4DCoord{0, 0, 0, 0},
+      cutlass::MatrixCoord{2, 3},
+      cutlass::MatrixCoord{5, 7});
+
+  EXPECT_EQ(problem.P, 4);
+  EXPECT_EQ(problem.Q, 4);
+}
+
+TEST(Conv3dProblemSize, ComputesDilatedOutputSizeWithSymmetricPadding) {
+  cutlass::conv::Conv3dProblemSize problem(
+      cutlass::Tensor5DCoord{1, 11, 8, 9, 4},
+      cutlass::Tensor5DCoord{16, 3, 3, 2, 4},
+      cutlass::Coord<3>({1, 0, 0}),
+      cutlass::Coord<3>({2, 1, 1}),
+      cutlass::Coord<3>({2, 2, 3}));
+
+  EXPECT_EQ(problem.Z, 5);
+  EXPECT_EQ(problem.P, 4);
+  EXPECT_EQ(problem.Q, 6);
+}
+
+TEST(Conv3dProblemSize, ComputesDilatedOutputSizeWithAsymmetricPadding) {
+  cutlass::conv::Conv3dProblemSize problem(
+      cutlass::Tensor5DCoord{1, 19, 18, 21, 4},
+      cutlass::Tensor5DCoord{16, 4, 3, 4, 4},
+      CUTLASS_STL_NAMESPACE::make_tuple(
+          cutlass::Coord<3>({2, 1, 3}),
+          cutlass::Coord<3>({1, 2, 1})),
+      cutlass::Coord<3>({3, 2, 3}),
+      cutlass::Coord<3>({2, 2, 2}));
+
+  EXPECT_EQ(problem.Z, 6);
+  EXPECT_EQ(problem.P, 9);
+  EXPECT_EQ(problem.Q, 7);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- compute Conv2d P/Q from the effective dilated filter extent, `(filter - 1) * dilation + 1`
- apply the same correction to Conv3d Z for both symmetric and asymmetric padding constructors
- add regression tests for dilated 2D/3D problems, asymmetric padding and stride, and 1x1 filters

## Background

The existing formula subtracts `filter * dilation`. It agrees with the standard convolution output-size formula only when dilation is 1. For dilation greater than 1 it undersizes the output, and a 1x1 filter is incorrectly made smaller by increasing dilation.

## Contribution roles

I led the contribution direction and acceptance criteria, reviewed and approved
the final design, and reviewed every changed line. I understand the change and
own the final design decision and the submission. AI assistance was used for
repository research, root-cause analysis, implementation preparation, and
automated validation execution.

## Testing

- reproduced the bug on the unmodified main branch: 2D output `3x4` instead of `4x6`, and 3D output `4x3x4` instead of `5x4x6`
- manually compiled and ran `test/unit/conv/problem_size.cpp` with MSVC 19.44, CUDA 12.9 headers, CCCL headers, and GoogleTest v1.14.0
- all 5 regression tests passed

Fixes #3502


