### PR TITLE
fix(CuTeDSL): preserve wrapped signatures for type checkers

### DIFF
--- a/python/CuTeDSL/_mlir_helpers/op.py
+++ b/python/CuTeDSL/_mlir_helpers/op.py
@@ -19,7 +19,7 @@ import os
 import types
 import warnings
 from functools import wraps, lru_cache
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, TypeVar, TYPE_CHECKING
 
 from .._mlir import ir
 from ..base_dsl.common import (
@@ -281,7 +281,10 @@ def _get_location_from_frame_info(frameInfo: inspect.Traceback) -> ir.Location:
     )
 
 
-def dsl_user_op(opFunc: Callable[..., Any]) -> Callable[..., Any]:
+_FuncT = TypeVar("_FuncT", bound=Callable[..., Any])
+
+
+def dsl_user_op(opFunc: _FuncT) -> _FuncT:
     """Decorator for user-facing DSL op wrappers.
 
     Responsibilities:
@@ -435,7 +438,7 @@ def dsl_user_op(opFunc: Callable[..., Any]) -> Callable[..., Any]:
 
         return res_or_list
 
-    return wrapper
+    return wrapper  # type: ignore[return-value]
 
 
 def _get_call_arg_names(frameInfo: Any) -> dict[str | int, str]:


### PR DESCRIPTION
## Summary

`@dsl_user_op` decorates every user-facing CuTe DSL wrapper (`local_tile`, `make_tiled_mma`, `copy`, `gemm`, etc.), but its annotation was `Callable[..., Any] -> Callable[..., Any]`, which erases the wrapped callable's signature for static analyzers.

Pyright/basedpyright (and language servers built on them) therefore see only `(*args, **kwargs)`. In practice this means:

- Editors show **no parameter names** in signature help: `cute.local_tile(` yields no `tiler`/`coord` hints;
- Bogus keyword calls compile silently (e.g. `cute.local_tile(mA, xxxxx=...)` passes type checking);
- Downstream projects that write their own `@dsl_user_op` wrappers (vLLM, SGLang, FlashInfer) are affected the same way.

## Change

Make the decorator signature-preserving with a `TypeVar` bound to `Callable`, the pattern recommended by [pyright's documentation](https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md):

```python
_FuncT = TypeVar("_FuncT", bound=Callable[..., Any])

def dsl_user_op(opFunc: _FuncT) -> _FuncT:
    ...
    return wrapper  # type: ignore[return-value]
```

Runtime behavior is unchanged (`functools.wraps` was already applied to the wrapper). `# type: ignore[return-value]` documents that the inner `wrapper` intentionally has a generic signature but must satisfy `_FuncT`.

## Verification

- `python -m py_compile op.py` — syntax OK.
- pyright, after patch: `cute.local_tile(mA, tiler=(128, 64), coord=(0, 0))` type-checks; `cute.local_tile(mA, xxxxx=(128, 64))` is rejected with `No parameter named "xxxxx"`, and `Arguments missing for parameters "tiler", "coord"` is reported for incomplete calls.

Fixes editor/signature-help blindness for the entire public CuTe DSL surface.
