### PR TITLE
Update Blackwell CuTeDSL helpers for Rubin compatibility

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell/kernel/blockscaled_grouped_gemm/grouped_blockscaled_gemm.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/blockscaled_grouped_gemm/grouped_blockscaled_gemm.py
@@ -36,6 +36,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
+from cutlass import testing
 from cutlass.cute.nvgpu import cpasync, tcgen05
 import cutlass.torch as cutlass_torch
 import cutlass.utils as utils
@@ -44,6 +45,7 @@ from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.runtime import from_dlpack
+
 
 """
 This example provides an experimental implementation of the SM100 grouped blockscaled GEMM kernel, please note that the APIs and implementation details related to this kernel may change in future releases.
@@ -62,8 +64,8 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/grouped_blockscaled_gemm.py                                     \
-      --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16                       \
+    python examples/cute/blackwell/kernel/blockscaled_grouped_gemm/grouped_blockscaled_gemm.py                                     \
+      --a_dtype Float4E2M1FN --b_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16                       \
       --c_dtype Float16                                                                       \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,1                                           \
       --problem_sizes_mnkl "(8192,1280,32,1),(32,384,1536,1),(640,1280,32,1),(640,160,32,1)"  \
@@ -77,8 +79,8 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/grouped_blockscaled_gemm.py                                 \
-      --ab_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16                       \
+    ncu python examples/cute/blackwell/kernel/blockscaled_grouped_gemm/grouped_blockscaled_gemm.py                                 \
+      --a_dtype Float4E2M1FN --b_dtype Float4E2M1FN --sf_dtype Float8E8M0FNU --sf_vec_size 16                       \
       --c_dtype Float16                                                                       \
       --mma_tiler_mn 128,128 --cluster_shape_mn 1,1                                           \
       --problem_sizes_mnkl "(8192,1280,32,1),(32,384,1536,1),(640,1280,32,1),(640,160,32,1)"  \
@@ -140,6 +142,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         sf_vec_size: int,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
+        use_cached_problem_shapes: bool = True,
     ):
         """Initializes the configuration for a Blackwell grouped blockscaled GEMM kernel.
 
@@ -151,11 +154,14 @@ class Sm100GroupedBlockScaledGemmKernel:
         :type mma_tiler_mn: tuple[int, int]
         :param cluster_shape_mn: tuple (ClusterM, ClusterN) shape of the cluster.
         :type cluster_shape_mn: tuple[int, int]
+        :param use_cached_problem_shapes: Enable double-buffered caching of problem shapes, defaults to True.
+        :type use_cached_problem_shapes: bool, optional
         """
         self.acc_dtype = cutlass.Float32
         self.sf_vec_size = sf_vec_size
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn
+        self.use_cached_problem_shapes = use_cached_problem_shapes
         # K dimension is deferred in _setup_attributes
         self.mma_tiler = (*mma_tiler_mn, 1)
 
@@ -163,7 +169,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
         )
 
-        self.tensormap_update_mode = utils.TensorMapUpdateMode.SMEM
+        self.tensormap_update_mode = cutlass.tensor_utils.TensorMapUpdateMode.SMEM
 
         self.occupancy = 1
         # Set specialized warp ids
@@ -175,8 +181,15 @@ class Sm100GroupedBlockScaledGemmKernel:
         )
         self.mma_warp_id = 4
         self.tma_warp_id = 5
+        self.scheduler_warp_id = 6
+
         self.threads_per_cta = 32 * len(
-            (self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id)
+            (
+                self.scheduler_warp_id,
+                self.mma_warp_id,
+                self.tma_warp_id,
+                *self.epilog_warp_id,
+            )
         )
         # Set barrier for epilogue sync and tmem ptr sync
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -192,7 +205,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             barrier_id=3,
             num_threads=64,
         )
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
 
     # Set up configurations that dependent on gemm inputs.
@@ -224,6 +237,7 @@ class Sm100GroupedBlockScaledGemmKernel:
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -234,6 +248,7 @@ class Sm100GroupedBlockScaledGemmKernel:
 
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -291,11 +306,16 @@ class Sm100GroupedBlockScaledGemmKernel:
         )
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
-        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_c_stage,
+            self.num_sched_stage,
+        ) = self._compute_stages(
             tiled_mma,
             self.mma_tiler,
-            self.a_dtype,
-            self.b_dtype,
+            self.smem_alloc_a_dtype,
+            self.smem_alloc_b_dtype,
             self.epi_tile,
             self.c_dtype,
             self.c_layout,
@@ -309,13 +329,13 @@ class Sm100GroupedBlockScaledGemmKernel:
         self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
             tiled_mma,
             self.mma_tiler,
-            self.a_dtype,
+            self.smem_alloc_a_dtype,
             self.num_ab_stage,
         )
         self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
             tiled_mma,
             self.mma_tiler,
-            self.b_dtype,
+            self.smem_alloc_b_dtype,
             self.num_ab_stage,
         )
         self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
@@ -343,7 +363,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             num_c_stage=self.num_c_stage,
         )
 
-        # Use utils.TensorMapUpdateMode.SMEM by default
+        # Use cutlass.tensor_utils.TensorMapUpdateMode.SMEM by default
         tensormap_smem_bytes = (
             Sm100GroupedBlockScaledGemmKernel.bytes_per_tensormap
             * Sm100GroupedBlockScaledGemmKernel.num_tensormaps
@@ -422,12 +442,34 @@ class Sm100GroupedBlockScaledGemmKernel:
         self.b_dtype = initial_b.element_type
         self.sf_dtype = initial_sfa.element_type
         self.c_dtype = initial_c.element_type
+        self.mxf8f6f4 = self.needs_unpack_tma(self.a_dtype, self.b_dtype)
+        self.smem_alloc_a_dtype = (
+            cutlass.Int8 if (self.mxf8f6f4 and self.a_dtype.width < 8) else self.a_dtype
+        )
+        self.smem_alloc_b_dtype = (
+            cutlass.Int8 if (self.mxf8f6f4 and self.b_dtype.width < 8) else self.b_dtype
+        )
         self.is_nvfp4_output = self.c_dtype is cutlass.Float4E2M1FN
-        self.a_major_mode = utils.LayoutEnum.from_tensor(initial_a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(initial_b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(initial_c)
-        if cutlass.const_expr(self.a_dtype != self.b_dtype):
-            raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            initial_a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            initial_b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(initial_c)
+
+        _SUPPORTED_AB_DTYPES = (
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        )
+        if cutlass.const_expr(
+            self.a_dtype not in _SUPPORTED_AB_DTYPES
+            or self.b_dtype not in _SUPPORTED_AB_DTYPES
+        ):
+            raise TypeError(
+                f"Unsupported A or B dtype: {self.a_dtype}, {self.b_dtype}, expected one of {_SUPPORTED_AB_DTYPES}"
+            )
 
         # Setup attributes that dependent on gemm inputs
         self._setup_attributes()
@@ -447,6 +489,7 @@ class Sm100GroupedBlockScaledGemmKernel:
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -457,6 +500,7 @@ class Sm100GroupedBlockScaledGemmKernel:
 
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -478,6 +522,9 @@ class Sm100GroupedBlockScaledGemmKernel:
             self.mma_tiler,
             tiled_mma,
             self.cluster_layout_vmnk.shape,
+            internal_type=self.smem_alloc_a_dtype
+            if (self.mxf8f6f4 and self.a_dtype.width < 8)
+            else None,
         )
 
         # Setup TMA load for B
@@ -492,6 +539,9 @@ class Sm100GroupedBlockScaledGemmKernel:
             self.mma_tiler,
             tiled_mma,
             self.cluster_layout_vmnk.shape,
+            internal_type=self.smem_alloc_b_dtype
+            if (self.mxf8f6f4 and self.b_dtype.width < 8)
+            else None,
         )
 
         # Setup TMA load for SFA
@@ -563,8 +613,13 @@ class Sm100GroupedBlockScaledGemmKernel:
             tensormap_buffer: cute.struct.MemRange[
                 cutlass.Int64, self.size_tensormap_in_i64
             ]
+            tile_info: cute.struct.MemRange[
+                cutlass.Int32, 9 * self.num_sched_stage
+            ]  # 9 member variables in GroupSearchResult
             ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
             ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            tile_info_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            tile_info_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
             acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
             tmem_dealloc_mbar: cutlass.Int64
@@ -580,14 +635,16 @@ class Sm100GroupedBlockScaledGemmKernel:
             # (MMA, MMA_M, MMA_K, STAGE)
             sA: cute.struct.Align[
                 cute.struct.MemRange[
-                    self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)
+                    self.smem_alloc_a_dtype,
+                    cute.cosize(self.a_smem_layout_staged.outer),
                 ],
                 self.buffer_align_bytes,
             ]
             # (MMA, MMA_N, MMA_K, STAGE)
             sB: cute.struct.Align[
                 cute.struct.MemRange[
-                    self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)
+                    self.smem_alloc_b_dtype,
+                    cute.cosize(self.b_smem_layout_staged.outer),
                 ],
                 self.buffer_align_bytes,
             ]
@@ -697,6 +754,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         #
         # Coords inside cluster
         bidx, bidy, bidz = cute.arch.block_idx()
+        bid = cute.arch.block_idx()
         mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
         is_leader_cta = mma_tile_coord_v == 0
         cta_rank_in_cluster = cute.arch.make_warp_uniform(
@@ -714,7 +772,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         #
         # Alloc and init: tensormap buffer, a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tensormap_smem_ptr = storage.tensormap_buffer.data_ptr()
@@ -737,14 +795,11 @@ class Sm100GroupedBlockScaledGemmKernel:
         )
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar.ptr
-        tmem_holding_buf_ptr = storage.tmem_holding_buf.ptr
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
 
         # Initialize mainloop ab_pipeline (barrier) and states
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
-        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, num_tma_producer
-        )
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Warp)
         ab_pipeline = pipeline.PipelineTmaUmma.create(
             barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
             num_stages=self.num_ab_stage,
@@ -752,6 +807,22 @@ class Sm100GroupedBlockScaledGemmKernel:
             consumer_group=ab_pipeline_consumer_group,
             tx_count=self.num_tma_load_bytes,
             cta_layout_vmnk=cluster_layout_vmnk,
+            enable_multicast_signaling=True,
+        )
+
+        # init barrier for scheduler
+        num_tile_info_pipeline_consumer_threads = (
+            self.threads_per_cta - 32  # scheduler pipeline threads
+        )
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.tile_info_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_sched_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 32 * 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                num_tile_info_pipeline_consumer_threads,
+            ),
+            defer_sync=True,
         )
 
         # Initialize acc_pipeline (barrier) and states
@@ -800,6 +871,12 @@ class Sm100GroupedBlockScaledGemmKernel:
         sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
         # (MMA, MMA_N, MMA_K, STAGE)
         sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        # Tile information
+        sTile_info = storage.tile_info.get_tensor(
+            cute.make_layout(
+                (9, self.num_sched_stage), stride=(1, 9)
+            )  # 9 member variables of group search result
+        )
 
         #
         # Compute multicast mask for A/B/SFA/SFB buffer full
@@ -949,8 +1026,8 @@ class Sm100GroupedBlockScaledGemmKernel:
             bidz * grid_dim[1] * grid_dim[0] + bidy * grid_dim[0] + bidx
         )
 
-        tensormap_manager = utils.TensorMapManager(
-            utils.TensorMapUpdateMode.SMEM,
+        tensormap_manager = cutlass.tensor_utils.TensorMapManager(
+            cutlass.tensor_utils.TensorMapUpdateMode.SMEM,
             Sm100GroupedBlockScaledGemmKernel.bytes_per_tensormap,
         )
         tensormap_a_gmem_ptr = tensormap_manager.get_tensormap_ptr(
@@ -970,29 +1047,31 @@ class Sm100GroupedBlockScaledGemmKernel:
         )
 
         #
-        # Persistent tile scheduling loop
-        #
-        # When the problem shapes are on device, we launch one CTA per SM.
-        # The if condition later prevents the warps from extra CTAs from doing any work.
-        tile_sched = utils.StaticPersistentGroupTileScheduler.create(
-            tile_sched_params,
-            cute.arch.block_idx(),
-            grid_dim,
-            self.cluster_tile_shape_mnk,
-            utils.create_initial_search_state(),
-            group_count,
-            problem_sizes_mnkl,
-        )
-        initial_work_tile_info = tile_sched.initial_work_tile_info()
-
-        #
         # Specialized TMA load warp
         #
-        if warp_idx == self.tma_warp_id and initial_work_tile_info.is_valid_tile:
+        if warp_idx == self.tma_warp_id:
             #
             # Persistent tile scheduling loop
             #
-            work_tile = initial_work_tile_info
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_sched_stage
+            )
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+            group_search_result = work_tile.group_search_result
+            is_valid_tile = work_tile.is_valid_tile
 
             tensormap_init_done = cutlass.Boolean(False)
             # group index of last tile
@@ -1002,10 +1081,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                 pipeline.PipelineUserType.Producer, self.num_ab_stage
             )
 
-            while work_tile.is_valid_tile:
-                grouped_gemm_cta_tile_info = work_tile.group_search_result
-                cur_k_tile_cnt = grouped_gemm_cta_tile_info.cta_tile_count_k
-                cur_group_idx = grouped_gemm_cta_tile_info.group_idx
+            while is_valid_tile:
+                cur_k_tile_cnt = group_search_result.cta_tile_count_k
+                cur_group_idx = group_search_result.group_idx
                 is_k_tile_cnt_zero = cur_k_tile_cnt == 0
                 # Do not load any data if cur_k_tile_cnt is 0
                 if not is_k_tile_cnt_zero:
@@ -1016,9 +1094,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                             cur_group_idx,
                             self.a_dtype,
                             (
-                                grouped_gemm_cta_tile_info.problem_shape_m,
-                                grouped_gemm_cta_tile_info.problem_shape_n,
-                                grouped_gemm_cta_tile_info.problem_shape_k,
+                                group_search_result.problem_shape_m,
+                                group_search_result.problem_shape_n,
+                                group_search_result.problem_shape_k,
                             ),
                             strides_abc,
                             ptrs_abc,
@@ -1028,9 +1106,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                             cur_group_idx,
                             self.b_dtype,
                             (
-                                grouped_gemm_cta_tile_info.problem_shape_m,
-                                grouped_gemm_cta_tile_info.problem_shape_n,
-                                grouped_gemm_cta_tile_info.problem_shape_k,
+                                group_search_result.problem_shape_m,
+                                group_search_result.problem_shape_n,
+                                group_search_result.problem_shape_k,
                             ),
                             strides_abc,
                             ptrs_abc,
@@ -1040,9 +1118,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                             cur_group_idx,
                             self.sf_dtype,
                             (
-                                grouped_gemm_cta_tile_info.problem_shape_m,
-                                grouped_gemm_cta_tile_info.problem_shape_n,
-                                grouped_gemm_cta_tile_info.problem_shape_k,
+                                group_search_result.problem_shape_m,
+                                group_search_result.problem_shape_n,
+                                group_search_result.problem_shape_k,
                             ),
                             ptrs_sfasfb,
                             0,  # 0 for tensor SFA
@@ -1051,9 +1129,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                             cur_group_idx,
                             self.sf_dtype,
                             (
-                                grouped_gemm_cta_tile_info.problem_shape_m,
-                                grouped_gemm_cta_tile_info.problem_shape_n,
-                                grouped_gemm_cta_tile_info.problem_shape_k,
+                                group_search_result.problem_shape_m,
+                                group_search_result.problem_shape_n,
+                                group_search_result.problem_shape_k,
                             ),
                             ptrs_sfasfb,
                             1,  # 1 for tensor SFB
@@ -1087,9 +1165,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                         )
 
                     mma_tile_coord_mnl = (
-                        grouped_gemm_cta_tile_info.cta_tile_idx_m
+                        group_search_result.cta_tile_idx_m
                         // cute.size(tiled_mma.thr_id.shape),
-                        grouped_gemm_cta_tile_info.cta_tile_idx_n,
+                        group_search_result.cta_tile_idx_n,
                         0,
                     )
 
@@ -1147,7 +1225,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                             mcast_mask=a_full_mcast_mask,
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_a_gmem_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
                         cute.copy(
@@ -1160,7 +1238,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                             mcast_mask=b_full_mcast_mask,
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_b_gmem_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
                         cute.copy(
@@ -1173,7 +1251,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                             mcast_mask=sfa_full_mcast_mask,
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_sfa_gmem_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
                         cute.copy(
@@ -1186,7 +1264,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                             mcast_mask=sfb_full_mcast_mask,
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_sfb_gmem_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
 
@@ -1202,11 +1280,40 @@ class Sm100GroupedBlockScaledGemmKernel:
                         # wait tensormap initialization complete
                         self.tensormap_ab_init_barrier.arrive_and_wait()
                         tensormap_init_done = True
+
                 #
                 # Advance to next tile
                 #
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                # consume the work tile info from the shmem
+                cur_sTile = sTile_info[(None, tile_info_consumer_state.index)]
+
+                # Reassembling the work tile information
+                work_tile_info = cute.make_rmem_tensor(
+                    cur_sTile.shape, cur_sTile.element_type
+                )
+                cute.autovec_copy(cur_sTile, work_tile_info)
+
+                # fence view async shared
+                cute.arch.fence_proxy(
+                    "async.shared",
+                    space="cta",
+                )
+
+                # release the barrier for producer to proceed
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                is_valid_tile = work_tile_info[0] == 1
+                group_search_result = utils.GroupSearchResult(
+                    work_tile_info[1],
+                    work_tile_info[2],
+                    work_tile_info[3],
+                    work_tile_info[4],
+                    work_tile_info[5],
+                    work_tile_info[6],
+                    work_tile_info[7],
+                )
                 last_group_idx = cur_group_idx
 
             #
@@ -1214,27 +1321,107 @@ class Sm100GroupedBlockScaledGemmKernel:
             #
             ab_pipeline.producer_tail(ab_producer_state)
 
+        # Schedule warp
+        if warp_idx == self.scheduler_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+
+            tile_info_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_sched_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # query next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                # acquire tile info pipeline
+                tile_info_pipeline.producer_acquire(tile_info_producer_state)
+
+                # store the group search result to the shmem
+                with cute.arch.elect_one():
+                    cur_sTile_info = sTile_info[(None, tile_info_producer_state.index)]
+                    cur_sTile_info[0] = cutlass.Int32(work_tile.is_valid_tile)
+                    cur_sTile_info[1] = work_tile.group_search_result.group_idx
+                    cur_sTile_info[2] = work_tile.group_search_result.cta_tile_idx_m
+                    cur_sTile_info[3] = work_tile.group_search_result.cta_tile_idx_n
+                    cur_sTile_info[4] = work_tile.group_search_result.problem_shape_m
+                    cur_sTile_info[5] = work_tile.group_search_result.problem_shape_n
+                    cur_sTile_info[6] = work_tile.group_search_result.problem_shape_k
+                    cur_sTile_info[7] = work_tile.group_search_result.cta_tile_count_k
+                    cur_sTile_info[8] = tile_sched.num_tiles_executed
+
+                # fence view async shared
+                cute.arch.fence_proxy(
+                    "async.shared",
+                    space="cta",
+                )
+                # commit tile info pipeline
+                tile_info_pipeline.producer_commit(tile_info_producer_state)
+                tile_info_producer_state.advance()
+
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
+
         #
         # Specialized MMA warp
         #
-        if warp_idx == self.mma_warp_id and initial_work_tile_info.is_valid_tile:
+        if warp_idx == self.mma_warp_id:
             #
-            # Initialize tensormaps for A, B, SFA and SFB
+            # Persistent tile scheduling loop
             #
-            tensormap_manager.init_tensormap_from_atom(
-                tma_atom_a, tensormap_a_smem_ptr, self.mma_warp_id
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_sched_stage
             )
-            tensormap_manager.init_tensormap_from_atom(
-                tma_atom_b, tensormap_b_smem_ptr, self.mma_warp_id
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
             )
-            tensormap_manager.init_tensormap_from_atom(
-                tma_atom_sfa, tensormap_sfa_smem_ptr, self.mma_warp_id
-            )
-            tensormap_manager.init_tensormap_from_atom(
-                tma_atom_sfb, tensormap_sfb_smem_ptr, self.mma_warp_id
-            )
-            # indicate tensormap initialization has finished
-            self.tensormap_ab_init_barrier.arrive_and_wait()
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+            group_search_result = work_tile.group_search_result
+            is_valid_tile = work_tile.is_valid_tile
+
+            if is_valid_tile:
+                #
+                # Initialize tensormaps for A, B, SFA and SFB
+                #
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_atom_a, tensormap_a_smem_ptr, self.mma_warp_id
+                )
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_atom_b, tensormap_b_smem_ptr, self.mma_warp_id
+                )
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_atom_sfa, tensormap_sfa_smem_ptr, self.mma_warp_id
+                )
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_atom_sfb, tensormap_sfb_smem_ptr, self.mma_warp_id
+                )
+                # indicate tensormap initialization has finished
+                self.tensormap_ab_init_barrier.arrive_and_wait()
 
             #
             # Bar sync for retrieve tensor memory ptr from shared mem
@@ -1248,7 +1435,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             acc_tmem_ptr = cute.arch.retrieve_tmem_ptr(
                 self.acc_dtype,
                 alignment=16,
-                ptr_to_buffer_holding_addr=tmem_holding_buf_ptr,
+                ptr_to_buffer_holding_addr=tmem_holding_buf,
             )
             # (MMA, MMA_M, MMA_N, STAGE)
             tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
@@ -1292,25 +1479,16 @@ class Sm100GroupedBlockScaledGemmKernel:
                 self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
             )
 
-            #
-            # Persistent tile scheduling loop
-            #
-            work_tile = initial_work_tile_info
-
             ab_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_ab_stage
             )
             acc_producer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer, self.num_acc_stage
             )
-            while work_tile.is_valid_tile:
-                cur_group_idx = work_tile.group_search_result.group_idx
-                problem_shape_k = work_tile.group_search_result.problem_shape_k
-
-                # MMA warp is only interested in number of tiles along K dimension
-                cur_k_tile_cnt = (
-                    problem_shape_k + self.cluster_tile_shape_mnk[2] - 1
-                ) // self.cluster_tile_shape_mnk[2]
+            while is_valid_tile:
+                cur_group_idx = group_search_result.group_idx
+                _problem_shape_k = group_search_result.problem_shape_k
+                cur_k_tile_cnt = group_search_result.cta_tile_count_k
                 is_k_tile_cnt_zero = cur_k_tile_cnt == 0
 
                 # (MMA, MMA_M, MMA_N)
@@ -1367,36 +1545,15 @@ class Sm100GroupedBlockScaledGemmKernel:
                         )
 
                         # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
-                        num_kblocks = cute.size(tCrA, mode=[2])
-                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
-                            kblock_coord = (
-                                None,
-                                None,
-                                kblock_idx,
-                                ab_consumer_state.index,
-                            )
-
-                            # Set SFA/SFB tensor to tiled_mma
-                            sf_kblock_coord = (None, None, kblock_idx)
-                            tiled_mma.set(
-                                tcgen05.Field.SFA,
-                                tCtSFA[sf_kblock_coord].iterator,
-                            )
-                            tiled_mma.set(
-                                tcgen05.Field.SFB,
-                                tCtSFB[sf_kblock_coord].iterator,
-                            )
-
-                            cute.gemm(
-                                tiled_mma,
-                                tCtAcc,
-                                tCrA[kblock_coord],
-                                tCrB[kblock_coord],
-                                tCtAcc,
-                            )
-
-                            # Enable accumulate on tCtAcc after first kblock
-                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        tile_crd = (None, None, None, ab_consumer_state.index)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            [tCrA[tile_crd], tCtSFA],
+                            [tCrB[tile_crd], tCtSFB],
+                            tCtAcc,
+                        )
 
                         # Async arrive AB buffer empty
                         ab_pipeline.consumer_release(ab_consumer_state)
@@ -1421,8 +1578,34 @@ class Sm100GroupedBlockScaledGemmKernel:
                 #
                 # Advance to next tile
                 #
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                # consume the work tile info from the shmem
+                cur_sTile = sTile_info[(None, tile_info_consumer_state.index)]
+                # Reassembling the work tile information
+                work_tile_info = cute.make_rmem_tensor(
+                    cur_sTile.shape, cur_sTile.element_type
+                )
+                cute.autovec_copy(cur_sTile, work_tile_info)
+
+                # fence view async shared
+                cute.arch.fence_proxy(
+                    "async.shared",
+                    space="cta",
+                )
+
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                is_valid_tile = work_tile_info[0] == 1
+                group_search_result = utils.GroupSearchResult(
+                    work_tile_info[1],
+                    work_tile_info[2],
+                    work_tile_info[3],
+                    work_tile_info[4],
+                    work_tile_info[5],
+                    work_tile_info[6],
+                    work_tile_info[7],
+                )
 
             #
             # Wait for accumulator buffer empty
@@ -1432,7 +1615,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         #
         # Specialized epilogue warps
         #
-        if warp_idx < self.mma_warp_id and initial_work_tile_info.is_valid_tile:
+        if warp_idx < self.mma_warp_id:
             # initialize tensorap for C
             tensormap_manager.init_tensormap_from_atom(
                 tma_atom_c,
@@ -1445,7 +1628,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             if warp_idx == self.epilog_warp_id[0]:
                 cute.arch.alloc_tmem(
                     self.num_tmem_alloc_cols,
-                    tmem_holding_buf_ptr,
+                    tmem_holding_buf,
                     is_two_cta=use_2cta_instrs,
                 )
 
@@ -1460,7 +1643,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             acc_tmem_ptr = cute.arch.retrieve_tmem_ptr(
                 self.acc_dtype,
                 alignment=16,
-                ptr_to_buffer_holding_addr=tmem_holding_buf_ptr,
+                ptr_to_buffer_holding_addr=tmem_holding_buf,
             )
             # (MMA, MMA_M, MMA_N, STAGE)
             tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
@@ -1489,7 +1672,26 @@ class Sm100GroupedBlockScaledGemmKernel:
             #
             # Persistent tile scheduling loop
             #
-            work_tile = initial_work_tile_info
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_sched_stage
+            )
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+            group_search_result = work_tile.group_search_result
+            is_valid_tile = work_tile.is_valid_tile
+            num_tiles_executed = tile_sched.num_tiles_executed
 
             acc_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
@@ -1507,10 +1709,9 @@ class Sm100GroupedBlockScaledGemmKernel:
             # group index to start searching
             last_group_idx = cutlass.Int32(-1)
 
-            while work_tile.is_valid_tile:
-                grouped_gemm_cta_tile_info = work_tile.group_search_result
-                cur_group_idx = grouped_gemm_cta_tile_info.group_idx
-                cur_k_tile_cnt = grouped_gemm_cta_tile_info.cta_tile_count_k
+            while is_valid_tile:
+                cur_group_idx = group_search_result.group_idx
+                cur_k_tile_cnt = group_search_result.cta_tile_count_k
                 is_k_tile_cnt_zero = cur_k_tile_cnt == 0
                 is_group_changed = cur_group_idx != last_group_idx
 
@@ -1521,9 +1722,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                         cur_group_idx,
                         self.c_dtype,
                         (
-                            grouped_gemm_cta_tile_info.problem_shape_m,
-                            grouped_gemm_cta_tile_info.problem_shape_n,
-                            grouped_gemm_cta_tile_info.problem_shape_k,
+                            group_search_result.problem_shape_m,
+                            group_search_result.problem_shape_n,
+                            group_search_result.problem_shape_k,
                         ),
                         strides_abc,
                         ptrs_abc,
@@ -1538,9 +1739,9 @@ class Sm100GroupedBlockScaledGemmKernel:
                     )
 
                 mma_tile_coord_mnl = (
-                    grouped_gemm_cta_tile_info.cta_tile_idx_m
+                    group_search_result.cta_tile_idx_m
                     // cute.size(tiled_mma.thr_id.shape),
-                    grouped_gemm_cta_tile_info.cta_tile_idx_n,
+                    group_search_result.cta_tile_idx_n,
                     0,
                 )
 
@@ -1580,7 +1781,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                 # Store accumulator to global memory in subtiles
                 #
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
-                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                num_prev_subtiles = num_tiles_executed * subtile_cnt
                 for subtile_idx in range(subtile_cnt):
                     if not is_k_tile_cnt_zero:
                         #
@@ -1637,7 +1838,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                             bSG_gC[(None, subtile_idx)],
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_c_gmem_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
                         # Fence and barrier to make sure shared memory store is visible to TMA store
@@ -1655,8 +1856,36 @@ class Sm100GroupedBlockScaledGemmKernel:
                 #
                 # Advance to next tile
                 #
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                # consume the work tile info from the shmem
+                cur_sTile = sTile_info[(None, tile_info_consumer_state.index)]
+
+                # Reassembling the work tile information
+                work_tile_info = cute.make_rmem_tensor(
+                    cur_sTile.shape, cur_sTile.element_type
+                )
+                cute.autovec_copy(cur_sTile, work_tile_info)
+
+                # fence view async shared
+                cute.arch.fence_proxy(
+                    "async.shared",
+                    space="cta",
+                )
+
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                is_valid_tile = work_tile_info[0] == 1
+                group_search_result = utils.GroupSearchResult(
+                    work_tile_info[1],
+                    work_tile_info[2],
+                    work_tile_info[3],
+                    work_tile_info[4],
+                    work_tile_info[5],
+                    work_tile_info[6],
+                    work_tile_info[7],
+                )
+                num_tiles_executed = work_tile_info[8]
                 last_group_idx = cur_group_idx
 
             #
@@ -1719,7 +1948,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                 f"dtype must be a type of cutlass.Numeric, got {type(dtype)}"
             )
         tensor_gmem_ptr = cute.make_ptr(
-            dtype, ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+            dtype, ptr_i64, cutlass.AddressSpace.gmem, assumed_align=16
         )
 
         strides_tensor_gmem = strides_abc[(group_idx, tensor_index, None)]
@@ -1792,7 +2021,7 @@ class Sm100GroupedBlockScaledGemmKernel:
                 f"dtype must be a type of cutlass.Numeric, got {type(dtype)}"
             )
         tensor_gmem_ptr = cute.make_ptr(
-            dtype, ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+            dtype, ptr_i64, cutlass.AddressSpace.gmem, assumed_align=16
         )
 
         c1 = cutlass.Int32(1)
@@ -2015,7 +2244,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -2036,7 +2265,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.
@@ -2052,6 +2281,7 @@ class Sm100GroupedBlockScaledGemmKernel:
         """
         # ACC stages
         num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 2
+        num_sched_stage = 2
 
         # Default C stages
         num_c_stage = 2
@@ -2116,7 +2346,7 @@ class Sm100GroupedBlockScaledGemmKernel:
             - occupancy * (mbar_helpers_bytes + c_bytes)
         ) // (occupancy * c_bytes_per_stage)
 
-        return num_acc_stage, num_ab_stage, num_c_stage
+        return num_acc_stage, num_ab_stage, num_c_stage, num_sched_stage
 
     @staticmethod
     def _compute_grid(
@@ -2157,6 +2387,39 @@ class Sm100GroupedBlockScaledGemmKernel:
         return tile_sched_params, grid
 
     @staticmethod
+    def needs_unpack_tma(
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Decide whether TMA must use the UNPACK_U8 variant (U4_UNPACK_U8 /
+        U6_UNPACK_U8) for narrow-precision operands.
+
+        Unpack is required when:
+          * Operand widths differ (mxf8f6f4 mixed-precision) — A and B must
+            share a uniform byte-per-element SMEM layout, so the narrower
+            operand is unpacked into 1B/elem containers in SMEM.
+          * Either operand is 6-bit — there is no packed U6 TMA format,
+            only U6_UNPACK_U8 exists.
+
+        Otherwise (same-width and no 6-bit operand, e.g. f4xf4 / f8xf8 /
+        f8E4M3xf8E5M2) TMA can use the natural packed format (U4 for 4-bit,
+        U8 for 8-bit).
+
+        :param a_dtype: Element data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: Element data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
+        :return: True if UNPACK_U8 TMA format must be used, False otherwise
+        :rtype: bool
+        """
+        if a_dtype.width != b_dtype.width:
+            return True
+        if a_dtype.width == 6 or b_dtype.width == 6:
+            return True
+        return False
+
+    @staticmethod
     def _get_mbar_smem_bytes(**kwargs_stages: int) -> int:
         """Calculate shared memory consumption for memory barriers based on provided stages.
 
@@ -2183,7 +2446,8 @@ class Sm100GroupedBlockScaledGemmKernel:
 
     @staticmethod
     def is_valid_dtypes_and_scale_factor_vec_size(
-        ab_dtype: Type[cutlass.Numeric],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         c_dtype: Type[cutlass.Numeric],
@@ -2191,8 +2455,10 @@ class Sm100GroupedBlockScaledGemmKernel:
         """
         Check if the dtypes and sf_vec_size are valid combinations
 
-        :param ab_dtype: The data type of the A and B operands
-        :type ab_dtype: Type[cutlass.Numeric]
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
         :param sf_dtype: The data type of the scale factor
         :type sf_dtype: Type[cutlass.Numeric]
         :param sf_vec_size: The vector size of the scale factor
@@ -2205,8 +2471,12 @@ class Sm100GroupedBlockScaledGemmKernel:
         """
         is_valid = True
 
-        # Check valid ab_dtype
-        if ab_dtype not in {
+        # Check valid a_dtype and b_dtype
+        if a_dtype not in {
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        } or b_dtype not in {
             cutlass.Float4E2M1FN,
             cutlass.Float8E5M2,
             cutlass.Float8E4M3FN,
@@ -2224,7 +2494,9 @@ class Sm100GroupedBlockScaledGemmKernel:
         # Check valid sf_dtype and sf_vec_size combinations
         if sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32:
             is_valid = False
-        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+        if a_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+        if b_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
             is_valid = False
 
         # Check valid c_dtype
@@ -2241,7 +2513,8 @@ class Sm100GroupedBlockScaledGemmKernel:
 
     @staticmethod
     def is_valid_layouts(
-        ab_dtype: Type[cutlass.Numeric],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
         c_dtype: Type[cutlass.Numeric],
         a_major: str,
         b_major: str,
@@ -2250,8 +2523,10 @@ class Sm100GroupedBlockScaledGemmKernel:
         """
         Check if layouts and dtypes are valid combinations
 
-        :param ab_dtype: The data type of the A and B operands
-        :type ab_dtype: Type[cutlass.Numeric]
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
         :param c_dtype: The data type of the output tensor
         :type c_dtype: Type[cutlass.Numeric]
         :param a_major: The major dimension of the A tensor
@@ -2266,7 +2541,9 @@ class Sm100GroupedBlockScaledGemmKernel:
         """
         is_valid = True
 
-        if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
+        if a_dtype is cutlass.Float4E2M1FN and not (a_major == "k"):
+            is_valid = False
+        if b_dtype is cutlass.Float4E2M1FN and not (b_major == "k"):
             is_valid = False
         return is_valid
 
@@ -2314,19 +2591,23 @@ class Sm100GroupedBlockScaledGemmKernel:
     @staticmethod
     def is_valid_tensor_alignment(
         problem_sizes_mnkl: List[Tuple[int, int, int, int]],
-        ab_dtype: Type[cutlass.Numeric],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
         c_dtype: Type[cutlass.Numeric],
         a_major: str,
         b_major: str,
         c_major: str,
+        mma_tiler_mn: Tuple[int, int],
     ) -> bool:
         """
         Check if the tensor alignment is valid
 
         :param problem_sizes_mnkl: The problem shape for each group
         :type problem_sizes_mnkl: List[Tuple[int, int, int, int]]
-        :param ab_dtype: The data type of the A and B operands
-        :type ab_dtype: Type[cutlass.Numeric]
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
         :param c_dtype: The data type of the output tensor
         :type c_dtype: Type[cutlass.Numeric]
         :param a_major: The major axis of the A tensor
@@ -2335,6 +2616,9 @@ class Sm100GroupedBlockScaledGemmKernel:
         :type b_major: str
         :param c_major: The major axis of the C tensor
         :type c_major: str
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler,
+            needed to verify per-CTA UNPACK alignment under 2CTA MMA.
+        :type mma_tiler_mn: Tuple[int, int]
 
         :return: True if the problem shape is valid, False otherwise
         :rtype: bool
@@ -2347,20 +2631,55 @@ class Sm100GroupedBlockScaledGemmKernel:
             num_contiguous_elements = 16 * 8 // dtype.width
             return num_major_elements % num_contiguous_elements == 0
 
+        def check_contigous_128_alignment(dtype, is_mode0_major, tensor_shape):
+            if dtype.width >= 8:
+                return True
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            return num_major_elements % 128 == 0
+
+        use_2cta_instrs = mma_tiler_mn[0] == 256
+        cta_div = 2 if use_2cta_instrs else 1
+        needs_unpack = Sm100GroupedBlockScaledGemmKernel.needs_unpack_tma(
+            a_dtype, b_dtype
+        )
+
         for m, n, k, l in problem_sizes_mnkl:
             if (
-                not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
-                or not check_contigous_16B_alignment(
-                    ab_dtype, b_major == "n", (n, k, l)
-                )
+                not check_contigous_16B_alignment(a_dtype, a_major == "m", (m, k, l))
+                or not check_contigous_16B_alignment(b_dtype, b_major == "n", (n, k, l))
                 or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+            ):
+                is_valid = False
+            # Mixed-precision (mxf8f6f4) loads use UNPACK_U8 TMA; the contiguous
+            # inner dim of any sub-byte operand must be a 128-element multiple.
+            if needs_unpack and (
+                not check_contigous_128_alignment(a_dtype, a_major == "m", (m, k, l))
+                or not check_contigous_128_alignment(b_dtype, b_major == "n", (n, k, l))
+            ):
+                is_valid = False
+            # When a sub-byte operand is non-K-major, the MMA tile contig dim
+            # (after 2CTA split) must also be a 128-element multiple.
+            if (
+                needs_unpack
+                and a_major == "m"
+                and a_dtype.width < 8
+                and (mma_tiler_mn[0] // cta_div) % 128 != 0
+            ):
+                is_valid = False
+            if (
+                needs_unpack
+                and b_major == "n"
+                and b_dtype.width < 8
+                and mma_tiler_mn[1] % 128 != 0
             ):
                 is_valid = False
         return is_valid
 
     @staticmethod
     def can_implement(
-        ab_dtype: Type[cutlass.Numeric],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         c_dtype: Type[cutlass.Numeric],
@@ -2374,8 +2693,10 @@ class Sm100GroupedBlockScaledGemmKernel:
         """
         Check if the gemm can be implemented
 
-        :param ab_dtype: The data type of the A and B operands
-        :type ab_dtype: Type[cutlass.Numeric]
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
         :param sf_dtype: The data type of the scale factor tensor
         :type sf_dtype: Type[cutlass.Numeric]
         :param sf_vec_size: The vector size
@@ -2400,12 +2721,12 @@ class Sm100GroupedBlockScaledGemmKernel:
         can_implement = True
         # Skip unsupported types
         if not Sm100GroupedBlockScaledGemmKernel.is_valid_dtypes_and_scale_factor_vec_size(
-            ab_dtype, sf_dtype, sf_vec_size, c_dtype
+            a_dtype, b_dtype, sf_dtype, sf_vec_size, c_dtype
         ):
             can_implement = False
         # Skip unsupported layouts
         if not Sm100GroupedBlockScaledGemmKernel.is_valid_layouts(
-            ab_dtype, c_dtype, a_major, b_major, c_major
+            a_dtype, b_dtype, c_dtype, a_major, b_major, c_major
         ):
             can_implement = False
         # Skip invalid mma tile shape and cluster shape
@@ -2415,7 +2736,14 @@ class Sm100GroupedBlockScaledGemmKernel:
             can_implement = False
         # Skip illegal problem shape for load/store alignment
         if not Sm100GroupedBlockScaledGemmKernel.is_valid_tensor_alignment(
-            problem_sizes_mnkl, ab_dtype, c_dtype, a_major, b_major, c_major
+            problem_sizes_mnkl,
+            a_dtype,
+            b_dtype,
+            c_dtype,
+            a_major,
+            b_major,
+            c_major,
+            mma_tiler_mn,
         ):
             can_implement = False
         return can_implement
@@ -2436,21 +2764,40 @@ def create_tensor_and_stride(
     is_mode0_major: bool,
     dtype: type[cutlass.Numeric],
     is_dynamic_layout: bool = True,
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
 ) -> tuple[int, torch.Tensor, cute.Tensor, torch.Tensor, tuple[int, int]]:
     """Create GPU tensor from either a new or existing CPU tensor.
 
-    :param torch_tensor_cpu: Optional existing CPU tensor to reuse. If None, creates a new one.
-    :type torch_tensor_cpu: torch.Tensor, optional
+    :param init_normal: Use normal distribution for initialization instead of random.
+    :type init_normal: bool, optional
+    :param normal_mean: Mean of normal distribution for initialization.
+    :type normal_mean: float, optional
+    :param normal_std: Standard deviation of normal distribution for initialization.
+    :type normal_std: float, optional
     """
 
-    # Create new CPU tensor
-    torch_tensor_cpu = cutlass_torch.matrix(
-        l,
-        mode0,
-        mode1,
-        is_mode0_major,
-        cutlass.Float32,
-    )
+    if init_normal:
+        # Create CPU reference tensor in Float32 with normal distribution
+        if is_mode0_major:
+            torch_tensor_cpu = torch.empty(
+                (l, mode1, mode0), dtype=torch.float32
+            ).permute(2, 1, 0)
+        else:
+            torch_tensor_cpu = torch.empty(
+                (l, mode0, mode1), dtype=torch.float32
+            ).permute(1, 2, 0)
+        torch_tensor_cpu.normal_(mean=normal_mean, std=normal_std)
+    else:
+        # Create new CPU tensor with default random initialization
+        torch_tensor_cpu = cutlass_torch.matrix(
+            l,
+            mode0,
+            mode1,
+            is_mode0_major,
+            cutlass.Float32,
+        )
 
     # Create GPU tensor from CPU tensor (new or existing)
     cute_tensor, torch_tensor = cutlass_torch.cute_tensor_like(
@@ -2471,11 +2818,15 @@ def create_tensor_and_stride(
 
 def create_tensors_abc_for_all_groups(
     problem_sizes_mnkl: List[tuple[int, int, int, int]],
-    ab_dtype: Type[cutlass.Numeric],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
     c_dtype: Type[cutlass.Numeric],
     a_major: str,
     b_major: str,
     c_major: str,
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
 ) -> tuple[
     List[List[int]],
     List[List[torch.Tensor]],
@@ -2498,7 +2849,16 @@ def create_tensors_abc_for_all_groups(
             cute_tensor_a,
             ref_torch_fp32_tensor_a,
             stride_mk_a,
-        ) = create_tensor_and_stride(l, m, k, a_major == "m", ab_dtype)
+        ) = create_tensor_and_stride(
+            l,
+            m,
+            k,
+            a_major == "m",
+            a_dtype,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
+        )
 
         (
             ptr_b,
@@ -2506,7 +2866,16 @@ def create_tensors_abc_for_all_groups(
             cute_tensor_b,
             ref_torch_fp32_tensor_b,
             stride_nk_b,
-        ) = create_tensor_and_stride(l, n, k, b_major == "n", ab_dtype)
+        ) = create_tensor_and_stride(
+            l,
+            n,
+            k,
+            b_major == "n",
+            b_dtype,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
+        )
 
         (
             ptr_c,
@@ -2514,7 +2883,16 @@ def create_tensors_abc_for_all_groups(
             cute_tensor_c,
             ref_torch_fp32_tensor_c,
             stride_mn_c,
-        ) = create_tensor_and_stride(l, m, n, c_major == "m", c_dtype)
+        ) = create_tensor_and_stride(
+            l,
+            m,
+            n,
+            c_major == "m",
+            c_dtype,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
+        )
 
         ref_torch_fp32_tensors_abc.append(
             [ref_torch_fp32_tensor_a, ref_torch_fp32_tensor_b, ref_torch_fp32_tensor_c]
@@ -2684,7 +3062,8 @@ def run(
     num_groups: int,
     problem_sizes_mnkl: List[Tuple[int, int, int, int]],
     host_problem_shape_available: bool,
-    ab_dtype: Type[cutlass.Numeric],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
     sf_dtype: Type[cutlass.Numeric],
     sf_vec_size: int,
     c_dtype: Type[cutlass.Numeric],
@@ -2698,12 +3077,27 @@ def run(
     iterations: int = 1,
     skip_ref_check: bool = False,
     use_cold_l2: bool = False,
+    use_cached_problem_shapes: bool = True,
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
     **kwargs,
 ):
     """Run SM100 grouped blockscaledGEMM example with specified configurations.
 
     :param use_cold_l2: Whether to use circular buffer strategy to ensure cold L2 cache, defaults to False
     :type use_cold_l2: bool, optional
+    :param use_cached_problem_shapes: Enable double-buffered caching of problem
+        shapes for better performance with many small groups, defaults to True.
+    :type use_cached_problem_shapes: bool, optional
+    :param init_normal: Whether to initialize tensors using normal distribution
+        instead of uniform random, defaults to False.
+    :type init_normal: bool, optional
+    :param normal_mean: Mean for normal distribution initialization, defaults to 0.0.
+    :type normal_mean: float, optional
+    :param normal_std: Standard deviation for normal distribution initialization,
+        defaults to 1.0.
+    :type normal_std: float, optional
     :return: Execution time of the GEMM kernel in microseconds
     :rtype: float
     """
@@ -2711,7 +3105,9 @@ def run(
     print(f"{num_groups} groups")
     for i, (m, n, k, l) in enumerate(problem_sizes_mnkl):
         print(f"Group {i}: {m}x{n}x{k}x{l}")
-    print(f"AB dtype: {ab_dtype}, SF dtype: {sf_dtype}, SF Vec size: {sf_vec_size}")
+    print(
+        f"A dtype: {a_dtype}, B dtype: {b_dtype}, SF dtype: {sf_dtype}, SF Vec size: {sf_vec_size}"
+    )
     print(f"C dtype: {c_dtype}")
     print(f"Matrix majors - A: {a_major}, B: {b_major}, C: {c_major}")
     print(f"Mma Tiler (M, N): {mma_tiler_mn}, Cluster Shape (M, N): {cluster_shape_mn}")
@@ -2720,10 +3116,12 @@ def run(
     print(f"Iterations: {iterations}")
     print(f"Skip reference checking: {skip_ref_check}")
     print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
+    print(f"Use cached problem shapes: {use_cached_problem_shapes}")
 
     # Skip unsupported testcase
     if not Sm100GroupedBlockScaledGemmKernel.can_implement(
-        ab_dtype,
+        a_dtype,
+        b_dtype,
         sf_dtype,
         sf_vec_size,
         c_dtype,
@@ -2734,8 +3132,8 @@ def run(
         b_major,
         c_major,
     ):
-        raise TypeError(
-            f"Unsupported testcase {ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype},  {mma_tiler_mn}, {cluster_shape_mn}, {problem_sizes_mnkl}, {a_major}, {b_major}, {c_major}"
+        raise cutlass.testing.CantImplementError(
+            f"Unsupported testcase {a_dtype}, {b_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype},  {mma_tiler_mn}, {cluster_shape_mn}, {problem_sizes_mnkl}, {a_major}, {b_major}, {c_major}"
         )
 
     if not torch.cuda.is_available():
@@ -2752,11 +3150,15 @@ def run(
         ref_f32_torch_tensors_abc,
     ) = create_tensors_abc_for_all_groups(
         problem_sizes_mnkl,
-        ab_dtype,
+        a_dtype,
+        b_dtype,
         c_dtype,
         a_major,
         b_major,
         c_major,
+        init_normal=init_normal,
+        normal_mean=normal_mean,
+        normal_std=normal_std,
     )
     # Create tensors SFA, SFB for all groups
     (
@@ -2772,13 +3174,18 @@ def run(
 
     # Setup inital tensors for TMA of A,B and C
     alignment = 16  # 16 bytes aligned
-    divisibility_ab = 32 if ab_dtype == cutlass.Float4E2M1FN else 16
+    divisibility_a = 32 if a_dtype == cutlass.Float4E2M1FN else 16
+    divisibility_b = 32 if b_dtype == cutlass.Float4E2M1FN else 16
     divisibility_c = 32 if c_dtype == cutlass.Float4E2M1FN else 16
     divisibility_sf = 32 if sf_dtype == cutlass.Float4E2M1FN else 16
 
-    min_ab_size = alignment * 8 // ab_dtype.width  # alignment bytes of width
-    div_mul_ab = (divisibility_ab + min_ab_size - 1) // min_ab_size
-    min_ab_size = min_ab_size * div_mul_ab
+    min_a_size = alignment * 8 // a_dtype.width  # alignment bytes of width
+    div_mul_a = (divisibility_a + min_a_size - 1) // min_a_size
+    min_a_size = min_a_size * div_mul_a
+
+    min_b_size = alignment * 8 // b_dtype.width  # alignment bytes of width
+    div_mul_b = (divisibility_b + min_b_size - 1) // min_b_size
+    min_b_size = min_b_size * div_mul_b
 
     min_c_size = alignment * 8 // c_dtype.width
     div_mul_c = (divisibility_c + min_c_size - 1) // min_c_size
@@ -2789,12 +3196,8 @@ def run(
     min_sf_size = min_sf_size * div_mul_sf
 
     initial_cute_tensors_abc = [
-        create_tensor_and_stride(1, min_ab_size, min_ab_size, a_major == "m", ab_dtype)[
-            2
-        ],
-        create_tensor_and_stride(1, min_ab_size, min_ab_size, b_major == "n", ab_dtype)[
-            2
-        ],
+        create_tensor_and_stride(1, min_a_size, min_a_size, a_major == "m", a_dtype)[2],
+        create_tensor_and_stride(1, min_b_size, min_b_size, b_major == "n", b_dtype)[2],
         create_tensor_and_stride(1, min_c_size, min_c_size, c_major == "m", c_dtype)[2],
     ]
     initial_cute_tensors_sfasfb = [
@@ -2828,6 +3231,7 @@ def run(
         sf_vec_size,
         mma_tiler_mn,
         cluster_shape_mn,
+        use_cached_problem_shapes,
     )
 
     # layout (num_groups, 4):(4, 1)
@@ -2924,7 +3328,6 @@ def run(
         tensor_of_tensormap,
         max_active_clusters,
         current_stream,
-        options=f"--opt-level 2",
     )
 
     # reference check
@@ -3001,11 +3404,15 @@ def run(
             _,
         ) = create_tensors_abc_for_all_groups(
             problem_sizes_mnkl,
-            ab_dtype,
+            a_dtype,
+            b_dtype,
             c_dtype,
             a_major,
             b_major,
             c_major,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
         )
 
         (
@@ -3021,10 +3428,10 @@ def run(
 
         initial_cute_tensors_abc_workspace = [
             create_tensor_and_stride(
-                1, min_ab_size, min_ab_size, a_major == "m", ab_dtype
+                1, min_a_size, min_a_size, a_major == "m", a_dtype
             )[2],
             create_tensor_and_stride(
-                1, min_ab_size, min_ab_size, b_major == "n", ab_dtype
+                1, min_b_size, min_b_size, b_major == "n", b_dtype
             )[2],
             create_tensor_and_stride(
                 1, min_c_size, min_c_size, c_major == "m", c_dtype
@@ -3067,7 +3474,7 @@ def run(
             is_dynamic_layout=False,
         )
 
-        args = cute.testing.JitArguments(
+        args = cutlass.testing.JitArguments(
             initial_cute_tensors_abc_workspace[0],
             initial_cute_tensors_abc_workspace[1],
             initial_cute_tensors_abc_workspace[2],
@@ -3112,11 +3519,11 @@ def run(
             # Add size of tensormap tensor
             tensor_of_tensormap_torch.numel() * tensor_of_tensormap_torch.element_size()
         )
-        workspace_count = cute.testing.get_workspace_count(
+        workspace_count = cutlass.testing.get_workspace_count(
             one_workspace_bytes, warmup_iterations, iterations
         )
 
-    exec_time = cute.testing.benchmark(
+    exec_time = cutlass.testing.benchmark(
         compiled_grouped_gemm,
         workspace_generator=generate_tensors,
         workspace_count=workspace_count,
@@ -3208,7 +3615,8 @@ if __name__ == "__main__":
         default=(1, 1),
         help="Cluster shape (comma-separated)",
     )
-    parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.Float4E2M1FN)
+    parser.add_argument("--a_dtype", type=cutlass.dtype, default=cutlass.Float4E2M1FN)
+    parser.add_argument("--b_dtype", type=cutlass.dtype, default=cutlass.Float4E2M1FN)
     parser.add_argument("--sf_dtype", type=cutlass.dtype, default=cutlass.Float8E8M0FNU)
     parser.add_argument("--sf_vec_size", type=int, default=16)
     parser.add_argument("--c_dtype", type=cutlass.dtype, default=cutlass.Float16)
@@ -3236,8 +3644,18 @@ if __name__ == "__main__":
         default=False,
         help="Use circular buffer tensor sets to ensure L2 cold cache",
     )
+    parser.add_argument(
+        "--no_use_cached_problem_shapes",
+        action="store_true",
+        default=False,
+        help="Disable double-buffered caching of problem shapes. "
+        "By default, caching is enabled for better performance with many small groups.",
+    )
+    testing.add_tensor_init_args(parser, supports_int_dtypes=False)
 
     args = parser.parse_args()
+
+    testing.validate_tensor_init_args(args, parser)
 
     if (
         len(args.problem_sizes_mnkl) != 0
@@ -3260,7 +3678,8 @@ if __name__ == "__main__":
         args.num_groups,
         args.problem_sizes_mnkl,
         args.host_problem_shape_available,
-        args.ab_dtype,
+        args.a_dtype,
+        args.b_dtype,
         args.sf_dtype,
         args.sf_vec_size,
         args.c_dtype,
@@ -3274,5 +3693,9 @@ if __name__ == "__main__":
         args.iterations,
         args.skip_ref_check,
         args.use_cold_l2,
+        not args.no_use_cached_problem_shapes,
+        args.init_normal,
+        args.normal_mean,
+        args.normal_std,
     )
     print("PASS")

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/dense_gemm/dense_gemm_persistent.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/dense_gemm/dense_gemm_persistent.py
@@ -27,18 +27,20 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-from typing import Optional, Tuple, Type, Union
+from typing import Optional, Tuple, Type, Union, Literal
 from functools import lru_cache
 import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.cute.testing as testing
+from cutlass import testing
 import cutlass.utils as utils
 from cutlass.utils import is_fp8_dtype, create_cute_tensor_for_fp8
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils
+
 
 """
 A high-performance persistent batched dense GEMM example for the NVIDIA Blackwell SM100 architecture
@@ -75,7 +77,7 @@ Input arguments to this example is same as dense_gemm.py.
 
 .. code-block:: bash
 
-    python examples/blackwell/dense_gemm_persistent.py                          \
+    python examples/cute/blackwell/kernel/dense_gemm/dense_gemm_persistent.py                          \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                  \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                             \
       --mnkl 8192,8192,8192,1                                                   \
@@ -85,7 +87,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/dense_gemm_persistent.py                     \
+    ncu python examples/cute/blackwell/kernel/dense_gemm/dense_gemm_persistent.py                     \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                 \
       --mma_tiler_mn 256,128 --cluster_shape_mn 2,1                            \
       --mnkl 8192,8192,8192,1                                                  \
@@ -218,7 +220,7 @@ class PersistentDenseGemmKernel:
     :note: Supported C data types:
         - Float32 (for float32 and int32 accumulator data types)
         - Int32 (for float32 and int32 accumulator data types)
-        - Float16/BFloat16 (for fp16 and fp8 accumulator data types)
+        - Float16/BFloat16 (for fp32, fp16, and fp8 accumulator data types)
         - Int8/Uint8 (for uint8/int8 accumulator data types)
         - Float8E4M3FN/Float8E5M2 (for float32 accumulator data types)
 
@@ -233,9 +235,10 @@ class PersistentDenseGemmKernel:
             acc_dtype=cutlass.Float32,
             use_2cta_instrs=True,
             mma_tiler_mn=(128, 128),
-            cluster_shape_mn=(2, 2)
+            cluster_shape_mn=(2, 2),
+            use_tma_store=True
         )
-        gemm(a, b, c, max_active_clusters, stream)
+        gemm(a, b, c, max_active_clusters, stream, epilogue_op)
     """
 
     def __init__(
@@ -245,6 +248,8 @@ class PersistentDenseGemmKernel:
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
         use_tma_store: bool,
+        swizzle_size: int = 1,
+        raster_along: Literal["m", "n"] = "m",
     ):
         """Initializes the configuration for a Blackwell dense GEMM kernel.
 
@@ -277,6 +282,8 @@ class PersistentDenseGemmKernel:
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
+        self.swizzle_size = swizzle_size
+        self.raster_along = raster_along
         # K dimension is deferred in _setup_attributes
         self.mma_tiler_mn = mma_tiler_mn
         self.mma_tiler = (*mma_tiler_mn, 1)
@@ -303,6 +310,7 @@ class PersistentDenseGemmKernel:
     def _create_tiled_mma(self):
         return utils.sm100.make_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.acc_dtype,
@@ -370,7 +378,7 @@ class PersistentDenseGemmKernel:
                 self.c_dtype, self.c_layout, self.epi_tile, 1
             )
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
         self.num_acc_stage, self.num_ab_stage, self.num_c_stage = _compute_stages(
@@ -440,9 +448,13 @@ class PersistentDenseGemmKernel:
         self.a_dtype: Type[cutlass.Numeric] = a.element_type
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -459,7 +471,10 @@ class PersistentDenseGemmKernel:
         a_op = utils.sm100.cluster_shape_to_tma_atom_A(
             self.cluster_shape_mn, tiled_mma.thr_id
         )
-        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        a_smem_layout = cute.select(
+            self.a_smem_layout_staged,
+            mode=list(range(cute.rank(self.a_smem_layout_staged) - 1)),
+        )
         tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
             a_op,
             a,
@@ -476,7 +491,10 @@ class PersistentDenseGemmKernel:
         b_op = utils.sm100.cluster_shape_to_tma_atom_B(
             self.cluster_shape_mn, tiled_mma.thr_id
         )
-        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.select(
+            self.b_smem_layout_staged,
+            mode=list(range(cute.rank(self.b_smem_layout_staged) - 1)),
+        )
         tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
             b_op,
             b,
@@ -504,7 +522,12 @@ class PersistentDenseGemmKernel:
 
         # Compute grid size
         self.tile_sched_params, grid = self._compute_grid(
-            c, self.cta_tile_shape_mnk, self.cluster_shape_mn, max_active_clusters
+            c,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            self.swizzle_size,
+            self.raster_along,
+            max_active_clusters,
         )
 
         # Launch the kernel synchronously
@@ -596,15 +619,12 @@ class PersistentDenseGemmKernel:
             tmem_dealloc_mbar: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
-        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, num_tma_producer
-        )
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Warp)
         ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
             barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
             num_stages=self.num_ab_stage,
@@ -612,6 +632,7 @@ class PersistentDenseGemmKernel:
             consumer_group=ab_pipeline_consumer_group,
             tx_count=self.num_tma_load_bytes,
             cta_layout_vmnk=cluster_layout_vmnk,
+            enable_multicast_signaling=True,
             defer_sync=True,
         ).make_participants()
 
@@ -643,7 +664,7 @@ class PersistentDenseGemmKernel:
                 num_threads=32 * len(self.epilogue_warp_id),
             )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
@@ -652,7 +673,7 @@ class PersistentDenseGemmKernel:
         )
 
         # Cluster arrive after barrier init
-        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
 
         #
         # Setup smem tensor A/B/C
@@ -713,6 +734,13 @@ class PersistentDenseGemmKernel:
         # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
         tCgC = thr_mma.partition_C(gC_mnl)
 
+        # Coordinate tensor used to predicate SIMT stores from partial clusters.
+        idC = cute.make_identity_tensor(mC_mnl.shape)
+        cC_mnl = cute.local_tile(
+            idC, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        tCcC = thr_mma.partition_C(cC_mnl)
+
         #
         # Partition global/shared tensor for TMA load A/B
         #
@@ -760,7 +788,7 @@ class PersistentDenseGemmKernel:
         #
         # Cluster wait before tensor memory alloc
         #
-        pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
 
         #
         # Construct the scheduler
@@ -780,7 +808,6 @@ class PersistentDenseGemmKernel:
             #
             # Persistent tile scheduling loop
             #
-
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
@@ -860,7 +887,6 @@ class PersistentDenseGemmKernel:
             #
             # Persistent tile scheduling loop
             #
-
             acc_producer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer, self.num_acc_stage
             )
@@ -891,11 +917,6 @@ class PersistentDenseGemmKernel:
                     acc_pipeline.producer_acquire(acc_producer_state)
 
                 #
-                # Reset the ACCUMULATE field for each tile
-                #
-                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-
-                #
                 # Mma mainloop
                 #
                 for k_tile in range(k_tile_cnt):
@@ -904,19 +925,11 @@ class PersistentDenseGemmKernel:
                         handle = ab_consumer.wait_and_advance(peek_ab_full_status)
 
                         # tCtAcc += tCrA * tCrB
-                        num_kblocks = cute.size(tCrA, mode=[2])
-                        for kblk_idx in cutlass.range(num_kblocks, unroll_full=True):
-                            kblk_crd = (None, None, kblk_idx, handle.index)
-
-                            cute.gemm(
-                                tiled_mma,
-                                tCtAcc,
-                                tCrA[kblk_crd],
-                                tCrB[kblk_crd],
-                                tCtAcc,
-                            )
-                            # Enable accumulate on tCtAcc after first kblock
-                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        tile_crd = (None, None, None, handle.index)
+                        cute.gemm(
+                            tiled_mma, tCtAcc, tCrA[tile_crd], tCrB[tile_crd], tCtAcc
+                        )
 
                         # Async arrive AB buffer empty
                         handle.release()
@@ -977,7 +990,6 @@ class PersistentDenseGemmKernel:
             acc_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
             )
-
             if cutlass.const_expr(self.use_tma_store):
                 assert tma_atom_c is not None and sC is not None
                 c_producer_group = pipeline.CooperativeGroup(
@@ -1030,6 +1042,8 @@ class PersistentDenseGemmKernel:
                         mma_tile_coord_mnl,
                         acc_consumer_state,
                         acc_pipeline,
+                        tCcC_base=tCcC,
+                        mC_mnl=mC_mnl,
                     )
 
             if cutlass.const_expr(self.use_tma_store):
@@ -1050,6 +1064,8 @@ class PersistentDenseGemmKernel:
         c: cute.Tensor,
         cta_tile_shape_mnk: Tuple[int, int, int],
         cluster_shape_mn: Tuple[int, int],
+        swizzle_size: int,
+        raster_along: Literal["m", "n"],
         max_active_clusters: cutlass.Constexpr,
     ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
         """Use persistent tile scheduler to compute the grid size for the output tensor C.
@@ -1060,7 +1076,7 @@ class PersistentDenseGemmKernel:
         :type cta_tile_shape_mnk: tuple[int, int, int]
         :param cluster_shape_mn: Shape of each cluster in M, N dimensions.
         :type cluster_shape_mn: tuple[int, int]
-        :param max_active_clusters: Maximum number of active clusters.
+        :param max_active_clusters: Maximum number of hardware clusters to launch
         :type max_active_clusters: cutlass.Constexpr
 
         :return: A tuple containing:
@@ -1074,7 +1090,7 @@ class PersistentDenseGemmKernel:
         cluster_shape_mnl = (*cluster_shape_mn, 1)
 
         tile_sched_params = utils.PersistentTileSchedulerParams(
-            num_ctas_mnl, cluster_shape_mnl
+            num_ctas_mnl, cluster_shape_mnl, swizzle_size, raster_along == "m"
         )
         grid = utils.StaticPersistentTileScheduler.get_grid_shape(
             tile_sched_params, max_active_clusters
@@ -1104,7 +1120,9 @@ class PersistentDenseGemmKernel:
         """
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake, arch=arch)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(
+            tCtAcc_fake, arch=arch
+        )
 
         return num_tmem_alloc_cols
 
@@ -1117,10 +1135,8 @@ class PersistentDenseGemmKernel:
         """
         Check if the dtypes are valid
 
-        :param a_dtype: The data type of the A operands
-        :type a_dtype: Type[cutlass.Numeric]
-        :param b_dtype: The data type of the B operands
-        :type b_dtype: Type[cutlass.Numeric]
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
         :param acc_dtype: The data type of the accumulator
         :type acc_dtype: Type[cutlass.Numeric]
         :param c_dtype: The data type of the output tensor
@@ -1128,6 +1144,9 @@ class PersistentDenseGemmKernel:
 
         :raises testing.CantImplementError: If the dtypes are invalid
         """
+        sm100_utils.check_int8_mma_arch(a_dtype)
+        sm100_utils.check_int8_mma_arch(b_dtype)
+
         valid_ab_dtypes = {
             cutlass.Float16,
             cutlass.BFloat16,
@@ -1262,9 +1281,9 @@ class PersistentDenseGemmKernel:
         :type k: int
         :param l: The number of columns in the C tensor
         :type l: int
-        :param a_dtype: The data type of the A operands
+        :param a_dtype: The data type of the A operand
         :type a_dtype: Type[cutlass.Numeric]
-        :param b_dtype: The data type of the B operands
+        :param b_dtype: The data type of the B operand
         :type b_dtype: Type[cutlass.Numeric]
         :param c_dtype: The data type of the output tensor
         :type c_dtype: Type[cutlass.Numeric]
@@ -1305,7 +1324,8 @@ class PersistentDenseGemmKernel:
 
         :raises testing.CantImplementError: If the epilogue store option is invalid
         """
-        # None TMA store version does not have predication, can not support OOB tiles
+
+        # Non TMA store version does not have predication, can not support OOB tiles
         cta_tile_shape_mn = (
             self.mma_tiler_mn[0] // (2 if self.use_2cta_instrs else 1),
             self.mma_tiler_mn[1],
@@ -1313,7 +1333,16 @@ class PersistentDenseGemmKernel:
         if not self.use_tma_store:
             if not (m % cta_tile_shape_mn[0] == 0 and n % cta_tile_shape_mn[1] == 0):
                 raise testing.CantImplementError(
-                    f"Invalid epilog store option: {m}, {n}"
+                    f"Problem shape {m}, {n} must be divisible by cta tile shape {cta_tile_shape_mn} for non TMA store"
+                )
+            # CTA swizzling improves the L2 cache utilization and reduces the number of cache misses.
+            m_per_swizzle = (m // cta_tile_shape_mn[0]) // self.cluster_shape_mn[0]
+            n_per_swizzle = (n // cta_tile_shape_mn[1]) // self.cluster_shape_mn[1]
+            if (m_per_swizzle % self.swizzle_size != 0) or (
+                n_per_swizzle % self.swizzle_size != 0
+            ):
+                raise testing.CantImplementError(
+                    f"Problem shape {m}, {n} must be divisible by swizzle size {self.swizzle_size} for non TMA store"
                 )
 
     def can_implement(
@@ -1331,9 +1360,9 @@ class PersistentDenseGemmKernel:
 
         :param mnkl: Problem size as a tuple (M, N, K, L).
         :type mnkl: Tuple[int, int, int, int]
-        :param a_dtype: Data type for input tensors A.
+        :param a_dtype: Data type for input tensors A and B.
         :type a_dtype: Type[cutlass.Numeric]
-        :param b_dtype: Data type for input tensors B.
+        :param b_dtype: Data type for input tensors B and B.
         :type b_dtype: Type[cutlass.Numeric]
         :param c_dtype: Data type for output tensor C.
         :type c_dtype: Type[cutlass.Numeric]
@@ -1451,17 +1480,12 @@ def prepare_tensors(
             0, 2, 1
         )
 
-    if init_random:
-        # Uniform random initialization in range [-2, 3)
-        a_f32.random_(-2, 3)
-        b_f32.random_(-2, 3)
-        c_f32.random_(-2, 3)
-
-    else:
-        # Normal (Gaussian) initialization with user-specified mean and std
-        a_f32.normal_(mean=normal_mean, std=normal_std)
-        b_f32.normal_(mean=normal_mean, std=normal_std)
-        c_f32.normal_(mean=normal_mean, std=normal_std)
+    # Initialize tensors with either uniform random or normal distribution
+    for tensor in [a_f32, b_f32, c_f32]:
+        if init_random:
+            tensor.random_(-2, 3)
+        else:
+            tensor.normal_(mean=normal_mean, std=normal_std)
 
     # For float8 types, use uint8 as storage type to avoid dlpack limitation
     # (dlpack doesn't support float8 types)
@@ -1487,22 +1511,34 @@ def compile_bmm(
     a_major: str,
     b_major: str,
     c_major: str,
-    mma_tiler_mn: Tuple[int, int] = (256, 256),
+    mma_tiler: Union[Tuple[int, int], Tuple[int, int, int]] = (256, 256),
     cluster_shape_mn: Tuple[int, int] = (2, 1),
     max_active_clusters: cutlass.Constexpr = None,
     use_2cta_instrs: bool = True,
     use_tma_store: bool = True,
+    swizzle_size: int = 1,
+    raster_along: Literal["m", "n"] = "m",
     epilogue_op: cutlass.Constexpr = lambda x: x,
+    kernel_class: cutlass.Constexpr = None,
 ):
     from cutlass.cute.runtime import make_fake_stream
 
-    gemm = PersistentDenseGemmKernel(
+    # Use provided kernel class or default to PersistentDenseGemmKernel
+    KernelClass = (
+        kernel_class if kernel_class is not None else PersistentDenseGemmKernel
+    )
+
+    # Build GEMM object
+    gemm = KernelClass(
         acc_dtype,
         use_2cta_instrs,
-        mma_tiler_mn,
+        mma_tiler,
         cluster_shape_mn,
         use_tma_store,
+        swizzle_size,
+        raster_along,
     )
+
     # Check if configuration can be implemented
     can_implement = gemm.can_implement(
         mnkl, a.element_type, b.element_type, c.element_type, a_major, b_major, c_major
@@ -1510,8 +1546,10 @@ def compile_bmm(
     if not can_implement:
         raise testing.CantImplementError(
             f"The current config which is invalid/unsupported: use_2cta_instrs = {use_2cta_instrs}, "
-            f"mma_tiler_mn = {mma_tiler_mn}, cluster_shape_mn = {cluster_shape_mn}, "
-            f"use_tma_store = {use_tma_store}"
+            f"mma_tiler = {mma_tiler}, cluster_shape_mn = {cluster_shape_mn}, "
+            f"use_tma_store = {use_tma_store}, "
+            f"swizzle_size = {swizzle_size}, "
+            f"raster_along = {raster_along}"
         )
 
     stream = make_fake_stream()
@@ -1528,6 +1566,8 @@ def run(
     c_major: str,
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Tuple[int, int] = (2, 1),
+    swizzle_size: int = 1,
+    raster_along: Literal["m", "n"] = "m",
     use_2cta_instrs: bool = True,
     use_tma_store: bool = True,
     tolerance: float = 1e-01,
@@ -1535,7 +1575,10 @@ def run(
     iterations: int = 1,
     skip_ref_check: bool = False,
     use_cold_l2: bool = False,
-    benchmark: bool = False,
+    benchmark: str = "default",
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
     **kwargs,
 ):
     """
@@ -1576,8 +1619,17 @@ def run(
     :type skip_ref_check: bool, optional
     :param use_cold_l2: Whether to use circular buffer strategy to ensure cold L2 cache, defaults to False.
     :type use_cold_l2: bool, optional
-    :param benchmark: Whether to only benchmark the kernel, defaults to False.
-    :type benchmark: bool, optional
+    :param benchmark: Benchmark mode - "default" uses CUDA events, "cupti" uses CUPTI profiler, defaults to "default".
+    :type benchmark: str, optional
+    :param init_normal: Whether to initialize tensors using normal distribution
+        instead of uniform random, defaults to False.
+    :type init_normal: bool, optional
+    :param normal_mean: Mean for normal distribution initialization, defaults to 0.0.
+    :type normal_mean: float, optional
+    :param normal_std: Standard deviation for normal distribution initialization,
+        defaults to 1.0.
+    :type normal_std: float, optional
+
     :raises RuntimeError: If CUDA GPU is not available.
     :raises ValueError: If the configuration is invalid or unsupported by the kernel.
     :return: Execution time of the GEMM kernel.
@@ -1601,7 +1653,16 @@ def run(
 
     # Run and verify BMM with torch
     a_f32, b_f32, c_f32, a_storage, b_storage, c_storage = prepare_tensors(
-        mnkl, ab_dtype, ab_dtype, c_dtype, a_major, b_major, c_major
+        mnkl,
+        ab_dtype,
+        ab_dtype,
+        c_dtype,
+        a_major,
+        b_major,
+        c_major,
+        init_random=not init_normal,
+        normal_mean=normal_mean,
+        normal_std=normal_std,
     )
 
     leading_dim_a = 2 if a_major == "k" else 1
@@ -1619,6 +1680,13 @@ def run(
         c_storage, c_dtype, leading_dim_c, source_f32_tensor=c_f32
     )
 
+    print("Compile Blackwell Persistent Dense GEMM with:")
+    print(f"ab_dtype: {ab_dtype}, c_dtype: {c_dtype}, acc_dtype: {acc_dtype}")
+    print(f"a_major: {a_major}, b_major: {b_major}, c_major: {c_major}")
+    print(f"mma_tiler_mn: {mma_tiler_mn}, cluster_shape_mn: {cluster_shape_mn}")
+    print(f"use_2cta_instrs: {use_2cta_instrs}, use_tma_store: {use_tma_store}")
+    print(f"swizzle_size: {swizzle_size}, raster_along: {raster_along}")
+
     compiled_fn = compile_bmm(
         mnkl,
         a_,
@@ -1634,6 +1702,8 @@ def run(
         use_2cta_instrs,
         use_tma_store,
         epilogue_op=lambda x: x,
+        swizzle_size=swizzle_size,
+        raster_along=raster_along,
     )
 
     print("Running Blackwell Persistent Dense GEMM test with:")
@@ -1649,7 +1719,6 @@ def run(
         compiled_fn(a_, b_, c_, current_stream)
 
         # Manually quantize to be comparable
-        # Use float32 source data for reference calculation
         ref = (
             torch.bmm(a_f32, b_f32)
             .to(dtype=torch_dtype(c_dtype))
@@ -1662,10 +1731,14 @@ def run(
             rtol=1e-03,
         )
 
-    if not benchmark:
+    if benchmark == "none":
         return 0
 
     def generate_tensors():
+        # Use init_normal from outer scope, but force random init for Int8/Uint8 types
+        use_normal_init = init_normal and (
+            ab_dtype not in [cutlass.Int8, cutlass.Uint8]
+        )
         a_f32, b_f32, c_f32, a_st, b_st, c_st = prepare_tensors(
             mnkl,
             ab_dtype,
@@ -1674,6 +1747,9 @@ def run(
             a_major,
             b_major,
             c_major,
+            init_random=not use_normal_init,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
         )
         a_ = create_cute_tensor_for_fp8(
             a_st, ab_dtype, leading_dim_a, source_f32_tensor=a_f32
@@ -1698,18 +1774,17 @@ def run(
         )
 
     # Return execution time in microseconds
-    return testing.benchmark(
+    exec_time = testing.benchmark(
         compiled_fn,
         workspace_generator=generate_tensors,
         workspace_count=workspace_count,
         stream=current_stream,
         warmup_iterations=warmup_iterations,
         iterations=iterations,
+        use_cupti=benchmark == "cupti",
     )
-
-
-def compute_tflops(time_ns, m, n, k):
-    return 2.0 * m * n * k / time_ns / 1000.0
+    print(f"[DSL INFO] Execution time: {exec_time} microseconds per iteration")
+    return exec_time
 
 
 
@@ -1733,26 +1808,13 @@ def prepare_parser():
         default=(256, 256, 512, 1),
         help="mnkl dimensions (comma-separated)",
     )
-    parser.add_argument(
-        "--cluster_shape_mn",
-        type=_parse_comma_separated_ints,
-        default=(1, 1),
-        help="Cluster shape (comma-separated)",
-    )
     parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.TFloat32)
     parser.add_argument("--c_dtype", type=cutlass.dtype, default=cutlass.Float32)
     parser.add_argument("--acc_dtype", type=cutlass.dtype, default=cutlass.Float32)
-    parser.add_argument(
-        "--use_2cta_instrs",
-        action="store_true",
-        help="Enable 2CTA MMA instructions feature",
-    )
+
     parser.add_argument("--a_major", choices=["k", "m"], type=str, default="k")
     parser.add_argument("--b_major", choices=["k", "n"], type=str, default="k")
     parser.add_argument("--c_major", choices=["n", "m"], type=str, default="n")
-    parser.add_argument(
-        "--use_tma_store", action="store_true", help="Use tma store or not"
-    )
     parser.add_argument(
         "--tolerance", type=float, default=1e-01, help="Tolerance for validation"
     )
@@ -1761,10 +1823,14 @@ def prepare_parser():
         type=str,
         default="default",
         choices=[
+            "cupti",
             "default",
             "none",
         ],
-        help="Benchmark the kernel with nsight or default (cute.testing.benchmark) or none",
+        help="Benchmark the kernel with nsight or default (cutlass.testing.benchmark) or none",
+    )
+    parser.add_argument(
+        "--skip_ref_check", action="store_true", help="Skip reference checking"
     )
     parser.add_argument(
         "--warmup_iterations", type=int, default=0, help="Warmup iterations"
@@ -1776,20 +1842,42 @@ def prepare_parser():
         help="Number of iterations to run the kernel",
     )
     parser.add_argument(
-        "--skip_ref_check", action="store_true", help="Skip reference checking"
-    )
-    parser.add_argument(
         "--use_cold_l2",
         action="store_true",
         default=False,
         help="Use circular buffer tensor sets to ensure L2 cold cache",
     )
+    parser.add_argument(
+        "--use_cupti",
+        action="store_true",
+        default=False,
+        help="Use cupti to measure the performance",
+    )
+    testing.add_tensor_init_args(parser, supports_int_dtypes=True)
 
     return parser
 
 
 if __name__ == "__main__":
     parser = prepare_parser()
+
+    # Kernel Configurations
+    parser.add_argument(
+        "--use_tma_store", action="store_true", help="Use tma store or not"
+    )
+    parser.add_argument(
+        "--cluster_shape_mn",
+        type=_parse_comma_separated_ints,
+        default=(1, 1),
+        help="Cluster shape (comma-separated)",
+    )
+
+    parser.add_argument(
+        "--use_2cta_instrs",
+        action="store_true",
+        help="Enable 2CTA MMA instructions feature",
+    )
+
     parser.add_argument(
         "--mma_tiler_mn",
         type=_parse_comma_separated_ints,
@@ -1797,7 +1885,23 @@ if __name__ == "__main__":
         help="Mma tile shape (comma-separated)",
     )
 
+    parser.add_argument(
+        "--swizzle_size",
+        type=int,
+        default=1,
+        help="Swizzling size in the unit of cluster for improving L2 cache hit rate",
+    )
+    parser.add_argument(
+        "--raster_order",
+        type=str,
+        choices=["m", "n"],
+        default="m",
+        help="Rasterization order of clusters",
+    )
+
     args = parser.parse_args()
+
+    testing.validate_tensor_init_args(args, parser)
 
     if len(args.mnkl) != 4:
         parser.error("--mnkl must contain exactly 4 values")
@@ -1808,7 +1912,7 @@ if __name__ == "__main__":
     if len(args.cluster_shape_mn) != 2:
         parser.error("--cluster_shape_mn must contain exactly 2 values")
 
-    print(f"[DSL INFO] Compiling Blackwell Persistent Dense GEMM with:")
+    print("[DSL INFO] Compiling Blackwell Persistent Dense GEMM with:")
     print(
         f"[DSL INFO] A dtype: {args.ab_dtype}, B dtype: {args.c_dtype}, C dtype: {args.acc_dtype}, Acc dtype: {args.acc_dtype}"
     )
@@ -1832,6 +1936,8 @@ if __name__ == "__main__":
         args.c_major,
         args.mma_tiler_mn,
         args.cluster_shape_mn,
+        args.swizzle_size,
+        args.raster_order,
         args.use_2cta_instrs,
         args.use_tma_store,
         args.tolerance,
@@ -1839,6 +1945,9 @@ if __name__ == "__main__":
         args.iterations,
         args.skip_ref_check,
         args.use_cold_l2,
-        args.benchmark == "default",
+        args.benchmark,
+        args.init_normal,
+        args.normal_mean,
+        args.normal_std,
     )
     print("PASS")

--- a/examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py
@@ -36,13 +36,14 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.cute.testing as testing
+from cutlass import testing
 import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, tcgen05
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.torch as cutlass_torch
+
 
 """
 A grouped GEMM example for the NVIDIA Blackwell SM100 architecture using CUTE DSL
@@ -59,7 +60,7 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/blackwell/grouped_gemm.py                                                 \
+    python examples/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py                                                 \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                \
       --mma_tiler_mn 128,64 --cluster_shape_mn 1,1                                            \
       --problem_sizes_mnkl "(8192,1280,32,1),(16,384,1536,1),(640,1280,16,1),(640,160,16,1)"  \
@@ -73,7 +74,7 @@ To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/blackwell/grouped_gemm.py                                             \
+    ncu python examples/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py                                             \
       --ab_dtype Float16 --c_dtype Float16 --acc_dtype Float32                                \
       --mma_tiler_mn 128,64 --cluster_shape_mn 1,1                                            \
       --problem_sizes_mnkl "(8192,1280,32,1),(16,384,1536,1),(640,1280,16,1),(640,160,16,1)"  \
@@ -97,7 +98,8 @@ class GroupedGemmKernel:
         use_2cta_instrs: bool,
         mma_tiler_mn: tuple[int, int],
         cluster_shape_mn: tuple[int, int],
-        tensormap_update_mode: utils.TensorMapUpdateMode = utils.TensorMapUpdateMode.SMEM,
+        tensormap_update_mode: cutlass.tensor_utils.TensorMapUpdateMode = cutlass.tensor_utils.TensorMapUpdateMode.SMEM,
+        use_cached_problem_shapes: bool = True,
     ):
         """Initializes the configuration for a Blackwell grouped GEMM kernel.
 
@@ -119,7 +121,9 @@ class GroupedGemmKernel:
         :param cluster_shape_mn: tuple (ClusterM, ClusterN) shape of the cluster.
         :type cluster_shape_mn: tuple[int, int]
         :param tensormap_update_mode: Mode for updating the tensormap (GMEM or SMEM), defaults to SMEM.
-        :type tensormap_update_mode: utils.TensorMapUpdateMode, optional
+        :type tensormap_update_mode: cutlass.tensor_utils.TensorMapUpdateMode, optional
+        :param use_cached_problem_shapes: Enable double-buffered caching of problem shapes, defaults to True.
+        :type use_cached_problem_shapes: bool, optional
         """
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
@@ -133,8 +137,9 @@ class GroupedGemmKernel:
         self.tensormap_update_mode = tensormap_update_mode
         # Delegate tensormap ab initialization to MMA warp when SMEM mode is used for better latency hiding
         self.delegate_tensormap_ab_init = (
-            tensormap_update_mode == utils.TensorMapUpdateMode.SMEM
+            tensormap_update_mode == cutlass.tensor_utils.TensorMapUpdateMode.SMEM
         )
+        self.use_cached_problem_shapes = use_cached_problem_shapes
 
         self.num_mcast_ctas_a = 1
         self.num_mcast_ctas_b = 1
@@ -151,8 +156,15 @@ class GroupedGemmKernel:
         )
         self.mma_warp_id = 4
         self.tma_warp_id = 5
+        self.scheduler_warp_id = 6
+
         self.threads_per_cta = 32 * len(
-            (self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id)
+            (
+                self.scheduler_warp_id,
+                self.mma_warp_id,
+                self.tma_warp_id,
+                *self.epilog_warp_id,
+            )
         )
         # Set barrier for epilog sync, tmem ptr sync and tensormap update sync
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -168,7 +180,7 @@ class GroupedGemmKernel:
             barrier_id=3,
             num_threads=32 * (len(self.epilog_warp_id) + 1),
         )
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         self.num_tma_load_bytes = 0
 
     def _setup_attributes(self):
@@ -181,6 +193,7 @@ class GroupedGemmKernel:
         # Configure tiled mma
         tiled_mma = sm100_utils.make_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.acc_dtype,
@@ -230,6 +243,7 @@ class GroupedGemmKernel:
             self.num_acc_stage,
             self.num_ab_stage,
             self.num_epi_stage,
+            self.num_sched_stage,
         ) = self._compute_stages(
             tiled_mma,
             self.mma_tiler,
@@ -340,9 +354,13 @@ class GroupedGemmKernel:
         self.b_dtype = initial_b.element_type
         self.c_dtype = initial_c.element_type
 
-        self.a_major_mode = utils.LayoutEnum.from_tensor(initial_a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(initial_b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(initial_c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            initial_a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            initial_b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(initial_c)
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
             raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
 
@@ -350,6 +368,7 @@ class GroupedGemmKernel:
         self._setup_attributes()
 
         tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.a_dtype,
             self.a_dtype,
             self.a_major_mode,
             self.b_major_mode,
@@ -409,7 +428,8 @@ class GroupedGemmKernel:
         self.buffer_align_bytes = 1024
         self.size_tensormap_in_i64 = (
             0
-            if self.tensormap_update_mode == utils.TensorMapUpdateMode.GMEM
+            if self.tensormap_update_mode
+            == cutlass.tensor_utils.TensorMapUpdateMode.GMEM
             else GroupedGemmKernel.num_tensormaps
             * GroupedGemmKernel.bytes_per_tensormap
             // 8
@@ -421,8 +441,13 @@ class GroupedGemmKernel:
             tensormap_buffer: cute.struct.MemRange[
                 cutlass.Int64, self.size_tensormap_in_i64
             ]
+            tile_info: cute.struct.MemRange[
+                cutlass.Int32, 9 * self.num_sched_stage
+            ]  # 9 member variables in GroupSearchResult
             ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
             ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            tile_info_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            tile_info_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
             acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
             tmem_dealloc_mbar: cutlass.Int64
@@ -539,14 +564,14 @@ class GroupedGemmKernel:
         #
         # Alloc and init: tensormap buffer, a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tensormap_a_smem_ptr = None
         tensormap_b_smem_ptr = None
         tensormap_c_smem_ptr = None
         if cutlass.const_expr(
-            self.tensormap_update_mode == utils.TensorMapUpdateMode.SMEM
+            self.tensormap_update_mode == cutlass.tensor_utils.TensorMapUpdateMode.SMEM
         ):
             tensormap_smem_ptr = storage.tensormap_buffer.data_ptr()
             tensormap_a_smem_ptr = tensormap_smem_ptr
@@ -559,10 +584,7 @@ class GroupedGemmKernel:
 
         #  init barrier for loading A, B with TMA
         ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
-        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread, num_tma_producer
-        )
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Warp)
         ab_pipeline = pipeline.PipelineTmaUmma.create(
             barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
             num_stages=self.num_ab_stage,
@@ -570,8 +592,25 @@ class GroupedGemmKernel:
             consumer_group=ab_pipeline_consumer_group,
             tx_count=self.num_tma_load_bytes,
             cta_layout_vmnk=cluster_layout_vmnk,
+            enable_multicast_signaling=True,
             defer_sync=True,
         )
+
+        # init barrier for scheduler
+        num_tile_info_pipeline_consumer_threads = (
+            self.threads_per_cta - 32  # scheduler pipeline threads
+        )
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.tile_info_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_sched_stage,  # self.num_tile_info_stage
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 32 * 1),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                num_tile_info_pipeline_consumer_threads,
+            ),
+            defer_sync=True,
+        )
+
         # Accumulator barrier init
         acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         num_acc_consumer_threads = len(self.epilog_warp_id) * (
@@ -589,7 +628,7 @@ class GroupedGemmKernel:
             defer_sync=True,
         )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -615,6 +654,12 @@ class GroupedGemmKernel:
         sB = storage.sB.get_tensor(
             b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
         )
+        # Tile information
+        sTile_info = storage.tile_info.get_tensor(
+            cute.make_layout(
+                (9, self.num_sched_stage), stride=(1, 9)
+            )  # 9 member variables of group search result
+        )
 
         #
         # Compute multicast mask for A/B buffer full and empty
@@ -630,11 +675,7 @@ class GroupedGemmKernel:
                 cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
             )
             ab_empty_mcast_mask = a_full_mcast_mask | b_full_mcast_mask
-        acc_full_mcast_mask = None
         if cutlass.const_expr(use_2cta_instrs):
-            acc_full_mcast_mask = cute.make_layout_image_mask(
-                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mode=0
-            )
             block_in_cluster_coord_vmnk_peer = (
                 block_in_cluster_coord_vmnk[0] ^ 1,
                 *block_in_cluster_coord_vmnk[1:],
@@ -736,7 +777,7 @@ class GroupedGemmKernel:
             bid[2] * grid_dim[1] * grid_dim[0] + bid[1] * grid_dim[0] + bid[0]
         )
 
-        tensormap_manager = utils.TensorMapManager(
+        tensormap_manager = cutlass.tensor_utils.TensorMapManager(
             self.tensormap_update_mode, GroupedGemmKernel.bytes_per_tensormap
         )
         tensormap_a_ptr = tensormap_manager.get_tensormap_ptr(
@@ -750,7 +791,7 @@ class GroupedGemmKernel:
         )
         # Setup tensormap initialization pointer based on the mode
         if cutlass.const_expr(
-            self.tensormap_update_mode == utils.TensorMapUpdateMode.SMEM
+            self.tensormap_update_mode == cutlass.tensor_utils.TensorMapUpdateMode.SMEM
         ):
             tensormap_a_init_ptr = tensormap_a_smem_ptr
             tensormap_b_init_ptr = tensormap_b_smem_ptr
@@ -761,49 +802,56 @@ class GroupedGemmKernel:
             tensormap_c_init_ptr = tensormap_c_ptr
 
         #
-        # Persistent tile scheduling loop
-        #
-        # When the problem shapes are on device, we launch one CTA per SM.
-        # The if condition later prevents the warps from extra CTAs from doing any work.
-        tile_sched = utils.StaticPersistentGroupTileScheduler.create(
-            tile_sched_params,
-            bid,
-            grid_dim,
-            self.cluster_tile_shape_mnk,
-            utils.create_initial_search_state(),
-            group_count,
-            problem_sizes_mnkl,
-        )
-        initial_work_tile_info = tile_sched.initial_work_tile_info()
-
-        #
         # Specialized TMA load warp
         #
-        if warp_idx == self.tma_warp_id and initial_work_tile_info.is_valid_tile:
-            # Initialize tensormaps for A, B
-            if cutlass.const_expr(self.delegate_tensormap_ab_init == False):
-                tensormap_manager.init_tensormap_from_atom(
-                    tma_atom_a, tensormap_a_init_ptr, self.tma_warp_id
-                )
-                tensormap_manager.init_tensormap_from_atom(
-                    tma_atom_b, tensormap_b_init_ptr, self.tma_warp_id
-                )
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_sched_stage
+            )
+            # Create tile scheduler
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+            group_search_result = work_tile.group_search_result
+            is_valid_tile = work_tile.is_valid_tile
+
+            if is_valid_tile:
+                # Initialize tensormaps for A, B
+                if cutlass.const_expr(self.delegate_tensormap_ab_init == False):
+                    tensormap_manager.init_tensormap_from_atom(
+                        tma_atom_a, tensormap_a_init_ptr, self.tma_warp_id
+                    )
+                    tensormap_manager.init_tensormap_from_atom(
+                        tma_atom_b, tensormap_b_init_ptr, self.tma_warp_id
+                    )
 
             tensormap_init_done = cutlass.Boolean(False)
             # group index of last tile
             last_group_idx = cutlass.Int32(-1)
 
-            work_tile = initial_work_tile_info
             ab_producer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer, self.num_ab_stage
             )
 
-            while work_tile.is_valid_tile:
-                grouped_gemm_cta_tile_info = work_tile.group_search_result
-
-                cur_k_tile_cnt = grouped_gemm_cta_tile_info.cta_tile_count_k
+            while is_valid_tile:
+                cur_k_tile_cnt = group_search_result.cta_tile_count_k
                 is_k_tile_cnt_zero = cur_k_tile_cnt == 0
-                cur_group_idx = grouped_gemm_cta_tile_info.group_idx
+                cur_group_idx = group_search_result.group_idx
+
                 # Do not load any data if cur_k_tile_cnt is 0
                 if not is_k_tile_cnt_zero:
                     is_group_changed = cur_group_idx != last_group_idx
@@ -813,9 +861,9 @@ class GroupedGemmKernel:
                             cur_group_idx,
                             self.a_dtype,
                             (
-                                grouped_gemm_cta_tile_info.problem_shape_m,
-                                grouped_gemm_cta_tile_info.problem_shape_n,
-                                grouped_gemm_cta_tile_info.problem_shape_k,
+                                group_search_result.problem_shape_m,
+                                group_search_result.problem_shape_n,
+                                group_search_result.problem_shape_k,
                             ),
                             strides_abc,
                             ptrs_abc,
@@ -825,9 +873,9 @@ class GroupedGemmKernel:
                             cur_group_idx,
                             self.b_dtype,
                             (
-                                grouped_gemm_cta_tile_info.problem_shape_m,
-                                grouped_gemm_cta_tile_info.problem_shape_n,
-                                grouped_gemm_cta_tile_info.problem_shape_k,
+                                group_search_result.problem_shape_m,
+                                group_search_result.problem_shape_n,
+                                group_search_result.problem_shape_k,
                             ),
                             strides_abc,
                             ptrs_abc,
@@ -849,9 +897,9 @@ class GroupedGemmKernel:
                         )
 
                     mma_tile_coord_mnl = (
-                        grouped_gemm_cta_tile_info.cta_tile_idx_m
+                        group_search_result.cta_tile_idx_m
                         // cute.size(tiled_mma.thr_id.shape),
-                        grouped_gemm_cta_tile_info.cta_tile_idx_n,
+                        group_search_result.cta_tile_idx_n,
                         0,
                     )
 
@@ -898,7 +946,7 @@ class GroupedGemmKernel:
                             mcast_mask=a_full_mcast_mask,
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_a_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
                         cute.copy(
@@ -911,7 +959,7 @@ class GroupedGemmKernel:
                             mcast_mask=b_full_mcast_mask,
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_b_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
 
@@ -929,9 +977,32 @@ class GroupedGemmKernel:
                             self.tensormap_ab_init_barrier.arrive_and_wait()
                         tensormap_manager.fence_tensormap_initialization()
                         tensormap_init_done = True
-                # Advance to next tile
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+
+                # Get the next tile information from the scheduler warp
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                # consume the work tile info from the shmem
+                cur_sTile = sTile_info[(None, tile_info_consumer_state.index)]
+
+                # Reassembling the work tile information
+                work_tile_info = cute.make_rmem_tensor(
+                    cur_sTile.shape, cur_sTile.element_type
+                )
+                cute.autovec_copy(cur_sTile, work_tile_info)
+
+                # release the barrier for producer to proceed
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                is_valid_tile = work_tile_info[0] == 1
+                group_search_result = utils.GroupSearchResult(
+                    work_tile_info[1],
+                    work_tile_info[2],
+                    work_tile_info[3],
+                    work_tile_info[4],
+                    work_tile_info[5],
+                    work_tile_info[6],
+                    work_tile_info[7],
+                )
                 last_group_idx = cur_group_idx
 
             #
@@ -939,10 +1010,61 @@ class GroupedGemmKernel:
             #
             ab_pipeline.producer_tail(ab_producer_state)
 
+        # Schedule warp
+        if warp_idx == self.scheduler_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            # Create tile scheduler
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+
+            tile_info_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_sched_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # query next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                # acquire tile info pipeline
+                tile_info_pipeline.producer_acquire(tile_info_producer_state)
+
+                # store the group search result to the shmem
+                with cute.arch.elect_one():
+                    cur_sTile_info = sTile_info[(None, tile_info_producer_state.index)]
+                    cur_sTile_info[0] = cutlass.Int32(work_tile.is_valid_tile)
+                    cur_sTile_info[1] = work_tile.group_search_result.group_idx
+                    cur_sTile_info[2] = work_tile.group_search_result.cta_tile_idx_m
+                    cur_sTile_info[3] = work_tile.group_search_result.cta_tile_idx_n
+                    cur_sTile_info[4] = work_tile.group_search_result.problem_shape_m
+                    cur_sTile_info[5] = work_tile.group_search_result.problem_shape_n
+                    cur_sTile_info[6] = work_tile.group_search_result.problem_shape_k
+                    cur_sTile_info[7] = work_tile.group_search_result.cta_tile_count_k
+                    cur_sTile_info[8] = tile_sched.num_tiles_executed
+
+                # commit tile info pipeline
+                tile_info_pipeline.producer_commit(tile_info_producer_state)
+                tile_info_producer_state.advance()
+
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
         #
         # Specialized MMA warp
         #
-        if warp_idx == self.mma_warp_id and initial_work_tile_info.is_valid_tile:
+        if warp_idx == self.mma_warp_id:
             #  Bar sync for retrieve tmem ptr from shared mem
             tmem.wait_for_alloc()
 
@@ -953,10 +1075,33 @@ class GroupedGemmKernel:
             # (MMA, MMA_M, MMA_N, STAGE)
             tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
 
+            # Persistent tile scheduling loop
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_sched_stage,  # self.num_tile_info_stage
+            )
+
             #
             # Persistent tile scheduling loop
             #
-            work_tile = initial_work_tile_info
+            # Create tile scheduler
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+            group_search_result = work_tile.group_search_result
+            is_valid_tile = work_tile.is_valid_tile
+
             ab_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_ab_stage
             )
@@ -965,14 +1110,10 @@ class GroupedGemmKernel:
             )
 
             # tile count we have searched
-            while work_tile.is_valid_tile:
-                cur_group_idx = work_tile.group_search_result.group_idx
-                problem_shape_k = work_tile.group_search_result.problem_shape_k
-
-                # MMA warp is only interested in number of tiles along K dimension
-                cur_k_tile_cnt = (
-                    problem_shape_k + self.cluster_tile_shape_mnk[2] - 1
-                ) // self.cluster_tile_shape_mnk[2]
+            while is_valid_tile:
+                cur_group_idx = group_search_result.group_idx
+                _problem_shape_k = group_search_result.problem_shape_k
+                cur_k_tile_cnt = group_search_result.cta_tile_count_k
                 is_k_tile_cnt_zero = cur_k_tile_cnt == 0
 
                 # (MMA, MMA_M, MMA_N)
@@ -1007,24 +1148,11 @@ class GroupedGemmKernel:
                             ab_consumer_state, peek_ab_full_status
                         )
                         # tCtAcc += tCrA * tCrB
-                        num_kblocks = cute.size(tCrA, mode=[2])
-                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
-                            kblock_coord = (
-                                None,
-                                None,
-                                kblock_idx,
-                                ab_consumer_state.index,
-                            )
-
-                            cute.gemm(
-                                tiled_mma,
-                                tCtAcc,
-                                tCrA[kblock_coord],
-                                tCrB[kblock_coord],
-                                tCtAcc,
-                            )
-                            # Enable accumulate on tCtAcc after first kblock
-                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        tile_crd = (None, None, None, ab_consumer_state.index)
+                        cute.gemm(
+                            tiled_mma, tCtAcc, tCrA[tile_crd], tCrB[tile_crd], tCtAcc
+                        )
 
                         # Async arrive AB buffer empty
                         ab_pipeline.consumer_release(ab_consumer_state)
@@ -1044,11 +1172,29 @@ class GroupedGemmKernel:
                         acc_pipeline.producer_commit(acc_producer_state)
                         acc_producer_state.advance()
 
-                #
-                # Advance to next tile
-                #
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                # consume the work tile info from the shmem
+                cur_sTile = sTile_info[(None, tile_info_consumer_state.index)]
+
+                # Reassembling the work tile information
+                work_tile_info = cute.make_rmem_tensor(
+                    cur_sTile.shape, cur_sTile.element_type
+                )
+                cute.autovec_copy(cur_sTile, work_tile_info)
+
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                is_valid_tile = work_tile_info[0] == 1
+                group_search_result = utils.GroupSearchResult(
+                    work_tile_info[1],
+                    work_tile_info[2],
+                    work_tile_info[3],
+                    work_tile_info[4],
+                    work_tile_info[5],
+                    work_tile_info[6],
+                    work_tile_info[7],
+                )
             #
             # Wait for accumulator buffer empty
             #
@@ -1057,23 +1203,52 @@ class GroupedGemmKernel:
         #
         # Specialized epilogue warps
         #
-        if warp_idx < self.mma_warp_id and initial_work_tile_info.is_valid_tile:
-            # initialize tensormap A, B for TMA warp
-            if cutlass.const_expr(self.delegate_tensormap_ab_init):
-                tensormap_manager.init_tensormap_from_atom(
-                    tma_atom_a, tensormap_a_init_ptr, self.epilog_warp_id[0]
-                )
-                tensormap_manager.init_tensormap_from_atom(
-                    tma_atom_b, tensormap_b_init_ptr, self.epilog_warp_id[0]
-                )
-                # signal tensormap initialization has finished
-                self.tensormap_ab_init_barrier.arrive_and_wait()
-            # initialize tensorap for C
-            tensormap_manager.init_tensormap_from_atom(
-                tma_atom_c,
-                tensormap_c_init_ptr,
-                self.epilog_warp_id[0],
+        if warp_idx < self.mma_warp_id:
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_sched_stage,
             )
+
+            #
+            # Persistent tile scheduling loop
+            #
+            # Create tile scheduler
+            tile_sched = utils.StaticPersistentGroupTileScheduler.create(
+                tile_sched_params,
+                bid,
+                grid_dim,
+                self.cluster_tile_shape_mnk,
+                utils.create_initial_search_state(),
+                group_count,
+                problem_sizes_mnkl,
+                use_cached_problem_shapes=self.use_cached_problem_shapes,
+            )
+            # Prefetch the problem shapes into caches
+            tile_sched.prefetch_problem_shapes()
+            # Get the initial tile information
+            work_tile = tile_sched.initial_work_tile_info()
+            group_search_result = work_tile.group_search_result
+            is_valid_tile = work_tile.is_valid_tile
+            num_tiles_executed = tile_sched.num_tiles_executed
+
+            if is_valid_tile:
+                if cutlass.const_expr(self.delegate_tensormap_ab_init):
+                    tensormap_manager.init_tensormap_from_atom(
+                        tma_atom_a, tensormap_a_init_ptr, self.epilog_warp_id[0]
+                    )
+                    tensormap_manager.init_tensormap_from_atom(
+                        tma_atom_b, tensormap_b_init_ptr, self.epilog_warp_id[0]
+                    )
+                    # signal tensormap initialization has finished
+                    self.tensormap_ab_init_barrier.arrive_and_wait()
+
+                # initialize tensormap for C (needed for both GMEM and SMEM modes)
+                tensormap_manager.init_tensormap_from_atom(
+                    tma_atom_c,
+                    tensormap_c_init_ptr,
+                    self.epilog_warp_id[0],
+                )
+
             # Alloc tensor memory buffer
             tmem.allocate(self.num_tmem_alloc_cols)
 
@@ -1111,17 +1286,14 @@ class GroupedGemmKernel:
                 bSG_gC_partitioned,
             ) = self.epilog_gmem_copy_and_partition(tma_atom_c, tCgC, epi_tile, sC)
 
-            #
-            # Persistent tile scheduling loop
-            #
+            if is_valid_tile:
+                # wait tensormap initialization complete before update
+                tensormap_manager.fence_tensormap_initialization()
 
-            work_tile = initial_work_tile_info
-
-            # wait tensormap initialization complete before update
-            tensormap_manager.fence_tensormap_initialization()
             acc_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
             )
+
             # Threads/warps participating in tma store pipeline
             c_producer_group = pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
@@ -1131,12 +1303,12 @@ class GroupedGemmKernel:
                 num_stages=self.num_epi_stage,
                 producer_group=c_producer_group,
             )
+
             # group index of last tile
             last_group_idx = cutlass.Int32(-1)
-            while work_tile.is_valid_tile:
-                grouped_gemm_cta_tile_info = work_tile.group_search_result
-                cur_group_idx = grouped_gemm_cta_tile_info.group_idx
-                cur_k_tile_cnt = grouped_gemm_cta_tile_info.cta_tile_count_k
+            while is_valid_tile:
+                cur_group_idx = group_search_result.group_idx
+                cur_k_tile_cnt = group_search_result.cta_tile_count_k
                 is_k_tile_cnt_zero = cur_k_tile_cnt == 0
                 is_group_changed = cur_group_idx != last_group_idx
                 # We still need to store 0s when k_tile_cnt is 0
@@ -1146,9 +1318,9 @@ class GroupedGemmKernel:
                         cur_group_idx,
                         self.c_dtype,
                         (
-                            grouped_gemm_cta_tile_info.problem_shape_m,
-                            grouped_gemm_cta_tile_info.problem_shape_n,
-                            grouped_gemm_cta_tile_info.problem_shape_k,
+                            group_search_result.problem_shape_m,
+                            group_search_result.problem_shape_n,
+                            group_search_result.problem_shape_k,
                         ),
                         strides_abc,
                         ptrs_abc,
@@ -1163,9 +1335,9 @@ class GroupedGemmKernel:
                     )
 
                 mma_tile_coord_mnl = (
-                    grouped_gemm_cta_tile_info.cta_tile_idx_m
+                    group_search_result.cta_tile_idx_m
                     // cute.size(tiled_mma.thr_id.shape),
-                    grouped_gemm_cta_tile_info.cta_tile_idx_n,
+                    group_search_result.cta_tile_idx_n,
                     0,
                 )
 
@@ -1202,7 +1374,7 @@ class GroupedGemmKernel:
                 # Store accumulator to global memory in subtiles
                 #
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
-                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                num_prev_subtiles = num_tiles_executed * subtile_cnt
                 for subtile_idx in range(subtile_cnt):
                     #
                     # Store C to shared memory
@@ -1243,7 +1415,7 @@ class GroupedGemmKernel:
                             bSG_gC[(None, subtile_idx)],
                             tma_desc_ptr=tensormap_manager.get_tensormap_ptr(
                                 tensormap_c_ptr,
-                                cute.AddressSpace.generic,
+                                cutlass.AddressSpace.generic,
                             ),
                         )
                         # Fence and barrier to make sure shared memory store is visible to TMA store
@@ -1258,11 +1430,30 @@ class GroupedGemmKernel:
                         acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
 
-                #
-                # Advance to next tile
-                #
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                # consume the work tile info from the shmem
+                cur_sTile = sTile_info[(None, tile_info_consumer_state.index)]
+
+                # Reassembling the work tile information
+                work_tile_info = cute.make_rmem_tensor(
+                    cur_sTile.shape, cur_sTile.element_type
+                )
+                cute.autovec_copy(cur_sTile, work_tile_info)
+
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                is_valid_tile = work_tile_info[0] == 1
+                group_search_result = utils.GroupSearchResult(
+                    work_tile_info[1],
+                    work_tile_info[2],
+                    work_tile_info[3],
+                    work_tile_info[4],
+                    work_tile_info[5],
+                    work_tile_info[6],
+                    work_tile_info[7],
+                )
+                num_tiles_executed = work_tile_info[8]
                 last_group_idx = cur_group_idx
 
             #
@@ -1317,7 +1508,7 @@ class GroupedGemmKernel:
                 f"dtype must be a type of cutlass.Numeric, got {type(dtype)}"
             )
         tensor_gmem_ptr = cute.make_ptr(
-            dtype, ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+            dtype, ptr_i64, cutlass.AddressSpace.gmem, assumed_align=16
         )
 
         strides_tensor_gmem = strides_abc[(group_idx, tensor_index, None)]
@@ -1501,7 +1692,7 @@ class GroupedGemmKernel:
         b_dtype: type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         smem_capacity: int,
         occupancy: int,
     ) -> tuple[int, int, int]:
@@ -1520,7 +1711,7 @@ class GroupedGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C in global memory.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param smem_capacity: Total available shared memory capacity in bytes.
         :type smem_capacity: int
         :param occupancy: Target number of CTAs per SM (occupancy).
@@ -1530,9 +1721,10 @@ class GroupedGemmKernel:
                  (accumulator stages, A/B operand stages, epilogue stages)
         :rtype: tuple[int, int, int]
         """
-        # Default accumulator and epilogue stages
+        # Default accumulator, epilogue and tile_info pipeline stages
         num_acc_stage = 2
         num_epi_stage = 2
+        num_sched_stage = 2
 
         # Calculate smem layout and size for one stage of A, B, and Epilogue
         a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
@@ -1579,7 +1771,7 @@ class GroupedGemmKernel:
             - occupancy * (GroupedGemmKernel.reserved_smem_bytes + epi_bytes)
         )
         num_epi_stage += remaining_smem // (occupancy * epi_bytes_per_stage)
-        return num_acc_stage, num_ab_stage, num_epi_stage
+        return num_acc_stage, num_ab_stage, num_epi_stage, num_sched_stage
 
     @staticmethod
     def _compute_grid(
@@ -1646,19 +1838,19 @@ class GroupedGemmKernel:
 
     @staticmethod
     def _get_tensormap_smem_bytes(
-        tensormap_update_mode: utils.TensorMapUpdateMode,
+        tensormap_update_mode: cutlass.tensor_utils.TensorMapUpdateMode,
     ) -> int:
         """Get the SMEM consumption for the tensormap buffer based on the update mode.
 
         :param tensormap_update_mode: Specifies whether tensormaps are updated in GMEM or SMEM.
-        :type tensormap_update_mode: utils.TensorMapUpdateMode
+        :type tensormap_update_mode: cutlass.tensor_utils.TensorMapUpdateMode
         :return: The shared memory bytes required for the tensormap buffer. Returns 0 if mode is GMEM.
         :rtype: int
         :raises ValueError: If an invalid tensormap update mode is provided.
         """
-        if tensormap_update_mode == utils.TensorMapUpdateMode.GMEM:
+        if tensormap_update_mode == cutlass.tensor_utils.TensorMapUpdateMode.GMEM:
             return 0
-        elif tensormap_update_mode == utils.TensorMapUpdateMode.SMEM:
+        elif tensormap_update_mode == cutlass.tensor_utils.TensorMapUpdateMode.SMEM:
             return (
                 GroupedGemmKernel.bytes_per_tensormap * GroupedGemmKernel.num_tensormaps
             )
@@ -1670,6 +1862,7 @@ class GroupedGemmKernel:
         tiled_mma: cute.TiledMma,
         mma_tiler: tuple[int, int, int],
         num_acc_stage: int,
+        arch: str = "sm_100",
     ) -> int:
         """
         Compute the number of tensor memory allocation columns.
@@ -1686,7 +1879,9 @@ class GroupedGemmKernel:
         """
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(
+            tCtAcc_fake, arch=arch
+        )
 
         return num_tmem_alloc_cols
 
@@ -1707,15 +1902,40 @@ def create_tensor_and_stride(
     dtype: type[cutlass.Numeric],
     is_dynamic_layout: bool = True,
     torch_tensor_cpu: torch.Tensor = None,
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
 ) -> tuple[int, torch.Tensor, cute.Tensor, torch.Tensor, tuple[int, int]]:
     """Create GPU tensor from either a new or existing CPU tensor.
 
     :param torch_tensor_cpu: Optional existing CPU tensor to reuse. If None, creates a new one.
     :type torch_tensor_cpu: torch.Tensor, optional
+    :param init_normal: Use normal distribution for initialization instead of random.
+    :type init_normal: bool, optional
+    :param normal_mean: Mean of normal distribution for initialization.
+    :type normal_mean: float, optional
+    :param normal_std: Standard deviation of normal distribution for initialization.
+    :type normal_std: float, optional
     """
     if torch_tensor_cpu is None:
-        # Create new CPU tensor
-        torch_tensor_cpu = cutlass_torch.matrix(l, mode0, mode1, is_mode0_major, dtype)
+        if init_normal:
+            # Create CPU tensor with normal distribution initialization
+            torch_dtype = cutlass_torch.dtype(dtype)
+            if is_mode0_major:
+                torch_tensor_cpu = torch.empty(
+                    (l, mode1, mode0), dtype=torch.float32
+                ).permute(2, 1, 0)
+            else:
+                torch_tensor_cpu = torch.empty(
+                    (l, mode0, mode1), dtype=torch.float32
+                ).permute(1, 2, 0)
+            torch_tensor_cpu.normal_(mean=normal_mean, std=normal_std)
+            torch_tensor_cpu = torch_tensor_cpu.to(dtype=torch_dtype)
+        else:
+            # Create new CPU tensor with default random initialization
+            torch_tensor_cpu = cutlass_torch.matrix(
+                l, mode0, mode1, is_mode0_major, dtype
+            )
 
     # Create GPU tensor from CPU tensor (new or existing)
     cute_tensor, torch_tensor = cutlass_torch.cute_tensor_like(
@@ -1732,12 +1952,16 @@ def create_tensor_and_stride(
 
 def create_tensors_for_all_groups(
     problem_sizes_mnkl: List[tuple[int, int, int, int]],
-    ab_dtype: Type[cutlass.Numeric],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
     c_dtype: Type[cutlass.Numeric],
     a_major: str,
     b_major: str,
     c_major: str,
     torch_fp32_tensors_abc: List[List[torch.Tensor]] = None,
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
 ) -> tuple[
     List[List[int]],
     List[List[torch.Tensor]],
@@ -1780,7 +2004,15 @@ def create_tensors_for_all_groups(
             tensor_fp32_a,
             stride_mk_a,
         ) = create_tensor_and_stride(
-            l, m, k, a_major == "m", ab_dtype, torch_tensor_cpu=existing_cpu_a
+            l,
+            m,
+            k,
+            a_major == "m",
+            a_dtype,
+            torch_tensor_cpu=existing_cpu_a,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
         )
         (
             ptr_b,
@@ -1789,7 +2021,15 @@ def create_tensors_for_all_groups(
             tensor_fp32_b,
             stride_nk_b,
         ) = create_tensor_and_stride(
-            l, n, k, b_major == "n", ab_dtype, torch_tensor_cpu=existing_cpu_b
+            l,
+            n,
+            k,
+            b_major == "n",
+            b_dtype,
+            torch_tensor_cpu=existing_cpu_b,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
         )
         (
             ptr_c,
@@ -1798,7 +2038,15 @@ def create_tensors_for_all_groups(
             tensor_fp32_c,
             stride_mn_c,
         ) = create_tensor_and_stride(
-            l, m, n, c_major == "m", c_dtype, torch_tensor_cpu=existing_cpu_c
+            l,
+            m,
+            n,
+            c_major == "m",
+            c_dtype,
+            torch_tensor_cpu=existing_cpu_c,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
         )
 
         # Only append to new_torch_fp32_tensors_abc if we created new CPU tensors
@@ -1840,18 +2088,33 @@ def run(
     mma_tiler_mn: tuple[int, int],
     cluster_shape_mn: tuple[int, int],
     use_2cta_instrs: bool,
-    tensormap_update_mode: utils.TensorMapUpdateMode,
+    tensormap_update_mode: cutlass.tensor_utils.TensorMapUpdateMode,
     tolerance: float,
     warmup_iterations: int,
     iterations: int,
     skip_ref_check: bool,
     use_cold_l2: bool = False,
+    use_cached_problem_shapes: bool = True,
+    init_normal: bool = False,
+    normal_mean: float = 0.0,
+    normal_std: float = 1.0,
     **kwargs,
 ):
     """Run grouped GEMM example with specified configurations.
 
     :param use_cold_l2: Whether to use circular buffer strategy to ensure cold L2 cache, defaults to False
     :type use_cold_l2: bool, optional
+    :param use_cached_problem_shapes: Enable double-buffered caching of problem
+        shapes for better performance with many small groups, defaults to True.
+    :type use_cached_problem_shapes: bool, optional
+    :param init_normal: Whether to initialize tensors using normal distribution
+        instead of uniform random, defaults to False.
+    :type init_normal: bool, optional
+    :param normal_mean: Mean for normal distribution initialization, defaults to 0.0.
+    :type normal_mean: float, optional
+    :param normal_std: Standard deviation for normal distribution initialization,
+        defaults to 1.0.
+    :type normal_std: float, optional
     :return: Execution time of the GEMM kernel in microseconds
     :rtype: float
     """
@@ -1869,6 +2132,7 @@ def run(
     print(f"Iterations: {iterations}")
     print(f"Skip reference checking: {skip_ref_check}")
     print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
+    print(f"Use cached problem shapes: {use_cached_problem_shapes}")
 
     # Skip unsupported types
     if ab_dtype not in {
@@ -1934,10 +2198,14 @@ def run(
     ) = create_tensors_for_all_groups(
         problem_sizes_mnkl,
         ab_dtype,
+        ab_dtype,
         c_dtype,
         a_major,
         b_major,
         c_major,
+        init_normal=init_normal,
+        normal_mean=normal_mean,
+        normal_std=normal_std,
     )
 
     # Setup inital tensors for TMA of A,B and C
@@ -1979,6 +2247,7 @@ def run(
         mma_tiler_mn,
         cluster_shape_mn,
         tensormap_update_mode,
+        use_cached_problem_shapes,
     )
 
     # layout (num_groups, 4):(4, 1)
@@ -2052,18 +2321,6 @@ def run(
     # Initialize Stream
     current_stream = cutlass_torch.default_stream()
 
-    # try to check CUDA version to decide the opt level
-    try:
-        from cutlass import CUDA_VERSION
-
-        opt_level = (
-            3
-            if CUDA_VERSION.major < 13
-            or (CUDA_VERSION.major == 13 and CUDA_VERSION.minor < 1)
-            else 2
-        )
-    except ImportError:
-        opt_level = 3
     # Compile grouped GEMM kernel
     compiled_grouped_gemm = cute.compile(
         grouped_gemm,
@@ -2078,7 +2335,6 @@ def run(
         tensor_of_tensormap,
         max_active_clusters,
         current_stream,
-        options=f"--opt-level {opt_level}",
     )
 
     if not skip_ref_check:
@@ -2122,11 +2378,15 @@ def run(
         ) = create_tensors_for_all_groups(
             problem_sizes_mnkl,
             ab_dtype,
+            ab_dtype,
             c_dtype,
             a_major,
             b_major,
             c_major,
             torch_fp32_tensors_abc,
+            init_normal=init_normal,
+            normal_mean=normal_mean,
+            normal_std=normal_std,
         )
 
         initial_cute_tensors_abc_workspace = [
@@ -2270,13 +2530,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--num_groups",
         type=int,
-        default=3,
+        default=4,
         help="Number of groups",
     )
     parser.add_argument(
         "--problem_sizes_mnkl",
         type=parse_comma_separated_tuples,
-        default=((128, 128, 128, 1), (512, 128, 128, 1), (128, 256, 128, 1)),
+        default=(
+            (128, 128, 128, 1),
+            (512, 128, 128, 1),
+            (128, 128, 128, 1),
+            (256, 256, 128, 1),
+        ),
         help="a tuple of problem sizes for each group (comma-separated tuples)",
     )
     parser.add_argument(
@@ -2334,8 +2599,18 @@ if __name__ == "__main__":
         default=False,
         help="Use circular buffer tensor sets to ensure L2 cold cache",
     )
+    parser.add_argument(
+        "--no_use_cached_problem_shapes",
+        action="store_true",
+        default=False,
+        help="Disable double-buffered caching of problem shapes. "
+        "By default, caching is enabled for better performance with many small groups.",
+    )
+    testing.add_tensor_init_args(parser, supports_int_dtypes=False)
 
     args = parser.parse_args()
+
+    testing.validate_tensor_init_args(args, parser)
 
     if (
         len(args.problem_sizes_mnkl) != 0
@@ -2358,9 +2633,9 @@ if __name__ == "__main__":
         parser.error("--tensormap_update_mode must be GMEM or SMEM")
 
     if args.tensormap_update_mode == "GMEM":
-        tensormap_update_mode = utils.TensorMapUpdateMode.GMEM
+        tensormap_update_mode = cutlass.tensor_utils.TensorMapUpdateMode.GMEM
     else:
-        tensormap_update_mode = utils.TensorMapUpdateMode.SMEM
+        tensormap_update_mode = cutlass.tensor_utils.TensorMapUpdateMode.SMEM
 
     torch.manual_seed(2025)
 
@@ -2383,5 +2658,9 @@ if __name__ == "__main__":
         args.iterations,
         args.skip_ref_check,
         args.use_cold_l2,
+        not args.no_use_cached_problem_shapes,
+        args.init_normal,
+        args.normal_mean,
+        args.normal_std,
     )
     print("PASS")

--- a/examples/python/CuTeDSL/helpers/cli_helper.py
+++ b/examples/python/CuTeDSL/helpers/cli_helper.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Command-line and configuration-printing helpers for the CuTe DSL examples.
+
+Most examples take the same problem-shape, dtype, layout and benchmark
+options, and echo them back in the same format.
+This module provides centralize location for common CLI helpers to
+add these options to an argparse.ArgumentParser.
+
+The adders are opt-in and take the values that legitimately differ (defaults,
+choices) as parameters. An example calls the groups it supports and declares the
+rest itself::
+
+    parser = argparse.ArgumentParser(description="Example of Dense GEMM on Blackwell.")
+    cli.add_mnkl_arg(parser)
+    cli.add_mma_tiler_arg(parser)
+    cli.add_cluster_shape_arg(parser)
+    cli.add_dtype_args(parser, ab=cutlass.Float16, c=cutlass.Float16)
+    cli.add_major_args(parser)
+    cli.add_benchmark_args(parser, tolerance=1e-02)
+    parser.add_argument("--use_2cta_instrs", action="store_true", ...)  # kernel-specific
+
+The print helpers mirror the same split: the shared header and benchmark block
+come from here, anything kernel-specific stays inline between them.
+"""
+
+import argparse
+from typing import Iterable, Mapping, Optional, Sequence, Tuple, Type
+
+import cutlass
+from cutlass.base_dsl.typing import Numeric
+
+#############################################################
+# argparse types
+#############################################################
+
+
+def comma_separated_ints(s: str) -> Tuple[int, ...]:
+    """argparse ``type`` for tuple options such as ``--mnkl 256,256,512,1``."""
+    try:
+        return tuple(int(x.strip()) for x in s.split(","))
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            "Invalid format. Expected comma-separated integers."
+        )
+
+
+def comma_separated_ints_of(count: int):
+    """:func:`comma_separated_ints` that also rejects the wrong number of values.
+
+    Use where a wrong-length tuple would otherwise fail deep in the kernel with
+    an unhelpful message.
+    """
+
+    def parse(s: str) -> Tuple[int, ...]:
+        values = comma_separated_ints(s)
+        if len(values) != count:
+            raise argparse.ArgumentTypeError(
+                f"Expected {count} comma-separated integers, got {len(values)}"
+            )
+        return values
+
+    return parse
+
+
+#############################################################
+# argument groups
+#############################################################
+
+
+def add_mnkl_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    default: Tuple[int, int, int, int] = (256, 256, 512, 1),
+    strict_length: bool = False,
+) -> None:
+    """Add ``--mnkl``. ``strict_length`` rejects anything but 4 values."""
+    parser.add_argument(
+        "--mnkl",
+        type=comma_separated_ints_of(4) if strict_length else comma_separated_ints,
+        default=default,
+        help="mnkl dimensions (comma-separated)",
+    )
+
+
+def add_mma_tiler_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    default: Tuple[int, int] = (128, 128),
+    choices: Optional[Sequence[Tuple[int, int]]] = None,
+    strict_length: bool = False,
+    help: str = "Mma tile shape (comma-separated)",
+) -> None:
+    """Add ``--mma_tiler_mn``."""
+    parser.add_argument(
+        "--mma_tiler_mn",
+        type=comma_separated_ints_of(2) if strict_length else comma_separated_ints,
+        default=default,
+        choices=choices,
+        help=help,
+    )
+
+
+def add_cluster_shape_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    default: Tuple[int, int] = (1, 1),
+    strict_length: bool = False,
+    help: str = "Cluster shape (comma-separated)",
+) -> None:
+    """Add ``--cluster_shape_mn``."""
+    parser.add_argument(
+        "--cluster_shape_mn",
+        type=comma_separated_ints_of(2) if strict_length else comma_separated_ints,
+        default=default,
+        help=help,
+    )
+
+
+def add_dtype_args(
+    parser: argparse.ArgumentParser,
+    *,
+    ab: Optional[Type[Numeric]] = None,
+    c: Optional[Type[Numeric]] = None,
+    acc: Optional[Type[Numeric]] = cutlass.Float32,
+    ab_choices: Optional[Sequence[Type[Numeric]]] = None,
+    acc_choices: Optional[Sequence[Type[Numeric]]] = None,
+) -> None:
+    """Add the ``--ab_dtype`` / ``--c_dtype`` / ``--acc_dtype`` trio.
+
+    Pass ``None`` for any of them to leave that flag out -- kernels that take
+    separate A and B dtypes declare their own ``--a_dtype``/``--b_dtype``.
+    """
+    if ab is not None:
+        parser.add_argument(
+            "--ab_dtype", type=cutlass.dtype, default=ab, choices=ab_choices
+        )
+    if c is not None:
+        parser.add_argument("--c_dtype", type=cutlass.dtype, default=c)
+    if acc is not None:
+        parser.add_argument(
+            "--acc_dtype", type=cutlass.dtype, default=acc, choices=acc_choices
+        )
+
+
+def add_major_args(
+    parser: argparse.ArgumentParser,
+    *,
+    a: Optional[Sequence[str]] = ("k", "m"),
+    b: Optional[Sequence[str]] = ("k", "n"),
+    c: Optional[Sequence[str]] = ("n", "m"),
+) -> None:
+    """Add ``--a_major`` / ``--b_major`` / ``--c_major``.
+
+    Each value is the list of layouts the kernel accepts; the first is the
+    default. Pass ``None`` to leave that flag out.
+    """
+    for name, choices in (("a", a), ("b", b), ("c", c)):
+        if choices is None:
+            continue
+        choices = list(choices)
+        parser.add_argument(
+            f"--{name}_major", choices=choices, type=str, default=choices[0]
+        )
+
+
+def add_benchmark_args(
+    parser: argparse.ArgumentParser,
+    *,
+    tolerance: Optional[float] = 1e-01,
+    iterations: int = 1,
+    warmup_iterations: int = 0,
+) -> None:
+    """Add the timing and validation flags every example shares.
+
+    ``--tolerance`` is skipped when ``tolerance`` is ``None``, for kernels whose
+    reference check is exact.
+    """
+    parser.add_argument(
+        "--warmup_iterations",
+        type=int,
+        default=warmup_iterations,
+        help="Warmup iterations",
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=iterations, help="Number of iterations"
+    )
+    parser.add_argument("--use_cold_l2", action="store_true", help="Use cold L2")
+    if tolerance is not None:
+        parser.add_argument(
+            "--tolerance",
+            type=float,
+            default=tolerance,
+            help="Tolerance for validation",
+        )
+    parser.add_argument(
+        "--skip_ref_check", action="store_true", help="Skip reference checking"
+    )
+
+
+#############################################################
+# configuration printing
+#############################################################
+
+
+def print_problem_config(
+    title: str,
+    mnkl=None,
+    *,
+    dtypes: Optional[Mapping[str, Type[Numeric]]] = None,
+    lines: Iterable[str] = (),
+    majors: Optional[Mapping[str, str]] = None,
+    mma_tiler_mn=None,
+    cluster_shape_mn=None,
+) -> None:
+    """Print the problem header shared by the examples.
+
+    :param mnkl: omitted when ``None`` -- grouped GEMMs list their per-group
+        shapes through ``lines`` instead of one problem size
+    :param dtypes: rendered as ``AB dtype: f16, C dtype: f16, Acc dtype: f32``
+    :param lines: printed verbatim after ``dtypes``, for kernels whose operand
+        set does not fit that one-line form (separate A/B dtypes, scale factors)
+    :param majors: rendered as ``Matrix majors - A: k, B: k, C: n``
+    """
+    print(f"Running {title} test with:")
+    if mnkl is not None:
+        print(f"mnkl: {mnkl}")
+    if dtypes:
+        print(", ".join(f"{name} dtype: {dt}" for name, dt in dtypes.items()))
+    for line in lines:
+        print(line)
+    if majors:
+        print(
+            "Matrix majors - "
+            + ", ".join(f"{name}: {major}" for name, major in majors.items())
+        )
+    if mma_tiler_mn is not None:
+        tiler_line = f"Mma Tiler (M, N): {mma_tiler_mn}"
+        if cluster_shape_mn is not None:
+            tiler_line += f", Cluster Shape (M, N): {cluster_shape_mn}"
+        print(tiler_line)
+
+
+def print_benchmark_config(
+    *,
+    warmup_iterations: int,
+    iterations: int,
+    skip_ref_check: bool,
+    use_cold_l2: bool,
+    tolerance: Optional[float] = None,
+) -> None:
+    """Print the timing/validation block that closes every example's header."""
+    if tolerance is not None:
+        print(f"Tolerance: {tolerance}")
+    print(f"Warmup iterations: {warmup_iterations}")
+    print(f"Iterations: {iterations}")
+    print(f"Skip reference checking: {skip_ref_check}")
+    print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")

--- a/examples/python/CuTeDSL/helpers/grouped_gemm_persistent_tile_scheduler.py
+++ b/examples/python/CuTeDSL/helpers/grouped_gemm_persistent_tile_scheduler.py
@@ -1,0 +1,1190 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import List, Optional, Tuple, Union
+
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Int32,
+    Integer,
+    extract_mlir_values,
+    new_from_mlir_values,
+    const_expr,
+    dsl_user_op,
+)
+from cutlass._mlir import ir
+from typing_extensions import deprecated
+
+from helpers.static_persistent_tile_scheduler import (
+    PersistentTileSchedulerParams,
+    StaticPersistentTileScheduler,
+    WorkTileInfo,
+)
+
+
+class GroupSearchResult:
+    """
+    The result of the group search for grouped gemm.
+
+    :param group_idx: The result group index
+    :type group_idx: Int32
+    :param cta_tile_idx_m: CTA tile index along M dimension after rasterization
+    :type cta_tile_idx_m: Int32
+    :param cta_tile_idx_n: CTA tile index along N dimension after rasterization
+    :type cta_tile_idx_n: Int32
+    :param problem_shape_m: The M dimension of the gemm problem
+    :type problem_shape_m: Int32
+    :param problem_shape_n: The N dimension of the gemm problem
+    :type problem_shape_n: Int32
+    :param problem_shape_k: The K dimension of the gemm problem
+    :type problem_shape_k: Int32
+    :param cta_tile_count_k: Number of tiles along K dimension
+    :type cta_tile_count_k: Int32
+    """
+
+    def __init__(
+        self,
+        group_idx: Int32,
+        cta_tile_idx_m: Int32,
+        cta_tile_idx_n: Int32,
+        problem_shape_m: Int32,
+        problem_shape_n: Int32,
+        problem_shape_k: Int32,
+        cta_tile_count_k: Int32,
+    ) -> None:
+        self.group_idx = group_idx
+        self.cta_tile_idx_m = cta_tile_idx_m
+        self.cta_tile_idx_n = cta_tile_idx_n
+        self.problem_shape_m = problem_shape_m
+        self.problem_shape_n = problem_shape_n
+        self.problem_shape_k = problem_shape_k
+        self.cta_tile_count_k = cta_tile_count_k
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = extract_mlir_values(self.group_idx)
+        values.extend(extract_mlir_values(self.cta_tile_idx_m))
+        values.extend(extract_mlir_values(self.cta_tile_idx_n))
+        values.extend(extract_mlir_values(self.problem_shape_m))
+        values.extend(extract_mlir_values(self.problem_shape_n))
+        values.extend(extract_mlir_values(self.problem_shape_k))
+        values.extend(extract_mlir_values(self.cta_tile_count_k))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "GroupSearchResult":
+        assert len(values) == 7
+        return GroupSearchResult(*tuple(values))
+
+
+class GroupedGemmGroupSearchState:
+    """
+    The state of group index search for grouped gemm.
+
+    The state will be initialized once and updated in every round of group index search.
+
+    :param start_group_idx: The group idx to start the search with
+    :type start_group_idx: Int32
+    :param tile_count_prev_group: Number of tiles before the matched group
+    :type tile_count_prev_group: Int32
+    :param tile_count_searched: Number of tiles we have searched. When the matched group
+                                is found, it records the number of tiles including the
+                                matched group
+    :type tile_count_searched: Int32
+    """
+
+    def __init__(
+        self,
+        start_group_idx: Int32,
+        tile_count_prev_group: Int32,
+        tile_count_searched: Int32,
+        found: Boolean,
+    ) -> None:
+        self.start_group_idx = start_group_idx
+        self.tile_count_prev_group = tile_count_prev_group
+        self.tile_count_searched = tile_count_searched
+        self.found = Boolean(found)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = extract_mlir_values(self.start_group_idx)
+        values.extend(extract_mlir_values(self.tile_count_prev_group))
+        values.extend(extract_mlir_values(self.tile_count_searched))
+        values.extend(extract_mlir_values(self.found))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "GroupedGemmGroupSearchState":
+        assert len(values) == 4
+        start_group_idx = new_from_mlir_values(self.start_group_idx, [values[0]])
+        tile_count_prev_group = new_from_mlir_values(
+            self.tile_count_prev_group, [values[1]]
+        )
+        tile_count_searched = new_from_mlir_values(
+            self.tile_count_searched, [values[2]]
+        )
+        found = new_from_mlir_values(self.found, [values[3]])
+        return GroupedGemmGroupSearchState(
+            start_group_idx, tile_count_prev_group, tile_count_searched, found
+        )
+
+
+def create_initial_search_state() -> GroupedGemmGroupSearchState:
+    """
+    Create an initial search state for grouped gemm.
+
+    :return: A new search state with initial values
+    :rtype: GroupedGemmGroupSearchState
+    """
+    return GroupedGemmGroupSearchState(
+        start_group_idx=Int32(0),
+        tile_count_prev_group=Int32(0),
+        tile_count_searched=Int32(0),
+        found=Boolean(False),
+    )
+
+
+# Grouped Work Tile Information
+class GroupedWorkTileInfo(WorkTileInfo):
+    """A class to represent information about a work tile.
+
+    :ivar tile_idx: The index of the tile.
+    :type tile_idx: cute.Coord
+    :ivar is_valid_tile: Whether the tile is valid.
+    :type is_valid_tile: Boolean
+    :ivar group_search_result: Group work tile information.
+    :type group_search_result: GroupSearchResult
+    """
+
+    def __init__(
+        self,
+        tile_idx: cute.Coord,
+        is_valid_tile: Boolean,
+        group_search_result: GroupSearchResult,
+    ):
+        super().__init__(tile_idx, is_valid_tile)
+        self.group_search_result = group_search_result
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.tile_idx)
+        values.extend(extract_mlir_values(self.is_valid_tile))
+        values.extend(extract_mlir_values(self.group_search_result))
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "GroupedWorkTileInfo":
+        if len(values) != 11:
+            raise ValueError("Length of mlir values extracted is incorrect.")
+        # Reconstruct tile_idx as a tuple -- WorkTileInfo.__init__ unpacks it
+        # into _tile_m, _tile_n, _tile_l.
+        new_tile_idx = (Int32(values[0]), Int32(values[1]), Int32(values[2]))
+        new_is_valid_tile = new_from_mlir_values(self._is_valid_tile, [values[3]])
+        new_group_search_result = new_from_mlir_values(
+            self.group_search_result, values[4:11]
+        )
+        return GroupedWorkTileInfo(
+            new_tile_idx, new_is_valid_tile, new_group_search_result
+        )
+
+
+# Static Persistent Grouped GEMM
+class StaticPersistentGroupTileScheduler(StaticPersistentTileScheduler):
+    """A scheduler for static persistent group-based tile execution in CUTLASS/CuTe
+    kernels.
+
+    :ivar params: Tile schedule related params, including cluster shape and
+                  problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar cluster_tile_shape_mnk: The shape of cluster tile as (m, n, k)
+    :type cluster_tile_shape_mnk: tuple[int, int, int]
+    :ivar search_state: The initial search state
+    :type search_state: GroupedGemmGroupSearchState
+    :ivar group_count: Number of groups in current grouped gemm problem
+    :type group_count: int
+    :ivar problem_shape_mnkl: Problem shape tensor for groups
+    :type problem_shape_mnkl: cute.Tensor
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+        cluster_tile_shape_mnk: tuple[int, int, int],
+        search_state: GroupedGemmGroupSearchState,
+        group_count: int,
+        problem_shape_mnkl: cute.Tensor,
+        cached_problem_shape_0: Tuple[Int32, Int32, Int32, Int32],
+        cached_problem_shape_1: Tuple[Int32, Int32, Int32, Int32],
+    ):
+        StaticPersistentTileScheduler.__init__(
+            self,
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+        self.group_count = group_count
+        self.lane_idx = cute.arch.lane_idx()
+        self.cluster_tile_shape_mnk = cluster_tile_shape_mnk
+        self.search_state = search_state
+        self.problem_shape_mnkl = problem_shape_mnkl
+
+        self.cached_problem_shape_0 = cached_problem_shape_0
+        self.cached_problem_shape_1 = cached_problem_shape_1
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.num_persistent_clusters)
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self._num_tiles_executed))
+        values.extend(extract_mlir_values(self.search_state))
+        values.extend(extract_mlir_values(self.problem_shape_mnkl))
+        values.extend(extract_mlir_values(self.cached_problem_shape_0))
+        values.extend(extract_mlir_values(self.cached_problem_shape_1))
+        values.extend(extract_mlir_values(self.params))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: list[ir.Value]
+    ) -> "StaticPersistentGroupTileScheduler":
+        if len(values) < 19:
+            raise ValueError("Length of mlir values extracted is incorrect.")
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(
+            self.cta_id_in_cluster, values[2:5]
+        )
+        new_num_tiles_executed = new_from_mlir_values(
+            self._num_tiles_executed, [values[5]]
+        )
+        search_state = new_from_mlir_values(self.search_state, values[6:10])
+        problem_shape_mnkl = new_from_mlir_values(self.problem_shape_mnkl, [values[10]])
+
+        cached_problem_shape_0 = (
+            Int32(values[11]),
+            Int32(values[12]),
+            Int32(values[13]),
+            Int32(values[14]),
+        )
+        cached_problem_shape_1 = (
+            Int32(values[15]),
+            Int32(values[16]),
+            Int32(values[17]),
+            Int32(values[18]),
+        )
+        params = new_from_mlir_values(self.params, values[19:])
+
+        return StaticPersistentGroupTileScheduler(
+            params,
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+            self.cluster_tile_shape_mnk,
+            search_state,
+            self.group_count,
+            problem_shape_mnkl,
+            cached_problem_shape_0,
+            cached_problem_shape_1,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        cluster_tile_shape_mnk: tuple[int, int, int],
+        initial_search_state: GroupedGemmGroupSearchState,
+        group_count: int,
+        problem_shape_mnkl: cute.Tensor,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentGroupTileScheduler":
+        """Initialize the static persistent group-based tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+        :param cluster_tile_shape_mnk: The shape of cluster tile as (m, n, k)
+        :type cluster_tile_shape_mnk: tuple[int, int, int]
+        :param initial_search_state: The initial search state
+        :type initial_search_state: GroupedGemmGroupSearchState
+        :param group_count: Number of groups in current grouped gemm problem
+        :type group_count: int
+        :param problem_shape_mnkl: Problem shape tensor for groups
+        :type problem_shape_mnkl: cute.Tensor
+
+        :return: A StaticPersistentGroupTileScheduler object.
+        :rtype: StaticPersistentGroupTileScheduler
+        """
+
+        has_distinct_fallback = getattr(params, "_has_distinct_fallback", False)
+        if const_expr(has_distinct_fallback):
+            active = params._select_active_params(params)
+        else:
+            active = params
+
+        bidx, bidy, bidz = block_idx
+
+        # Mixed-cluster bodies share the same grid but have different numbers of
+        # CTAs per cluster. Use the runtime cluster dimensions in each cloned body
+        # so its persistent-loop stride and CTA coordinates match the active shape.
+        if const_expr(has_distinct_fallback):
+            cdx, cdy, _ = params.runtime_cluster_dims()
+            num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // (cdx * cdy)
+            cta_id_in_cluster = (
+                Int32(bidx % cdx),
+                Int32(bidy % cdy),
+                Int32(0),
+            )
+        else:
+            num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+                active.cluster_shape_mn, loc=loc, ip=ip
+            )
+            cta_id_in_cluster = (
+                Int32(bidx % active.cluster_shape_mn[0]),
+                Int32(bidy % active.cluster_shape_mn[1]),
+                Int32(0),
+            )
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        cached_problem_shape_0 = (
+            Int32(-1),
+            Int32(-1),
+            Int32(-1),
+            Int32(-1),
+        )
+        cached_problem_shape_1 = (
+            Int32(-1),
+            Int32(-1),
+            Int32(-1),
+            Int32(-1),
+        )
+
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentGroupTileScheduler(
+            active,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+            cluster_tile_shape_mnk,
+            initial_search_state,
+            group_count,
+            problem_shape_mnkl,
+            cached_problem_shape_0,
+            cached_problem_shape_1,
+        )
+
+    @property
+    def num_tiles_executed(self) -> Int32:
+        return self._num_tiles_executed
+
+    @num_tiles_executed.setter
+    def num_tiles_executed(self, value: Int32) -> None:
+        self._num_tiles_executed = value
+
+    @dsl_user_op
+    @cute.jit
+    def _prefix_sum(
+        self,
+        value_per_thread: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Int32:
+        """
+        Perform prefix sum within a full warp.
+
+        :param value_per_thread: The value for this thread to contribute to the prefix
+                                 sum
+        :type value_per_thread: Int32
+        :return: The prefix sum result for this thread
+        :rtype: Int32
+        """
+        clamp_value = 0
+        idx = 1
+        sum_per_thread = value_per_thread
+        while const_expr(idx < cute.arch.WARP_SIZE):
+            value = cute.arch.shuffle_sync_up(
+                sum_per_thread, idx, mask_and_clamp=clamp_value, loc=loc, ip=ip
+            )
+            if self.lane_idx >= idx:
+                sum_per_thread += value
+            idx = idx << 1
+        return sum_per_thread
+
+    @dsl_user_op
+    def _get_problem_for_group(
+        self,
+        problem_shape_mnkl: cute.Tensor,
+        group_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32, Int32, Int32]:
+        """
+        Load gemm problem (m,n,k,l) for the specified group from global memory to
+        register.
+
+        :param problem_shape_mnkl: Tensor in global memory with layout
+        :return: The problem shape tensor for the specified group
+        :rtype: Tuple[Int32, Int32, Int32, Int32]
+        """
+        cur_problem_mnkl = cute.make_rmem_tensor(
+            cute.make_layout(4), problem_shape_mnkl.element_type, loc=loc, ip=ip
+        )
+        cute.autovec_copy(
+            problem_shape_mnkl[(group_idx, None)], cur_problem_mnkl, loc=loc, ip=ip
+        )
+        return (
+            cur_problem_mnkl[0],
+            cur_problem_mnkl[1],
+            cur_problem_mnkl[2],
+            cur_problem_mnkl[3],
+        )
+
+    @dsl_user_op
+    @cute.jit
+    def prefetch_problem_shapes(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        if self.lane_idx < self.group_count:
+            cur_problem_mnkl = self._get_problem_for_group(
+                self.problem_shape_mnkl, self.lane_idx, loc=loc, ip=ip
+            )
+            self.cached_problem_shape_1 = cur_problem_mnkl
+
+    @dsl_user_op
+    def _get_cluster_tile_count_mn(
+        self,
+        problem_shape: Tuple[Int32, Int32, Int32, Int32],
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Int32:
+        """
+        Compute total cluster count.
+
+        :param problem_shape: Tensor containing problem shape (m, n, k, l)
+        :type problem_shape: Tuple[Int32, Int32, Int32, Int32]
+        :return: The total cluster tile count for M and N dimensions
+        :rtype: Int32
+        """
+        cur_ntile_m = (
+            problem_shape[0] + self.cluster_tile_shape_mnk[0] - 1  # type: ignore[operator]
+        ) // self.cluster_tile_shape_mnk[0]
+        cur_ntile_n = (
+            problem_shape[1] + self.cluster_tile_shape_mnk[1] - 1  # type: ignore[operator]
+        ) // self.cluster_tile_shape_mnk[1]
+        cur_ntile_mn = cur_ntile_m * cur_ntile_n
+        return cur_ntile_mn  # type: ignore[return-value]
+
+    @dsl_user_op
+    def _compute_cta_tile_coord(
+        self,
+        cluster_tile_idx: Int32,
+        cta_tile_coord_in_cluster: tuple,
+        cluster_tile_count_m: Int32,
+        cluster_tile_count_n: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> tuple:
+        """
+        Compute CTA tile indices along M and N dimensions based on the linear index
+        within a group.
+
+        It uses the AlongM mode to decompose the linear index onto M and N dimensions.
+
+        :param cluster_tile_idx: The linear index within a group
+        :type cluster_tile_idx: Int32
+        :param cta_tile_coord_in_cluster: CTA indices along M and N dimensions within a
+                                          cluster
+        :type cta_tile_coord_in_cluster: tuple of Int32
+        :param cluster_tile_count_m: The number of clusters along M dimension of the
+                                     matched group
+        :type cluster_tile_count_m: Int32
+        :param cluster_tile_count_n: The number of clusters along N dimension of the
+                                     matched group
+        :type cluster_tile_count_n: Int32
+        :return: A tuple containing CTA tile indices along M and N dimensions
+        :rtype: tuple of (Int32, Int32)
+        """
+        cluster_layout_mn = cute.make_layout(
+            (cluster_tile_count_m, cluster_tile_count_n), loc=loc, ip=ip
+        )
+        (mi, ni) = cluster_layout_mn.get_hier_coord(cluster_tile_idx)
+        cta_tile_idx_m = (
+            mi * self.params.cluster_shape_mn[0] + cta_tile_coord_in_cluster[0]
+        )
+        cta_tile_idx_n = (
+            ni * self.params.cluster_shape_mn[1] + cta_tile_coord_in_cluster[1]
+        )
+        return (cta_tile_idx_m, cta_tile_idx_n)
+
+    @dsl_user_op
+    @cute.jit
+    def _group_search(
+        self,
+        linear_idx: Int32,
+        problem_shape_mnkl: cute.Tensor,
+        init_group_idx: Int32,
+        init_tile_count_searched: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> GroupedGemmGroupSearchState:
+        """
+        Search which group the linear index belongs to.
+
+        :param linear_idx: The linear index to be decomposed
+        :type linear_idx: Int32
+        :param problem_shape_mnkl: Tensor containing gemm problem size (M, N, K, L) for
+                                   all groups
+        :type problem_shape_mnkl: cute.Tensor
+        :param init_group_idx: The group idx to start the search with
+        :type init_group_idx: Int32
+        :param init_tile_count_searched: The number of tiles we have searched
+        :type init_tile_count_searched: Int32
+        :return: The updated search state
+        :rtype: GroupedGemmGroupSearchState
+        """
+        c_0 = Int32(0).ir_value()
+        last_lane_idx = cute.arch.WARP_SIZE - 1
+
+        tile_count_searched = init_tile_count_searched
+        start_group_idx = init_group_idx
+        not_found = linear_idx >= tile_count_searched
+        start_not_found = not_found
+        tile_count_prev_group = self.search_state.tile_count_prev_group
+
+        while not_found and start_group_idx < self.group_count:
+            # get group to search for current lane
+            cur_group_idx = start_group_idx + self.lane_idx
+            # check if the group to be checked is out of range
+            inside_group_bound = cur_group_idx < self.group_count
+
+            # Rotate cache
+            self.cached_problem_shape_0 = self.cached_problem_shape_1
+
+            # Prefetch problem shape for next while iteration
+            next_prefetch_group_idx = (
+                start_group_idx + cute.arch.WARP_SIZE + self.lane_idx
+            )
+            if next_prefetch_group_idx < self.group_count:
+                self.cached_problem_shape_1 = self._get_problem_for_group(
+                    problem_shape_mnkl, next_prefetch_group_idx, loc=loc, ip=ip
+                )
+
+            cur_ntile_mn = c_0
+            if inside_group_bound:
+                # get problem size of current group
+                cur_problem_mnkl = self.cached_problem_shape_0
+                cur_ntile_mn = self._get_cluster_tile_count_mn(
+                    cur_problem_mnkl, loc=loc, ip=ip
+                )
+
+            # compute tile count from beginning to current group(included)
+            total_cluster_tile_count_ps_per_thread = self._prefix_sum(
+                cur_ntile_mn, loc=loc, ip=ip
+            )
+            cluster_tile_count_end_per_thread = (
+                total_cluster_tile_count_ps_per_thread + tile_count_searched
+            )
+
+            group_not_in_window = linear_idx >= cluster_tile_count_end_per_thread
+            hit_group_idx_in_search_window = cute.arch.popc(
+                cute.arch.vote_ballot_sync(group_not_in_window, loc=loc, ip=ip),
+                loc=loc,
+                ip=ip,
+            )
+            not_found = hit_group_idx_in_search_window == cute.arch.WARP_SIZE
+            start_group_idx = hit_group_idx_in_search_window + start_group_idx
+
+            hit_the_1st_problem_in_search_window = hit_group_idx_in_search_window == c_0
+            tile_count_prev_group = tile_count_searched
+            if not hit_the_1st_problem_in_search_window:
+                tile_count_prev_group = cute.arch.shuffle_sync(
+                    cluster_tile_count_end_per_thread,
+                    hit_group_idx_in_search_window - 1,
+                )
+
+            # If no matched group, then get new_cluster_tile_count_end from last lane
+            # Otherwise, get new_cluster_tile_count_end from the hit group
+            lane_idx_for_cluster_tile_count_end = hit_group_idx_in_search_window
+
+            if not_found:
+                lane_idx_for_cluster_tile_count_end = last_lane_idx
+            tile_count_searched = cute.arch.shuffle_sync(
+                cluster_tile_count_end_per_thread,
+                lane_idx_for_cluster_tile_count_end,
+            )
+
+            # Prefetch problem shape for next wave
+            if not not_found:  # noqa: SIM102
+                if start_group_idx + self.lane_idx < self.group_count:
+                    self.cached_problem_shape_1 = self._get_problem_for_group(
+                        problem_shape_mnkl, start_group_idx + self.lane_idx
+                    )
+
+        # The tile is invalid if not_found doesn't change before and after the while
+        # loop.
+        end_not_found = not_found
+        is_valid = start_not_found != end_not_found
+
+        return GroupedGemmGroupSearchState(
+            start_group_idx,
+            tile_count_prev_group,
+            tile_count_searched,
+            is_valid,
+        )
+
+    @dsl_user_op
+    @cute.jit
+    def _group_search_and_load_problem_shape(
+        self,
+        linear_idx: Int32,
+        problem_shape_mnkl: cute.Tensor,
+        start_group_idx: Int32,
+        tile_count_searched: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32, Tuple[Int32, Int32, Int32, Int32]]:
+        """
+        Perform group search and load problem shape for the matched group.
+
+        :param linear_idx: The linear index to be decomposed
+        :type linear_idx: Int32
+        :param problem_shape_mnkl: Tensor containing gemm problem size (M, N, K, L) for
+                                   all groups
+        :type problem_shape_mnkl: cute.Tensor
+        :param start_group_idx: The group idx to start the search with
+        :type start_group_idx: Int32
+        :param tile_count_searched: The number of tiles we have searched
+        :type tile_count_searched: Int32
+        :return: A tuple containing the final group index and the problem shape tensor
+        :rtype: Tuple[Int32, Int32, Tuple[Int32, Int32, Int32, Int32]]
+        """
+        self.search_state = self._group_search(
+            linear_idx,
+            problem_shape_mnkl,
+            start_group_idx,
+            tile_count_searched,
+            loc=loc,
+            ip=ip,
+        )
+        # get final group search state
+        found = self.search_state.found
+
+        final_group_idx: Union[Int32, int] = -1
+        problem_mnkl = (Int32(-1), Int32(-1), Int32(-1), Int32(-1))
+        if found:
+            final_group_idx = self.search_state.start_group_idx
+            problem_mnkl = self._get_problem_for_group(
+                problem_shape_mnkl, final_group_idx, loc=loc, ip=ip
+            )
+        return Int32(found), Int32(final_group_idx), problem_mnkl
+
+    @dsl_user_op
+    def delinearize_z(
+        self,
+        cta_tile_coord: tuple,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> GroupSearchResult:
+        """
+        Delinearize the linear z index and return GroupSearchResult.
+
+        This function should be used by warps that need to know the CTA tile index on M
+        and N dimensions.
+
+        :param cta_tile_coord: The raw CTA coordinate from tile scheduler
+        :type cta_tile_coord: tuple of Int32
+        :return: The search result containing group index and tile coordinates
+        :rtype: GroupSearchResult
+        """
+        # delinearize the z coord
+
+        linear_idx = self._current_work_linear_idx
+
+        found, group_idx, problem_mnkl = self._group_search_and_load_problem_shape(
+            linear_idx,
+            self.problem_shape_mnkl,
+            self.search_state.start_group_idx,
+            self.search_state.tile_count_prev_group,
+            loc=loc,
+            ip=ip,
+        )
+
+        # The work_tile is valid if its linear index could be mapped to a group in the
+        # problem shapes
+        is_valid = found
+
+        # linear index local to current group
+        cluster_tile_idx_in_current_group = (
+            linear_idx - self.search_state.tile_count_prev_group
+        )
+
+        cluster_count_m, cluster_count_n, cluster_count_k = cute.ceil_div(
+            (problem_mnkl[0], problem_mnkl[1], problem_mnkl[2]),
+            (
+                self.cluster_tile_shape_mnk[0],
+                self.cluster_tile_shape_mnk[1],
+                self.cluster_tile_shape_mnk[2],
+            ),
+            loc=loc,
+            ip=ip,
+        )
+
+        # decompose to get indices on M and N
+        cta_tile_idx_m, cta_tile_idx_n = self._compute_cta_tile_coord(
+            cluster_tile_idx_in_current_group,
+            cta_tile_coord,
+            cluster_count_m,
+            cluster_count_n,
+            loc=loc,
+            ip=ip,
+        )
+
+        group_search_result = GroupSearchResult(
+            group_idx,
+            cta_tile_idx_m,
+            cta_tile_idx_n,
+            problem_mnkl[0],
+            problem_mnkl[1],
+            problem_mnkl[2],
+            cluster_count_k,
+        )
+
+        return GroupedWorkTileInfo(cta_tile_coord, is_valid, group_search_result)  # type: ignore[return-value]
+
+    @dsl_user_op
+    def get_current_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        work_tile = self._get_current_work_for_linear_idx(
+            self._current_work_linear_idx, loc=loc, ip=ip
+        )
+        grouped_work_tile = self.delinearize_z(work_tile.tile_idx, loc=loc, ip=ip)
+        return grouped_work_tile
+
+
+@deprecated(
+    "API is deprecated, use StaticPersistentGroupTileScheduler from this module instead."
+)
+class GroupedGemmTileSchedulerHelper:
+    """
+    A helper to translate the raw block index (x, y, z) from tile scheduler to real CTA
+    tile index for grouped gemm.
+
+    :param group_count: Number of groups in current grouped gemm problem
+    :type group_count: int
+    :param tile_sched_params: Parameter used to create the tile scheduler this helper
+                              works with
+    :type tile_sched_params: PersistentTileSchedulerParams
+    :param cluster_tile_shape_mnk: The shape of cluster tile as (m, n, k)
+    :type cluster_tile_shape_mnk: tuple[int, int, int]
+    :param search_state: The initial search state
+    :type search_state: GroupedGemmGroupSearchState
+    """
+
+    def __init__(
+        self,
+        group_count: int,
+        tile_sched_params: PersistentTileSchedulerParams,
+        cluster_tile_shape_mnk: tuple[int, int, int],
+        search_state: GroupedGemmGroupSearchState,
+    ) -> None:
+        self.tile_sched_params = tile_sched_params
+        self.group_count = group_count
+        self.lane_idx = cute.arch.lane_idx()
+        self.cluster_tile_shape_mnk = cluster_tile_shape_mnk
+        self.search_state = search_state
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = extract_mlir_values(self.tile_sched_params)
+        values.extend(extract_mlir_values(self.search_state))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "GroupedGemmTileSchedulerHelper":
+        # Reconstruct tile_sched_params and determine how many values it consumed.
+        # NOTE: tile_sched_params may contain FastDivmod divisors
+        # (when swizzle_size == 1),
+        # which adds extra MLIR values.
+        params_values = extract_mlir_values(self.tile_sched_params)
+        n_params_values = len(params_values)
+        tile_sched_params = new_from_mlir_values(
+            self.tile_sched_params, values[:n_params_values]
+        )
+
+        # Reconstruct search_state from remaining values
+        search_state = new_from_mlir_values(self.search_state, values[n_params_values:])
+
+        return GroupedGemmTileSchedulerHelper(
+            self.group_count,
+            tile_sched_params,
+            self.cluster_tile_shape_mnk,
+            search_state,
+        )
+
+    def delinearize_z(
+        self,
+        cta_tile_coord: tuple,
+        problem_shape_mnkl: cute.Tensor,
+    ) -> GroupSearchResult:
+        """
+        Delinearize the linear z index and return GroupSearchResult.
+
+        This function should be used by warps that need to know the CTA tile index on M
+        and N dimensions.
+
+        :param cta_tile_coord: The raw CTA coordinate from tile scheduler
+        :type cta_tile_coord: tuple of Int32
+        :param problem_shape_mnkl: Tensor containing gemm problem size (M, N, K, L) for
+                                   each group
+        :type problem_shape_mnkl: cute.Tensor
+        :return: The search result containing group index and tile coordinates
+        :rtype: GroupSearchResult
+        """
+        # delinearize the z coord
+        linear_idx = cta_tile_coord[2]
+        group_idx, problem_mnkl = self._group_search_and_load_problem_shape(
+            linear_idx,
+            problem_shape_mnkl,
+            self.search_state.start_group_idx,
+            self.search_state.tile_count_prev_group,
+        )
+        # linear index local to current group
+        cluster_tile_idx_in_current_group = (
+            linear_idx - self.search_state.tile_count_prev_group
+        )
+        cluster_count_m, cluster_count_n, cluster_count_k = cute.ceil_div(
+            (problem_mnkl[0], problem_mnkl[1], problem_mnkl[2]),
+            (
+                self.cluster_tile_shape_mnk[0],
+                self.cluster_tile_shape_mnk[1],
+                self.cluster_tile_shape_mnk[2],
+            ),
+        )
+        # decompose to get indices on M and N
+        cta_tile_idx_m, cta_tile_idx_n = self._compute_cta_tile_coord(
+            cluster_tile_idx_in_current_group,
+            cta_tile_coord,
+            cluster_count_m,
+            cluster_count_n,
+        )
+        return GroupSearchResult(
+            group_idx,
+            cta_tile_idx_m,
+            cta_tile_idx_n,
+            problem_mnkl[0],  # type: ignore[arg-type]
+            problem_mnkl[1],  # type: ignore[arg-type]
+            problem_mnkl[2],  # type: ignore[arg-type]
+            cluster_count_k,
+        )
+
+    def search_cluster_tile_count_k(
+        self,
+        cta_tile_coord: tuple,
+        problem_shape_mnkl: cute.Tensor,
+    ) -> Tuple[Int32, Int32]:
+        """
+        Search the matched group for given linear index and compute the number of tiles
+        along K dimension for the matched group.
+
+        This function should be used by warps that are only interested in the number of
+        tiles along K dimension.
+
+        :param cta_tile_coord: The raw CTA coordinate from tile scheduler
+        :type cta_tile_coord: tuple of Int32
+        :param problem_shape_mnkl: Tensor containing gemm problem size (M, N, K, L) for
+                                   all groups
+        :type problem_shape_mnkl: cute.Tensor
+        :return: A tuple containing cluster count along K dimension and the group index
+        :rtype: Tuple[Int32, Int32]
+        """
+        group_idx, problem_mnk = self._group_search_and_load_problem_shape(
+            cta_tile_coord[2],
+            problem_shape_mnkl,
+            self.search_state.start_group_idx,
+            self.search_state.tile_count_prev_group,
+        )
+        cluster_count_k = (
+            problem_mnk[2] + self.cluster_tile_shape_mnk[2] - 1  # type: ignore[operator]
+        ) // self.cluster_tile_shape_mnk[2]
+        return cluster_count_k, group_idx  # type: ignore[return-value]
+
+    @cute.jit
+    def _prefix_sum(self, value_per_thread: Int32) -> Int32:
+        """
+        Perform prefix sum within a full warp.
+
+        :param value_per_thread: The value for this thread to contribute to the prefix
+                                 sum
+        :type value_per_thread: Int32
+        :return: The prefix sum result for this thread
+        :rtype: Int32
+        """
+        clamp_value = 0
+        idx = 1
+        sum_per_thread = value_per_thread
+        while const_expr(idx < cute.arch.WARP_SIZE):
+            value = cute.arch.shuffle_sync_up(
+                sum_per_thread, idx, mask_and_clamp=clamp_value
+            )
+            if self.lane_idx >= idx:
+                sum_per_thread += value
+            idx = idx << 1
+        return sum_per_thread
+
+    def _get_problem_for_group(
+        self, problem_shape_mnkl: cute.Tensor, group_idx: Int32
+    ) -> cute.Tensor:
+        """
+        Load gemm problem (m,n,k,l) for the specified group from global memory to
+        register.
+
+        :param problem_shape_mnkl: Tensor in global memory with layout
+                                   (group_count, 4):(4, 1)
+        :type problem_shape_mnkl: cute.Tensor
+        :param group_idx: The index of the group to load
+        :type group_idx: Int32
+        :return: The problem shape tensor for the specified group
+        :rtype: cute.Tensor
+        """
+        cur_problem_mnkl = cute.make_rmem_tensor(
+            cute.make_layout(4), problem_shape_mnkl.element_type
+        )
+        cute.autovec_copy(problem_shape_mnkl[(group_idx, None)], cur_problem_mnkl)
+        return cur_problem_mnkl
+
+    def _get_cluster_tile_count_mn(self, problem_shape: cute.Tensor) -> Int32:
+        """
+        Compute total cluster count.
+
+        :param problem_shape: Tensor containing problem shape (m, n, k, l)
+        :type problem_shape: cute.Tensor
+        :return: The total cluster tile count for M and N dimensions
+        :rtype: Int32
+        """
+        cur_ntile_m = (
+            problem_shape[0] + self.cluster_tile_shape_mnk[0] - 1  # type: ignore[operator]
+        ) // self.cluster_tile_shape_mnk[0]
+        cur_ntile_n = (
+            problem_shape[1] + self.cluster_tile_shape_mnk[1] - 1  # type: ignore[operator]
+        ) // self.cluster_tile_shape_mnk[1]
+        cur_ntile_mn = cur_ntile_m * cur_ntile_n
+        return cur_ntile_mn  # type: ignore[return-value]
+
+    def _compute_cta_tile_coord(
+        self,
+        cluster_tile_idx: Int32,
+        cta_tile_coord_in_cluster: tuple,
+        cluster_tile_count_m: Int32,
+        cluster_tile_count_n: Int32,
+    ) -> tuple:
+        """
+        Compute CTA tile indices along M and N dimensions based on the linear index
+        within a group.
+
+        It uses the AlongM mode to decompose the linear index onto M and N dimensions.
+
+        :param cluster_tile_idx: The linear index within a group
+        :type cluster_tile_idx: Int32
+        :param cta_tile_coord_in_cluster: CTA indices along M and N dimensions within a
+                                          cluster
+        :type cta_tile_coord_in_cluster: tuple of Int32
+        :param cluster_tile_count_m: The number of clusters along M dimension of the
+                                     matched group
+        :type cluster_tile_count_m: Int32
+        :param cluster_tile_count_n: The number of clusters along N dimension of the
+                                     matched group
+        :type cluster_tile_count_n: Int32
+        :return: A tuple containing CTA tile indices along M and N dimensions
+        :rtype: tuple of (Int32, Int32)
+        """
+        cluster_layout_mn = cute.make_layout(
+            (cluster_tile_count_m, cluster_tile_count_n)
+        )
+        (mi, ni) = cluster_layout_mn.get_hier_coord(cluster_tile_idx)
+        cta_tile_idx_m = (
+            mi * self.tile_sched_params.cluster_shape_mn[0]
+            + cta_tile_coord_in_cluster[0]
+        )
+        cta_tile_idx_n = (
+            ni * self.tile_sched_params.cluster_shape_mn[1]
+            + cta_tile_coord_in_cluster[1]
+        )
+        return (cta_tile_idx_m, cta_tile_idx_n)
+
+    @cute.jit
+    def _group_search(
+        self,
+        linear_idx: Int32,
+        problem_shape_mnkl: cute.Tensor,
+        init_group_idx: Int32,
+        init_tile_count_searched: Int32,
+    ) -> GroupedGemmGroupSearchState:
+        """
+        Search which group the linear index belongs to.
+
+        :param linear_idx: The linear index to be decomposed
+        :type linear_idx: Int32
+        :param problem_shape_mnkl: Tensor containing gemm problem size (M, N, K, L) for
+                                   all groups
+        :type problem_shape_mnkl: cute.Tensor
+        :param init_group_idx: The group idx to start the search with
+        :type init_group_idx: Int32
+        :param init_tile_count_searched: The number of tiles we have searched
+        :type init_tile_count_searched: Int32
+        :return: The updated search state
+        :rtype: GroupedGemmGroupSearchState
+        """
+        c_0 = Int32(0).ir_value()
+        last_lane_idx = cute.arch.WARP_SIZE - 1
+
+        tile_count_searched = init_tile_count_searched
+        start_group_idx = init_group_idx
+        not_found = linear_idx >= tile_count_searched
+        tile_count_prev_group = self.search_state.tile_count_prev_group
+        while not_found:
+            # get group to search for current lane
+            cur_group_idx = start_group_idx + self.lane_idx
+            # check if the group to be checked is out of range
+            inside_group_bound = cur_group_idx < self.group_count
+            cur_ntile_mn = c_0
+            if inside_group_bound:
+                # get problem size of current group
+                cur_problem_mnkl = self._get_problem_for_group(
+                    problem_shape_mnkl, cur_group_idx
+                )
+                cur_ntile_mn = self._get_cluster_tile_count_mn(cur_problem_mnkl)
+            # compute tile count from beginning to current group(included)
+            total_cluster_tile_count_ps_per_thread = self._prefix_sum(cur_ntile_mn)
+            cluster_tile_count_end_per_thread = (
+                total_cluster_tile_count_ps_per_thread + tile_count_searched
+            )
+
+            group_not_in_window = linear_idx >= cluster_tile_count_end_per_thread
+            hit_group_idx_in_search_window = cute.arch.popc(
+                cute.arch.vote_ballot_sync(group_not_in_window)
+            )
+            not_found = hit_group_idx_in_search_window == cute.arch.WARP_SIZE
+            start_group_idx = hit_group_idx_in_search_window + start_group_idx
+            hit_the_1st_problem_in_search_window = hit_group_idx_in_search_window == c_0
+            tile_count_prev_group = tile_count_searched
+            if not hit_the_1st_problem_in_search_window:
+                tile_count_prev_group = cute.arch.shuffle_sync(
+                    cluster_tile_count_end_per_thread,
+                    hit_group_idx_in_search_window - 1,
+                )
+
+            # If no matched group, then get new_cluster_tile_count_end from last lane
+            # Otherwise, get new_cluster_tile_count_end from the hit group
+            lane_idx_for_cluster_tile_count_end = hit_group_idx_in_search_window
+            if not_found:
+                lane_idx_for_cluster_tile_count_end = last_lane_idx
+            tile_count_searched = cute.arch.shuffle_sync(
+                cluster_tile_count_end_per_thread,
+                lane_idx_for_cluster_tile_count_end,
+            )
+
+        return GroupedGemmGroupSearchState(
+            start_group_idx,
+            tile_count_prev_group,
+            tile_count_searched,
+            Boolean(1),  # found will always be 1 for old api
+        )
+
+    def _group_search_and_load_problem_shape(
+        self,
+        linear_idx: Int32,
+        problem_shape_mnkl: cute.Tensor,
+        start_group_idx: Int32,
+        tile_count_searched: Int32,
+    ) -> Tuple[Int32, cute.Tensor]:
+        """
+        Perform group search and load problem shape for the matched group.
+
+        :param linear_idx: The linear index to be decomposed
+        :type linear_idx: Int32
+        :param problem_shape_mnkl: Tensor containing gemm problem size (M, N, K, L) for
+                                   all groups
+        :type problem_shape_mnkl: cute.Tensor
+        :param start_group_idx: The group idx to start the search with
+        :type start_group_idx: Int32
+        :param tile_count_searched: The number of tiles we have searched
+        :type tile_count_searched: Int32
+        :return: A tuple containing the final group index and the problem shape tensor
+        :rtype: Tuple[Int32, cute.Tensor]
+        """
+        self.search_state = self._group_search(
+            linear_idx,
+            problem_shape_mnkl,
+            start_group_idx,
+            tile_count_searched,
+        )
+        # get final group search state
+        final_group_idx = self.search_state.start_group_idx
+        # let's revisit if it's better to broadcast problem_shape_mnk in group_search
+        problem_mnkl = self._get_problem_for_group(problem_shape_mnkl, final_group_idx)
+        return final_group_idx, problem_mnkl

--- a/examples/python/CuTeDSL/helpers/static_persistent_tile_scheduler.py
+++ b/examples/python/CuTeDSL/helpers/static_persistent_tile_scheduler.py
@@ -1,0 +1,820 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import inspect
+from typing import Optional, Tuple
+
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Integer,
+    Int32,
+    min,
+    extract_mlir_values,
+    new_from_mlir_values,
+    dsl_user_op,
+    const_expr,
+)
+from cutlass._mlir import ir
+import cutlass.cute as cute
+
+##############################################################################
+# Static persistent tile scheduler
+##############################################################################
+
+
+class WorkTileInfo:
+    """A class to represent information about a work tile.
+
+    :ivar tile_idx: The index of the tile.
+    :type tile_idx: cute.Coord
+    :ivar is_valid_tile: Whether the tile is valid.
+    :type is_valid_tile: Boolean
+    """
+
+    def __init__(self, tile_idx: cute.Coord, is_valid_tile: Boolean):
+        self._tile_idx = tile_idx
+        self._is_valid_tile = Boolean(is_valid_tile)
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.tile_idx)
+        values.extend(extract_mlir_values(self.is_valid_tile))
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "WorkTileInfo":
+        assert len(values) == 4
+        new_tile_idx = new_from_mlir_values(self._tile_idx, values[:-1])
+        new_is_valid_tile = new_from_mlir_values(self._is_valid_tile, [values[-1]])
+        return WorkTileInfo(new_tile_idx, new_is_valid_tile)
+
+    @property
+    @cute.jit
+    def is_valid_tile(self) -> Boolean:
+        """Check latest tile returned by the scheduler is valid or not. Any scheduling
+        requests after all tasks completed will return an invalid tile.
+
+        :return: The validity of the tile.
+        :rtype: Boolean
+        """
+        return self._is_valid_tile
+
+    @property
+    @cute.jit
+    def tile_idx(self) -> cute.Coord:
+        """
+        Get the index of the tile.
+
+        :return: The index of the tile.
+        :rtype: cute.Coord
+        """
+        return self._tile_idx
+
+
+class PersistentTileSchedulerParams:
+    """A class to represent parameters for a persistent tile scheduler.
+
+    This class is designed to manage and compute the layout of clusters and tiles
+    in a batched gemm problem.
+
+    :ivar cluster_shape_mn: Shape of the cluster in (m, n) dimensions (K dimension cta count must be 1).
+    :type cluster_shape_mn: tuple
+    :ivar problem_layout_ncluster_mnl: Layout of the problem in terms of
+        number of clusters in (m, n, l) dimensions.
+    :type problem_layout_ncluster_mnl: cute.Layout
+    """
+
+    @dsl_user_op
+    def __init__(
+        self,
+        problem_shape_ntile_mnl: cute.Shape,
+        cluster_shape_mnk: cute.Shape,
+        swizzle_size: int = 1,
+        raster_along_m: bool = True,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """
+        Initializes the PersistentTileSchedulerParams with the given parameters.
+
+        :param problem_shape_ntile_mnl: The shape of the problem in terms of
+            number of CTA (Cooperative Thread Array) in (m, n, l) dimensions.
+        :type problem_shape_ntile_mnl: cute.Shape
+        :param cluster_shape_mnk: The shape of the cluster in (m, n) dimensions.
+        :type cluster_shape_mnk: cute.Shape
+        :param swizzle_size: Swizzling size in the unit of cluster. 1 means no swizzle
+        :type swizzle_size: int
+        :param raster_along_m: Rasterization order of clusters. Only used when swizzle_size > 1.
+            True means along M, false means along N.
+        :type raster_along_m: bool
+
+        :raises ValueError: If cluster_shape_k is not 1.
+        """
+
+        if cluster_shape_mnk[2] != 1:  # type: ignore[index]
+            raise ValueError(f"unsupported cluster_shape_k {cluster_shape_mnk[2]}")  # type: ignore[index]
+        if swizzle_size < 1:
+            raise ValueError(f"expect swizzle_size >= 1, but get {swizzle_size}")
+
+        self.problem_shape_ntile_mnl = problem_shape_ntile_mnl
+        # cluster_shape_mnk is kept for reconstruction
+        self._cluster_shape_mnk = cluster_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mnk[:2]  # type: ignore[index]
+        self.swizzle_size = swizzle_size
+        self.raster_along_m = raster_along_m
+        self._loc = loc
+
+        # By default, we follow m major (col-major) raster order, so make a col-major layout
+        self.problem_layout_ncluster_mnl = cute.make_layout(
+            cute.ceil_div(
+                self.problem_shape_ntile_mnl,
+                cluster_shape_mnk[:2],  # type: ignore[index]
+                loc=loc,
+                ip=ip,
+            ),
+            loc=loc,
+            ip=ip,
+        )
+
+        # Apply swizzle if swizzle_size > 1
+        if swizzle_size > 1:
+            problem_shape_ncluster_mnl = cute.round_up(
+                self.problem_layout_ncluster_mnl.shape,
+                (1, swizzle_size, 1) if raster_along_m else (swizzle_size, 1, 1),
+            )
+
+            if raster_along_m:
+                self.problem_layout_ncluster_mnl = cute.make_layout(
+                    (
+                        problem_shape_ncluster_mnl[0],  # type: ignore[index]
+                        (swizzle_size, problem_shape_ncluster_mnl[1] // swizzle_size),  # type: ignore[index, operator]
+                        problem_shape_ncluster_mnl[2],  # type: ignore[index]
+                    ),
+                    stride=(
+                        swizzle_size,
+                        (1, swizzle_size * problem_shape_ncluster_mnl[0]),  # type: ignore[index]
+                        problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],  # type: ignore[index, operator]
+                    ),
+                    loc=loc,
+                    ip=ip,
+                )
+            else:
+                self.problem_layout_ncluster_mnl = cute.make_layout(
+                    (
+                        (swizzle_size, problem_shape_ncluster_mnl[0] // swizzle_size),  # type: ignore[index, operator]
+                        problem_shape_ncluster_mnl[1],  # type: ignore[index]
+                        problem_shape_ncluster_mnl[2],  # type: ignore[index]
+                    ),
+                    stride=(
+                        (1, swizzle_size * problem_shape_ncluster_mnl[1]),  # type: ignore[index]
+                        swizzle_size,
+                        problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],  # type: ignore[index, operator]
+                    ),
+                    loc=loc,
+                    ip=ip,
+                )
+
+        # Create FastDivmod divisors (only when swizzle_size == 1 for correctness)
+        # FastDivmod assumes simple col-major layout, incompatible with swizzled layouts
+        if swizzle_size == 1:
+            _problem_layout_size = cute.size(
+                self.problem_layout_ncluster_mnl, loc=loc, ip=ip
+            )
+            cluster_count_m = self.problem_layout_ncluster_mnl.shape[0]
+            cluster_count_n = self.problem_layout_ncluster_mnl.shape[1]
+
+            if raster_along_m:
+                cluster_count_major = cluster_count_m
+                cluster_count_minor = cluster_count_n
+            else:
+                cluster_count_major = cluster_count_n
+                cluster_count_minor = cluster_count_m
+
+            # cluster_shape_major_fdd: Used to decode work_unit_id to cluster coordinates
+            self.cluster_shape_major_fdd = cute.fast_divmod_create_divisor(
+                cluster_count_major, loc=loc, ip=ip
+            )
+
+            # cluster_shape_minor_fdd: Used for the second level decomposition
+            self.cluster_shape_minor_fdd = cute.fast_divmod_create_divisor(
+                cluster_count_minor, loc=loc, ip=ip
+            )
+        else:
+            # FastDivmod not applicable with swizzling, set to None
+            self.cluster_shape_major_fdd = None
+            self.cluster_shape_minor_fdd = None
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values, self._values_pos = [], []
+        for obj in [
+            self.problem_shape_ntile_mnl,
+            self._cluster_shape_mnk,
+            self.swizzle_size,
+            self.raster_along_m,
+        ]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+
+        # Add FastDivmod divisors to MLIR values for Host->Device transfer
+        # Only add non-None values to avoid MLIR type errors
+        fastdivmod_values = []
+        fastdivmod_indices = []  # Track which FastDivmod objects are present
+
+        for i, (fdd_name, fdd_obj) in enumerate(
+            [
+                ("cluster_shape_major_fdd", self.cluster_shape_major_fdd),
+                ("cluster_shape_minor_fdd", self.cluster_shape_minor_fdd),
+            ]
+        ):
+            if fdd_obj is not None:
+                # Extract MLIR values from FastDivmodDivisor objects
+                fdd_values = extract_mlir_values(fdd_obj)
+                fastdivmod_values.extend(fdd_values)
+                fastdivmod_indices.append(i)
+
+        values += fastdivmod_values
+        self._values_pos.append(
+            len(fastdivmod_indices)
+        )  # Store count of FastDivmod objects, not values
+        self._fastdivmod_indices = fastdivmod_indices  # Store for reconstruction
+
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: list[ir.Value]
+    ) -> "PersistentTileSchedulerParams":
+        obj_list = []
+        values_copy = list(values)  # Make a copy to avoid modifying original
+
+        # Reconstruct original objects from MLIR values
+        for obj, n_items in zip(
+            [
+                self.problem_shape_ntile_mnl,
+                self._cluster_shape_mnk,
+                self.swizzle_size,
+                self.raster_along_m,
+            ],
+            self._values_pos[:-1],  # Exclude FastDivmod count
+        ):
+            obj_list.append(new_from_mlir_values(obj, values_copy[:n_items]))
+            values_copy = values_copy[n_items:]
+
+        # Create new params object by calling __init__ with reconstructed values
+        # This properly recreates layouts and other derived attributes in the device context
+        new_params = PersistentTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+
+        # Restore FastDivmod divisors from remaining values
+        fdd_names = ["cluster_shape_major_fdd", "cluster_shape_minor_fdd"]
+
+        if hasattr(self, "_fastdivmod_indices") and len(self._fastdivmod_indices) > 0:
+            # Override the FastDivmod divisors created by __init__ with reconstructed ones
+            for j, original_index in enumerate(self._fastdivmod_indices):
+                fdd_name = fdd_names[original_index]
+                # Get the original FastDivmodDivisor object
+                original_fdd = getattr(self, fdd_name)
+                if original_fdd is not None and j < len(values_copy):
+                    # Each FastDivmodDivisor has 1 MLIR value
+                    reconstructed_fdd = new_from_mlir_values(
+                        original_fdd, [values_copy[j]]
+                    )
+                    setattr(new_params, fdd_name, reconstructed_fdd)
+
+        return new_params
+
+    @dsl_user_op
+    def get_grid_shape(
+        self,
+        max_active_clusters: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Integer, Integer, Integer]:
+        """
+        Computes the grid shape based on the maximum active clusters allowed.
+
+        :param max_active_clusters: The maximum number of active clusters that
+            can run in one wave.
+        :type max_active_clusters: Int32
+
+        :return: A tuple containing the grid shape in (m, n, persistent_clusters).
+            - m: self.cluster_shape_m.
+            - n: self.cluster_shape_n.
+            - persistent_clusters: Number of persistent clusters that can run.
+        """
+
+        # Total ctas in problem size
+        num_ctas_mnl = tuple(
+            cute.size(x) * y
+            for x, y in zip(
+                self.problem_layout_ncluster_mnl.shape, self.cluster_shape_mn
+            )
+        ) + (self.problem_layout_ncluster_mnl.shape[2],)
+
+        num_ctas_in_problem = cute.size(num_ctas_mnl, loc=loc, ip=ip)
+
+        num_ctas_per_cluster = cute.size(self.cluster_shape_mn, loc=loc, ip=ip)
+        # Total ctas that can run in one wave
+        num_ctas_per_wave = max_active_clusters * num_ctas_per_cluster
+
+        num_persistent_ctas = min(num_ctas_in_problem, num_ctas_per_wave)
+        num_persistent_clusters = num_persistent_ctas // num_ctas_per_cluster
+
+        return (*self.cluster_shape_mn, num_persistent_clusters)
+
+
+# Set explicit signature for Sphinx documentation to avoid issues with @dsl_user_op decorator
+PersistentTileSchedulerParams.__init__.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+    [
+        inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]
+)
+
+
+class StaticPersistentTileScheduler:
+    """A scheduler for static persistent tile execution in CUTLASS/CuTe kernels.
+
+    :ivar params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+    ):
+        """
+        Initializes the StaticPersistentTileScheduler with the given parameters.
+
+        :param params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl.
+        :type params: PersistentTileSchedulerParams
+        :param num_persistent_clusters: Number of persistent clusters that can be launched.
+        :type num_persistent_clusters: Int32
+        :param current_work_linear_idx: Current cluster index.
+        :type current_work_linear_idx: Int32
+        :param cta_id_in_cluster: ID of the CTA within its cluster.
+        :type cta_id_in_cluster: cute.Coord
+        :param num_tiles_executed: Counter for executed tiles.
+        :type num_tiles_executed: Int32
+        """
+        self.params = params
+        self.num_persistent_clusters = num_persistent_clusters
+        self._current_work_linear_idx = current_work_linear_idx
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self._num_tiles_executed = num_tiles_executed
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.num_persistent_clusters)
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self._num_tiles_executed))
+
+        # CRITICAL: Also extract FastDivmod divisors from params
+        values.extend(extract_mlir_values(self.params))
+
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: list[ir.Value]
+    ) -> "StaticPersistentTileScheduler":
+        assert len(values) >= 6
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(
+            self.cta_id_in_cluster, values[2:5]
+        )
+        new_num_tiles_executed = new_from_mlir_values(
+            self._num_tiles_executed, [values[5]]
+        )
+
+        # Reconstruct params with FastDivmod divisors
+        params_values = values[6:]  # Remaining values are from params
+        new_params = new_from_mlir_values(self.params, params_values)
+
+        return StaticPersistentTileScheduler(
+            new_params,  # Use reconstructed params with FastDivmod divisors
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentTileScheduler":
+        """Initialize the static persistent tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+
+        :return: A StaticPersistentTileScheduler object.
+        :rtype: StaticPersistentTileScheduler
+        """
+
+        # Calculate the number of persistent clusters by dividing the total grid size
+        # by the number of CTAs per cluster
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        # CTA id in the cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentTileScheduler(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: PersistentTileSchedulerParams,
+        max_active_clusters: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Integer, Integer, Integer]:
+        """Calculates the grid shape to be launched on GPU using problem shape,
+        threadblock shape, and active cluster size.
+
+        :param params: Parameters for grid shape calculation.
+        :type params: PersistentTileSchedulerParams
+        :param max_active_clusters: Maximum active clusters allowed.
+        :type max_active_clusters: Int32
+
+        :return: The calculated 3d grid shape.
+        :rtype: Tuple[Integer, Integer, Integer]
+        """
+
+        return params.get_grid_shape(max_active_clusters, loc=loc, ip=ip)
+
+    # private method
+    def _get_current_work_for_linear_idx(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        """Compute current tile coord given current_work_linear_idx and cta_id_in_cluster.
+
+        :param current_work_linear_idx: The linear index of the current work.
+        :type current_work_linear_idx: Int32
+
+        :return: An object containing information about the current tile coordinates
+            and validity status.
+        :rtype: WorkTileInfo
+        """
+
+        is_valid = current_work_linear_idx < cute.size(
+            self.params.problem_layout_ncluster_mnl, loc=loc, ip=ip
+        )
+
+        # Choose coordinate calculation method based on swizzle configuration
+        if self.params.swizzle_size == 1:
+            # Use FastDivmod optimization for non-swizzled layouts
+            cur_cluster_coord = self._get_cluster_work_idx_with_fastdivmod(
+                current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            # Use get_flat_coord for swizzled layouts (FastDivmod doesn't support them)
+            cur_cluster_coord = self.params.problem_layout_ncluster_mnl.get_flat_coord(
+                current_work_linear_idx, loc=loc, ip=ip
+            )
+
+        cur_tile_coord = tuple(
+            cute.arch.make_warp_uniform(Int32(x) * Int32(z) + Int32(y))
+            for x, y, z in zip(
+                cur_cluster_coord,
+                self.cta_id_in_cluster,  # type: ignore[arg-type]
+                (*self.params.cluster_shape_mn, Int32(1)),
+            )
+        )
+
+        return WorkTileInfo(cur_tile_coord, cute.arch.make_warp_uniform(is_valid))
+
+    def _get_cluster_work_idx_with_fastdivmod(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        """
+        FastDivmod optimized CLUSTER coordinate calculation.
+
+        CRITICAL: This should mimic problem_layout_ncluster_mnl.get_hier_coord()
+        which returns CLUSTER coordinates, not tile coordinates!
+
+        :param current_work_linear_idx: Linear index in the work space
+        :type current_work_linear_idx: Int32
+        :return: Cluster coordinates (m, n, l) or None if FastDivmod not available
+        :rtype: Tuple[Int32, Int32, Int32] or None
+        """
+
+        # Step 1: Decode current_work_linear_idx using FastDivmod objects
+        # The layout structure is: problem_layout_ncluster_mnl has shape (cluster_count_m, cluster_count_n, batch_count)
+        # current_work_linear_idx needs to be decomposed into (batch_l, cluster_minor, cluster_major) in little-endian order
+
+        # First, get cluster_major using cluster_shape_major_fdd
+        cluster_minor_batch, cluster_major = divmod(
+            current_work_linear_idx, self.params.cluster_shape_major_fdd
+        )
+
+        # Then decode cluster_minor_batch to get cluster_minor and batch_l using FastDivmod
+        batch_l, cluster_minor = divmod(
+            cluster_minor_batch, self.params.cluster_shape_minor_fdd
+        )
+
+        if self.params.raster_along_m:
+            cluster_m = cluster_major
+            cluster_n = cluster_minor
+        else:
+            cluster_m = cluster_minor
+            cluster_n = cluster_major
+
+        return (cluster_m, cluster_n, batch_l)
+
+    @dsl_user_op
+    @cute.jit
+    def get_current_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        return self._get_current_work_for_linear_idx(
+            self._current_work_linear_idx, loc=loc, ip=ip
+        )
+
+    @dsl_user_op
+    @cute.jit
+    def initial_work_tile_info(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        return self.get_current_work(loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def advance_to_next_work(
+        self,
+        *,
+        advance_count: int = 1,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        self._current_work_linear_idx += Int32(advance_count) * Int32(
+            self.num_persistent_clusters
+        )
+        self._num_tiles_executed += Int32(1)
+
+    @property
+    @cute.jit
+    def num_tiles_executed(self) -> Int32:
+        return self._num_tiles_executed
+
+
+class StaticPersistentRuntimeTileScheduler(StaticPersistentTileScheduler):
+    """A scheduler for static persistent runtime tile execution in CUTLASS/CuTe kernels.
+    This scheduler will always launch all the SMs and the scheduler will generate the real tile info for each SM.
+
+    :ivar params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+        inner_mode: int = 1,
+    ):
+        """
+        Initializes the StaticPersistentRuntimeTileScheduler with the given parameters.
+
+        :param params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl.
+        :type params: PersistentTileSchedulerParams
+        :param num_persistent_clusters: Number of persistent clusters that can be launched.
+        :type num_persistent_clusters: Int32
+        :param current_work_linear_idx: Current cluster index.
+        :type current_work_linear_idx: Int32
+        :param cta_id_in_cluster: ID of the CTA within its cluster.
+        :type cta_id_in_cluster: cute.Coord
+        :param num_tiles_executed: Counter for executed tiles.
+        :type num_tiles_executed: Int32
+        :param inner_mode: The inner mode along which the linear index will be decomposed first.
+        :type inner_mode: int
+        """
+        super().__init__(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+        if inner_mode not in [0, 1]:
+            raise ValueError(
+                f"inner_mode must be 0(for M mode) or 1(for N mode), but got {inner_mode}"
+            )
+        self.inner_mode = inner_mode
+
+    def __new_from_mlir_values__(
+        self, values: list[ir.Value]
+    ) -> "StaticPersistentRuntimeTileScheduler":
+        assert len(values) >= 6
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(
+            self.cta_id_in_cluster, values[2:5]
+        )
+        new_num_tiles_executed = new_from_mlir_values(
+            self._num_tiles_executed, [values[5]]
+        )
+
+        # Reconstruct params with FastDivmod divisors (same as parent class)
+        params_values = values[6:]  # Remaining values are from params
+        new_params = new_from_mlir_values(self.params, params_values)
+
+        return StaticPersistentRuntimeTileScheduler(
+            new_params,  # Use reconstructed params with FastDivmod divisors
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+            self.inner_mode,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        inner_mode: int = 1,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentRuntimeTileScheduler":
+        """Initialize the static persistent tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+        :param inner_mode: The inner mode along which the linear index will be decomposed first.
+        :type inner_mode: int
+
+        :return: A StaticPersistentRuntimeTileScheduler object.
+        :rtype: StaticPersistentRuntimeTileScheduler
+        """
+
+        # Calculate the number of persistent clusters by dividing the total grid size
+        # by the number of CTAs per cluster
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        # CTA id in the cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentRuntimeTileScheduler(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+            inner_mode,
+        )
+
+    # private method
+    def _get_current_work_for_linear_idx(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        """Compute current tile coord given current_work_linear_idx and cta_id_in_cluster.
+
+        :param current_work_linear_idx: The linear index of the current work.
+        :type current_work_linear_idx: Int32
+
+        :return: An object containing information about the current tile coordinates
+            and validity status.
+        :rtype: WorkTileInfo
+        """
+        ntile_shape = self.params.problem_layout_ncluster_mnl.shape
+        int_max = 2147483647
+        if const_expr(self.inner_mode == 1):
+            ntile_layout = cute.make_layout(
+                (int_max, ntile_shape[1]), stride=(ntile_shape[1], 1)
+            )
+        else:
+            ntile_layout = cute.make_layout(
+                (ntile_shape[0], int_max), stride=(1, ntile_shape[0])
+            )
+        cluster_tile_coord_mn = ntile_layout.get_hier_coord(current_work_linear_idx)
+        cur_tile_coord = (
+            cluster_tile_coord_mn[0],
+            cluster_tile_coord_mn[1],
+            Int32(0),
+        )
+
+        # it is determined by kernel implementation
+        is_valid = Boolean(True)
+
+        return WorkTileInfo(cur_tile_coord, is_valid)


### PR DESCRIPTION
## Summary

Update public CuTeDSL examples for compatibility with the 4.8 DSL wheel.

## Fix

- Add the shared CLI and persistent scheduler helpers.
- Align the Blackwell grouped and persistent GEMM examples with the 4.8 scheduler APIs.