### PR TITLE
docs: fix minor typos in documentation

### DIFF
--- a/media/docs/cpp/code_organization.md
+++ b/media/docs/cpp/code_organization.md
@@ -22,7 +22,7 @@ Like NVIDIA CUB, the components of CUTLASS are organized hierarchically based on
 elements. For example, warp-level GEMM components perform a matrix multiply collectively by the
 set of threads within a warp. The following figure illustrates each layer.
 
-Components are designed to be usable by client applications accessing functionailty at each scope.
+Components are designed to be usable by client applications accessing functionality at each scope.
 
 CUTLASS Templates are implemented by header files in the following directory structure:
 
@@ -187,7 +187,7 @@ examples/
 
   05_batched_gemm/           # example demonstrating CUTLASS's batched strided GEMM operation
 
-  06_splitK_gemm/            # exmaple demonstrating CUTLASS's Split-K parallel reduction kernel
+  06_splitK_gemm/            # example demonstrating CUTLASS's Split-K parallel reduction kernel
 
   07_volta_tensorop_gemm/    # example demonstrating mixed precision GEMM using Volta Tensor Cores
 

--- a/media/docs/cpp/cute/02_layout_algebra.md
+++ b/media/docs/cpp/cute/02_layout_algebra.md
@@ -418,7 +418,7 @@ Consider tiling the 1-D layout `A = (4,2,3):(2,1,8)` with the tiler `B = 4:2`. I
 
 This is computed in the three steps described in the implementation above.
 * Complement of `B = 4:2` under `size(A) = 24` is `B* = (2,3):(1,8)`.
-* Concantenation of `(B,B*) = (4,(2,3)):(2,(1,8))`.
+* Concatenation of `(B,B*) = (4,(2,3)):(2,(1,8))`.
 * Composition of `A = (4,2,3):(2,1,8)` with `(B,B*)` is then `((2,2),(2,3)):((4,1),(2,8))`.
 
 ![divide1.png](../../../images/cute/divide1.png)
@@ -538,7 +538,7 @@ We can use the by-mode `tiler` strategies previously developed to write multidim
 
 ![product2d.png](../../../images/cute/product2d.png)
 
-The above image demonstates the use of a `tiler` to apply `logical_product` by-mode. Despite this **not being the recommended approach**, the result is a rank-2 layout consisting of 2x5 row-major block that is tiled across a 3x4 column-major arrangement.
+The above image demonstrates the use of a `tiler` to apply `logical_product` by-mode. Despite this **not being the recommended approach**, the result is a rank-2 layout consisting of 2x5 row-major block that is tiled across a 3x4 column-major arrangement.
 
 The reason **this is not the recommended approach** is that the `tiler B` in the above expression is highly unintuitive. In fact, it requires perfect knowledge of the shape and strides of `A` in order to construct. We would like to express "Tile Layout `A` according to Layout `B`" in a way that makes `A` and `B` independent and is much more intuitive.
 

--- a/media/docs/cpp/cute/03_tensor.md
+++ b/media/docs/cpp/cute/03_tensor.md
@@ -225,7 +225,7 @@ logical_divide(Tensor, Tiler)
   tiled_divide(Tensor, Tiler)
    flat_divide(Tensor, Tiler)
 ```
-The above operations allows arbitrary subtensors to be "factored out" of `Tensor`s. This very commonly used in tiling for threadgroups, tiling for MMAs, and reodering tiles of data for threads.
+The above operations allows arbitrary subtensors to be "factored out" of `Tensor`s. This very commonly used in tiling for threadgroups, tiling for MMAs, and reordering tiles of data for threads.
 
 Note that the `_product` operations are not implemented for `Tensor`s as those would
 often produce layouts with increased codomain sizes, which means the `Tensor` would
@@ -245,7 +245,7 @@ retain that mode of the tensor as if no coordinate had been used.
 
 Slicing a tensor performs two operations,
 * the `Layout` is evaluated on the partial coordinate and the resulting offset is accumulated into the iterator -- the new iterator points to the start of the new tensor.
-* the `Layout` modes cooresponding to `_`-elements of the coordinate are used to construct a new layout.
+* the `Layout` modes corresponding to `_`-elements of the coordinate are used to construct a new layout.
 Together, the new iterator and the new layout construct the new tensor.
 
 ```cpp

--- a/media/docs/cpp/fundamental_types.md
+++ b/media/docs/cpp/fundamental_types.md
@@ -93,7 +93,7 @@ Array<T, kN> elements;
 
 CUTLASS_PRAGMA_UNROLL                        // required to ensure array remains in registers
 for (auto x : elements) {
-  printf("%d, %f", int64_t(x), double(x));   // explictly convert to int64_t or double
+  printf("%d, %f", int64_t(x), double(x));   // explicitly convert to int64_t or double
 }
 ```
 

--- a/media/docs/cpp/gemm_api.md
+++ b/media/docs/cpp/gemm_api.md
@@ -206,7 +206,7 @@ The warp-level GEMM API is a generalization of CUDA's WMMA API to achieve the fo
 
 - native matrix multiply sizes of Tensor Cores
 - permuted shared memory layouts to ensure conflict-free accesses
-- pointer initilization outside of the mainloop
+- pointer initialization outside of the mainloop
 - efficient traversal
 
 Defining a warp-level matrix multiply in CUTLASS is similar to WMMA as shown below.
@@ -523,7 +523,7 @@ For column-major source (C) matrix, Transpose(C) is row-major, and efficient epi
 row-major.
 
 Note that cuBLAS typically expects a column-major source (C) and output matrix (D). Thus,
-CUTLASS library only instantiates and generates GEMM operatos with column-major layout. However, 
+CUTLASS library only instantiates and generates GEMM operators with column-major layout. However, 
 CUTLASS by itself can run both row-major and column-major output layouts for all combinations 
 of input layouts. Thus, CUTLASS supports the following layout combinations for input and output layouts: 
 

--- a/media/docs/cpp/implicit_gemm_convolution.md
+++ b/media/docs/cpp/implicit_gemm_convolution.md
@@ -160,7 +160,7 @@ To get the best performance, the following parameters are recommended.
 - Channel count (C) is a multiple of 32 elements
 - Filter count (K) is a multiple of 32 elements
 
-This enables 128-bit vector memory acceses which lead to efficient CUDA kernels. Smaller alignment is supported even on tensor cores by setting AlignmentA and AlignmentB in `conv::kernel::DefaultConv2dFprop`, but the performance is lower than 128-bit aligned tensors.
+This enables 128-bit vector memory accesses which lead to efficient CUDA kernels. Smaller alignment is supported even on tensor cores by setting AlignmentA and AlignmentB in `conv::kernel::DefaultConv2dFprop`, but the performance is lower than 128-bit aligned tensors.
 
 # CUTLASS Device-level Convolution Operator
 

--- a/media/docs/cpp/profiler.md
+++ b/media/docs/cpp/profiler.md
@@ -55,7 +55,7 @@ The CUTLASS profiler employs a four-digit integer level (global instantiation le
 0. **Instruction Shape**
 1. **MMA Shape Multiplier**
 2. **Cluster Shape**
-3. **Schedule Pruning**
+3. **Schedule Prunning**
 
 Cluster shape levels define the number of CTAs (Cooperative Thread Arrays) included in the kernel generation:
 
@@ -81,17 +81,17 @@ Instruction shape levels control the selection of WGMMA shapes used in kernel ge
 
 The detailed definition of the three instantiation levels controlling cluster shape, MMA shape multiplier, and instruction shape can be found in [sm90_shapes.py](https://github.com/NVIDIA/cutlass/tree/main/python/cutlass_library/sm90_shapes.py).
 
-Schedule pruning levels decide the epilogue schedule and mainloop schedule to stamp out a kernel instance. As defined in `get_valid_schedules` in [sm90_utils.py](https://github.com/NVIDIA/cutlass/tree/main/python/cutlass_library/sm90_utils.py),
+Schedule prunning levels decide the epilogue schedule and mainloop schedule to stamp out a kernel instance. As defined in `get_valid_schedules` in [sm90_utils.py](https://github.com/NVIDIA/cutlass/tree/main/python/cutlass_library/sm90_utils.py),
 
-- **Level >= 1**: Indicates that no pruning is being applied.
-- **Level 0**: Indicates pruning according to existing [generator.py](https://github.com/NVIDIA/cutlass/tree/main/python/cutlass_library/generator.py) behavior.
+- **Level >= 1**: Indicates that no prunning is being applied.
+- **Level 0**: Indicates prunning according to existing [generator.py](https://github.com/NVIDIA/cutlass/tree/main/python/cutlass_library/generator.py) behavior.
 
 An instantiation level `500`, which is padded to `0500`, thus indicates:
 
 - **Instruction Shapes**: At level 0, generating only the "default" shape.
 - **MMA Multipliers**: At level 0, generating only one multiplier, `(2, 1, 4)`.
 - **Cluster Sizes**: At level 5, allowing for clusters with 1, 2, 4, 8, or 16 CTAs.
-- **Schedule Pruning**: At level 0, where pruning is applied according to the existing `generator.py` behavior.
+- **Schedule Prunning**: At level 0, where prunning is applied according to the existing `generator.py` behavior.
 
 ## Instantiating more MMA shapes with Hopper
 
@@ -143,7 +143,7 @@ The CUTLASS profiler uses the same four-digit integer level (global instantiatio
 0. **Instruction Shape**
 1. **MMA Shape Multiplier**
 2. **Cluster Shape**
-3. **Data Type and Schedule Pruning**
+3. **Data Type and Schedule Prunning**
 
 Note for Blackwell kernels an MMA shape multiplier is no longer necessary since Blackwell kernels do not have a different
 ping pong or cooperative schedule. The profiler ignores this digit when instantiating.
@@ -248,7 +248,7 @@ Profiling:
                                                    are launched up to the profiling duration. If non-zero, this
                                                    overrides `profiling-duration` and `min-iterations`.
 
-  --profiling-duration=<duration>                  Time to spend profiling each kernel (ms). Overriden by
+  --profiling-duration=<duration>                  Time to spend profiling each kernel (ms). Overridden by
                                                    `profiling-iterations` when `profiling-iterations` != 0.
                                                    Note that `min-iterations` must also be satisfied.
 
@@ -424,7 +424,7 @@ In addition to encoded data types, CUTLASS profiler allows non-encoded generic d
 Cluster shapes can be statically set to `Shape<int,int,_1>;` and specified via runtime arguments: `cluster_m`, `cluster_n` and `cluster_k` in CUTLASS profiler.  In addition to preferred cluster shapes, a user can also specify fallback cluster shapes via runtime arguments: `cluster_m_fallback`, `cluster_n_fallback` and `cluster_k_fallback` in CUTLASS profiler. Those fallback cluster shapes are smaller shapes than the preferred ones for the hardware to assign when there is no chance to issue a larger preferred cluster to the GPU. There are several rules for using a dynamic cluster: 1) Preferred cluster size should be divisible by fallback cluster size. 2) Grid dim should be divisible by preferred cluster size. 3) Preferred cluster and fallback cluster must have the same depth (cluster_dim.z must be equal). One may refer to our CUTLASS Example [73_blackwell_gemm_dynamic_cluster](https://github.com/NVIDIA/cutlass/tree/main/examples/73_blackwell_gemm_preferred_cluster/blackwell_gemm_preferred_cluster.cu) for more details of the this feature. 
 Please be noted that this feature (dynamic cluster shapes within a single grid) is only applicable to `sm100a` kernels. The hardware will rasterize into a single cluster shape for those kernels that do not support this feature even with preferred or fallback cluster shapes assigned.
 
-CUTLASS 3.x kernels for Hopper and Blackwell also support a new feature called programatic dependent launch (PDL). This can be enabled with `--use-pdl`, and can overlap the epilogue of the prior kernel with the prologue of the next kernel. This can effectively hide kernel prologues. Using PDL can improve performance for back to back GEMMs. See [dependent kernel launch](dependent_kernel_launch.md) for more information. CUDA graphs can also be used (`--use-cuda-graphs`) with PDL to ensure that smaller kernels are enqueued back-to-back on a stream.
+CUTLASS 3.x kernels for Hopper and Blackwell also support a new feature called programmatic dependent launch (PDL). This can be enabled with `--use-pdl`, and can overlap the epilogue of the prior kernel with the prologue of the next kernel. This can effectively hide kernel prologues. Using PDL can improve performance for back to back GEMMs. See [dependent kernel launch](dependent_kernel_launch.md) for more information. CUDA graphs can also be used (`--use-cuda-graphs`) with PDL to ensure that smaller kernels are enqueued back-to-back on a stream.
 
 ## Exhaustive search mode and top-k output ranking according to performance in GFLOPS/s
 
@@ -746,7 +746,7 @@ reference_device: Passed
 
 ## Example Tensor Core Convolution Operation
 
-Example command line for profiling forward propagation convolution kernels runing on Tensor Cores is as follows:
+Example command line for profiling forward propagation convolution kernels running on Tensor Cores is as follows:
 ```bash
 $ ./tools/profiler/cutlass_profiler --kernels=tensorop*fprop  --verification-providers=device --n=8 --h=224 --w=224 --c=128 --k=128 --r=3 --s=3
 

--- a/media/docs/cpp/programming_guidelines.md
+++ b/media/docs/cpp/programming_guidelines.md
@@ -1108,7 +1108,7 @@ Some compilers may emit spurious unused warnings for some variable declarations,
 Avoid direct access to CUDA built-in variables `threadIdx`, `blockIdx`, `blockDim`, and `gridDim` within
 CUTLASS components except in special circumstances.
 
-Using built-in global variables directly within resuable components necessitates that all components
+Using built-in global variables directly within reusable components necessitates that all components
 use them consistently which may not be possible if CUTLASS components are used in other contexts.
 
 Instead, components should accept a linear ID identifying threads, warps, and threadblocks from calling

--- a/media/docs/cpp/quickstart.md
+++ b/media/docs/cpp/quickstart.md
@@ -606,7 +606,7 @@ It is advised to only compile CUTLASS kernels for NVIDIA architectures one plans
 can be selectively included in the CUTLASS Library by specifying filter strings and wildcard characters when executing CMake.
 
 Several examples are defined below for convenience. They may be combined as a comma-delimited list.
-Compling only the kernels desired reduces compilation time.
+Compiling only the kernels desired reduces compilation time.
 
 
 ## GEMM CMake Examples

--- a/media/docs/cpp/tile_iterator_concept.md
+++ b/media/docs/cpp/tile_iterator_concept.md
@@ -251,7 +251,7 @@ struct WriteableRandomAccessContiguousTileIteratorConcept :
   void store(
     Fragment const &frag,                       ///< fragment to store to the location pointed to by the tensor
     TensorCoord const &tile_offset,             ///< stores a tile with a logical offset in units of whole tiles
-    Index pointer_offset);                      ///< stores a tile witha logical offset AND a pointer offset
+    Index pointer_offset);                      ///< stores a tile with a logical offset AND a pointer offset
 };
 ```
 
@@ -268,7 +268,7 @@ clearing or enabling all guarded memory accesses.
 /// supports. These remain implementation-dependent details of iterators implementing this concept.
 struct MaskedTileIteratorConcept {
 
-  using Mask;                                        ///< mask object used to guard against acceses.
+  using Mask;                                        ///< mask object used to guard against accesses.
 
   CUTLASS_DEVICE void clear_mask();                  ///< efficiently disables all accesses guarded by mask
   CUTLASS_DEVICE void enable_mask();                 ///< efficiently enables all accesses guarded by mask


### PR DESCRIPTION
Fixes various minor typos in the C++ and CuTe documentation (e.g., functionailty -> functionality, initilization -> initialization, acceses -> accesses, etc).