### PR TITLE
Fix packed uint1b logical array reductions

### DIFF
--- a/include/cutlass/reduction/thread/reduction_operators.h
+++ b/include/cutlass/reduction/thread/reduction_operators.h
@@ -160,19 +160,23 @@ struct ReduceArrayOperation<logical_and<uint1b_t>, uint1b_t, N> {
 
   CUTLASS_HOST_DEVICE
   uint1b_t operator()(
-    logical_and<uint1b_t> const &reduction_op, 
+    logical_and<uint1b_t> const &,
     ArrayType const &array) const {
 
-    uint8_t const *ptr = reinterpret_cast<uint8_t const *>(&array);
-    bool item = false;
+    uint8_t const *ptr = reinterpret_cast<uint8_t const *>(array.raw_data());
+    bool item = true;
 
     CUTLASS_PRAGMA_UNROLL
-    for (int byte = 0; byte < (N + 7) / 8; ++byte) {
-      uint8_t bits = ptr[byte];
-      item = (item || !bits);
+    for (int byte = 0; byte < N / 8; ++byte) {
+      item = item && (ptr[byte] == uint8_t(0xff));
     }
 
-    return uint1b_t{!item};
+    if (N % 8) {
+      uint8_t mask = uint8_t((1u << (N % 8)) - 1);
+      item = item && ((ptr[N / 8] & mask) == mask);
+    }
+
+    return uint1b_t{item};
   }
 };
 
@@ -183,16 +187,20 @@ struct ReduceArrayOperation<logical_or<uint1b_t>, uint1b_t, N> {
 
   CUTLASS_HOST_DEVICE
   uint1b_t operator()(
-    logical_and<uint1b_t> const &reduction_op, 
+    logical_or<uint1b_t> const &,
     ArrayType const &array) const {
 
-    uint8_t const *ptr = reinterpret_cast<uint8_t const *>(&array);
-    bool item = true;
+    uint8_t const *ptr = reinterpret_cast<uint8_t const *>(array.raw_data());
+    bool item = false;
 
     CUTLASS_PRAGMA_UNROLL
-    for (int byte = 0; byte < (N + 7) / 8; ++byte) {
-      uint8_t bits = ptr[byte];
-      item = (item || bits);
+    for (int byte = 0; byte < N / 8; ++byte) {
+      item = item || ptr[byte];
+    }
+
+    if (N % 8) {
+      uint8_t mask = uint8_t((1u << (N % 8)) - 1);
+      item = item || (ptr[N / 8] & mask);
     }
 
     return uint1b_t{item};

--- a/test/unit/reduction/thread/CMakeLists.txt
+++ b/test/unit/reduction/thread/CMakeLists.txt
@@ -29,5 +29,6 @@
 cutlass_test_unit_add_executable(
   cutlass_test_unit_reduction_thread
   reduction_thread.cu
+  reduction_operators.cu
   testbed.h
   )

--- a/test/unit/reduction/thread/reduction_operators.cu
+++ b/test/unit/reduction/thread/reduction_operators.cu
@@ -1,0 +1,112 @@
+/***************************************************************************************************
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#include "../../common/cutlass_unit_test.h"
+
+#include "cutlass/reduction/thread/reduction_operators.h"
+
+namespace {
+
+template <int N>
+using BitArray = cutlass::Array<cutlass::uint1b_t, N>;
+
+template <int N>
+unsigned reduce_and(BitArray<N> const &bits) {
+  return static_cast<unsigned>(cutlass::reduction::thread::detail::ReduceArray(
+      cutlass::logical_and<cutlass::uint1b_t>{}, bits));
+}
+
+template <int N>
+unsigned reduce_or(BitArray<N> const &bits) {
+  return static_cast<unsigned>(cutlass::reduction::thread::detail::ReduceArray(
+      cutlass::logical_or<cutlass::uint1b_t>{}, bits));
+}
+
+template <int N>
+void expect_logical_and_reduction() {
+  BitArray<N> bits;
+  bits.clear();
+
+  EXPECT_EQ(reduce_and(bits), 0u) << "N = " << N;
+
+  for (int i = 0; i < N; ++i) {
+    bits[i] = cutlass::uint1b_t{1u};
+  }
+  EXPECT_EQ(reduce_and(bits), 1u) << "N = " << N;
+
+  for (int zero = 0; zero < N; ++zero) {
+    bits[zero] = cutlass::uint1b_t{0u};
+    EXPECT_EQ(reduce_and(bits), 0u) << "N = " << N << ", zero = " << zero;
+    bits[zero] = cutlass::uint1b_t{1u};
+  }
+}
+
+template <int N>
+void expect_logical_or_reduction() {
+  BitArray<N> bits;
+  bits.clear();
+
+  if constexpr (N % 8) {
+    uint8_t valid_mask = uint8_t((1u << (N % 8)) - 1);
+    uint8_t *bytes = reinterpret_cast<uint8_t *>(bits.raw_data());
+    bytes[N / 8] = uint8_t(~valid_mask);
+  }
+  EXPECT_EQ(reduce_or(bits), 0u) << "N = " << N;
+
+  bits.clear();
+  for (int one = 0; one < N; ++one) {
+    bits[one] = cutlass::uint1b_t{1u};
+    EXPECT_EQ(reduce_or(bits), 1u) << "N = " << N << ", one = " << one;
+    bits[one] = cutlass::uint1b_t{0u};
+  }
+}
+
+} // namespace
+
+TEST(ReduceArrayUint1b, LogicalAndChecksEveryValidBit) {
+  expect_logical_and_reduction<1>();
+  expect_logical_and_reduction<7>();
+  expect_logical_and_reduction<8>();
+  expect_logical_and_reduction<9>();
+  expect_logical_and_reduction<15>();
+  expect_logical_and_reduction<16>();
+  expect_logical_and_reduction<32>();
+}
+
+TEST(ReduceArrayUint1b, LogicalOrChecksOnlyValidBits) {
+  expect_logical_or_reduction<1>();
+  expect_logical_or_reduction<7>();
+  expect_logical_or_reduction<8>();
+  expect_logical_or_reduction<9>();
+  expect_logical_or_reduction<15>();
+  expect_logical_or_reduction<16>();
+  expect_logical_or_reduction<32>();
+}


### PR DESCRIPTION
## Summary

- fix the `uint1b_t` logical OR reduction specialization to accept `logical_or`
- use the correct identities and packed-byte checks for logical AND and OR
- mask padding bits in partial trailing bytes
- add regression coverage across logical bit and storage boundaries

## Background

The logical OR specialization currently cannot be called through `ReduceArray` because its operator takes `logical_and`. Even when called directly through the specialization, its `true` identity makes an all-zero array reduce to true.

The logical AND specialization checks whether each storage byte is nonzero rather than whether every valid bit is set. For example, `0x7f` incorrectly reduces to true. Partial trailing bytes also need a mask so padding bits do not participate in either reduction.

This change keeps the packed-byte path: full bytes are reduced directly, while only the valid low bits of a partial trailing byte are considered.

## Contribution roles

I led the contribution direction and acceptance criteria, reviewed and approved
the final design, and reviewed every changed line. I understand the change and
own the final design decision and the submission. AI assistance was used for
repository research, root-cause analysis, implementation preparation, and
automated validation execution.

## Testing

- reproduced the public logical OR helper compilation failure on the unmodified main branch
- reproduced incorrect runtime results on main: AND of `[1,1,1,1,1,1,1,0]` returned 1, and OR of an all-zero array returned 1
- manually compiled and ran the new regression source with MSVC 19.44, CUDA 12.9 headers, CCCL headers, and GoogleTest v1.14.0
- 2/2 tests passed, exhaustively checking each logical position for `N = 1, 7, 8, 9, 15, 16, 32`, including padding-bit isolation
- `git diff --check`

Fixes #3510


