### PR TITLE
Fix profiler defects (Resolves #3544)

### DIFF
--- a/tools/profiler/src/device_allocation.cu
+++ b/tools/profiler/src/device_allocation.cu
@@ -256,7 +256,7 @@ size_t DeviceAllocation::construct_layout(
       return construct_layout_<cutlass::layout::RowMajorInterleaved<64>>(bytes, layout_id, extent, stride);
 
     case library::LayoutTypeID::kTensorNCHW:
-      return construct_layout_<cutlass::layout::TensorNHWC>(bytes, layout_id, extent, stride);
+      return construct_layout_<cutlass::layout::TensorNCHW>(bytes, layout_id, extent, stride);
 
     case library::LayoutTypeID::kTensorNHWC:
       return construct_layout_<cutlass::layout::TensorNHWC>(bytes, layout_id, extent, stride);
@@ -1633,6 +1633,7 @@ void DeviceAllocation::initialize_random_sparsemeta_device(int seed, int MetaSiz
   // this reason.
 
   switch (type_) {
+  case library::NumericTypeID::kS16:
   case library::NumericTypeID::kU16:
     cutlass::reference::device::BlockFillRandomSparseMeta<uint16_t>(
       reinterpret_cast<uint16_t *>(pointer_),
@@ -1641,6 +1642,7 @@ void DeviceAllocation::initialize_random_sparsemeta_device(int seed, int MetaSiz
       MetaSizeInBits
     );
     break;
+  case library::NumericTypeID::kS32:
   case library::NumericTypeID::kU32:
     cutlass::reference::device::BlockFillRandomSparseMeta<uint32_t>(
       reinterpret_cast<uint32_t *>(pointer_),
@@ -1670,6 +1672,7 @@ void DeviceAllocation::initialize_random_sparsemeta_host(int seed, int MetaSizeI
 
   switch (type_) {
   case library::NumericTypeID::kS16:
+  case library::NumericTypeID::kU16:
     cutlass::reference::host::BlockFillRandomSparseMeta<uint16_t>(
       reinterpret_cast<uint16_t *>(host_data.data()),
       capacity_,
@@ -1678,6 +1681,7 @@ void DeviceAllocation::initialize_random_sparsemeta_host(int seed, int MetaSizeI
     );
     break;
   case library::NumericTypeID::kS32:
+  case library::NumericTypeID::kU32:
     cutlass::reference::host::BlockFillRandomSparseMeta<uint32_t>(
       reinterpret_cast<uint32_t *>(host_data.data()),
       capacity_,

--- a/tools/profiler/src/options.cu
+++ b/tools/profiler/src/options.cu
@@ -80,7 +80,7 @@ Options::Device::Device(cutlass::CommandLine const &cmdline) {
         if (!res.second) {
           throw std::runtime_error("Duplicate device specified: " +
                                    std::to_string(device));
-        } else if (device > num_devices) {
+        } else if (device >= num_devices) {
           throw std::runtime_error("Bad device ID: " +
                                    std::to_string(device));
         } else {


### PR DESCRIPTION
Fixes #3544.
Knocked out those three minor profiler bugs mentioned in the issue:
1. **Device ID validation:** Fixed the off-by-one bug in `options.cu` so it properly errors out on `device >= num_devices` instead of letting it slip through and crashing later.
2. **NCHW layout typo:** In `device_allocation.cu`, `kTensorNCHW` was accidentally returning `TensorNHWC` due to a copy-paste error. Swapped it out to use the correct `TensorNCHW` layout.
3. **Sparse-meta type mismatches:** Tweaked the host and device `BlockFillRandomSparseMeta` initialization functions so they both handle signed (`kS16`, `kS32`) and unsigned (`kU16`, `kU32`) type IDs. This stops the host initialization from silently falling through to all-zeros when the types don't line up.