### PR TITLE
Fix validation gaps (Resolves #3542)

### DIFF
--- a/include/cutlass/gemm/device/gemm_splitk_parallel.h
+++ b/include/cutlass/gemm/device/gemm_splitk_parallel.h
@@ -250,6 +250,9 @@ public:
 
   /// Determines whether the GEMM can execute the given problem.
   static Status can_implement(Arguments const &args) {
+    if (args.split_k_slices == 0) {
+      return Status::kErrorInvalidProblem;
+    }
     return Status::kSuccess;
   }
 

--- a/include/cutlass/gemm/kernel/gemm_grouped.h
+++ b/include/cutlass/gemm/kernel/gemm_grouped.h
@@ -289,6 +289,9 @@ public:
   }
 
   static Status can_implement(Arguments const &args) {
+    if (ProblemVisitor::kRequiresPrecomputation && args.host_problem_sizes == nullptr) {
+      return Status::kErrorInvalidProblem;
+    }
     return Status::kSuccess;
   }
  

--- a/include/cutlass/gemm/kernel/gemm_universal_with_visitor.h
+++ b/include/cutlass/gemm/kernel/gemm_universal_with_visitor.h
@@ -144,11 +144,7 @@ public:
       ptr_gather_A_indices(const_cast<int *>(args.ptr_gather_A_indices)),
       ptr_gather_B_indices(const_cast<int *>(args.ptr_gather_B_indices))
     {
-      // Raise error on unsupported modes
-      assert(args.mode != GemmUniversalMode::kGemmSplitKParallel && "Sm80 EVT does not support SplitKParallel.");
-      assert(!(args.mode == GemmUniversalMode::kGemm && this->grid_tiled_shape.k() > 1 )
-        && "Sm80 EVT does not support SplitKSerial.");
-      assert(args.mode != GemmUniversalMode::kArray && "Sm80 EVT does not support Array Gemm.");
+      // Modes are validated by can_implement()
     }
 
     /// Lightweight update given a subset of arguments.
@@ -177,6 +173,29 @@ public:
   //
   // Device-only API
   //
+  /// Determines whether the GEMM can execute the given problem.
+  static Status can_implement(Arguments const &args) {
+    if (args.mode == GemmUniversalMode::kGemmSplitKParallel) {
+      return Status::kErrorNotSupported;
+    }
+
+    ThreadblockSwizzle threadblock_swizzle;
+    cutlass::gemm::GemmCoord grid_tiled_shape = threadblock_swizzle.get_tiled_shape(
+        args.problem_size, 
+        {ThreadblockShape::kM, ThreadblockShape::kN, ThreadblockShape::kK},
+        args.batch_count);
+
+    if (args.mode == GemmUniversalMode::kGemm && grid_tiled_shape.k() > 1) {
+      return Status::kErrorNotSupported;
+    }
+
+    if (args.mode == GemmUniversalMode::kArray) {
+      return Status::kErrorNotSupported;
+    }
+
+    return Base::can_implement(args);
+  }
+
 
   // Factory invocation
   CUTLASS_DEVICE

--- a/include/cutlass/gemm/threadblock/threadblock_swizzle.h
+++ b/include/cutlass/gemm/threadblock/threadblock_swizzle.h
@@ -251,7 +251,7 @@ struct GemmBatchedIdentityThreadblockSwizzle {
     return GemmCoord(
       (problem_size.m() + tile_size.m() - 1) / tile_size.m(),
       (problem_size.n() + tile_size.n() - 1) / tile_size.n(),
-      batch_count % (1 << 16));
+      (batch_count > 65535 ? 65535 : batch_count));
   }
 
   /// Computes CUDA grid dimensions given a size in units of logical tiles


### PR DESCRIPTION
Fixes #3542.

This PR addresses the four validation gaps outlined in the issue:

1. **Grouped GEMM Validation (`gemm_grouped.h`)**:
   Added a check in `can_implement` to return `kErrorInvalidProblem` if `host_problem_sizes` is null and `kRequiresPrecomputation` is true. This prevents host segfaults during `precompute`.

2. **Split-K Parallel Zero Division (`gemm_splitk_parallel.h`)**:
   Added a check in `can_implement` to properly return `kErrorInvalidProblem` if `split_k_slices == 0`, preventing a divide-by-zero fault.

3. **Batch Grid Dimension Wrapping (`threadblock_swizzle.h`)**:
   Clamped the batched grid `z` dimension to `65535` instead of wrapping it via modulo. This stops multiples of 65536 from producing a 0-dimension launch.

4. **Sm80 EVT assert-only validation (`gemm_universal_with_visitor.h`)**:
   Replaced the debug-only `assert()` statements with a proper `can_implement` validation pass that safely returns `kErrorNotSupported` for Split-K Parallel, Split-K Serial, and Array GEMM modes, preventing silent garbage execution in release builds.
