### PR TITLE
Fix GEMM profiler verification across all batches

### DIFF
--- a/tools/profiler/include/cutlass/profiler/operation_profiler.h
+++ b/tools/profiler/include/cutlass/profiler/operation_profiler.h
@@ -201,6 +201,13 @@ public:
     DeviceAllocation &reference,
     int64_t count = 0);
 
+  /// Compares consecutive tensor batches for equality
+  static Disposition compare_tensor_batches(
+    Options const &options,
+    DeviceAllocation &experimental,
+    DeviceAllocation &reference,
+    int logical_batch_count);
+
   static void save_workspace(
     DeviceContext &device_context,
     Options const &options,

--- a/tools/profiler/src/block_scaled_gemm_operation_profiler.cu
+++ b/tools/profiler/src/block_scaled_gemm_operation_profiler.cu
@@ -1355,20 +1355,20 @@ bool BlockScaledGemmOperationProfiler::verify_with_reference_(
   //
   // Verify results
   //
-  auto resultD = compare_tensors(
+  auto resultD = compare_tensor_batches(
     options,
     *gemm_workspace_.Computed,
     *gemm_workspace_.Reference,
-    gemm_workspace_.Computed->batch_stride()
+    problem_.batch_count
   );
   
   auto resultSFD = Disposition::kPassed;
   if (gemm_desc.SFD.element != library::NumericTypeID::kVoid) {
-    resultSFD = compare_tensors(
+    resultSFD = compare_tensor_batches(
       options,
       *gemm_workspace_.Computed_SFD,
       *gemm_workspace_.Reference_SFD,
-      gemm_workspace_.Computed_SFD->batch_stride()
+      problem_.batch_count
     );
   }
   
@@ -1658,4 +1658,3 @@ Status BlockScaledGemmOperationProfiler::profile_cutlass_(
 } // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
-

--- a/tools/profiler/src/blockwise_gemm_operation_profiler.cu
+++ b/tools/profiler/src/blockwise_gemm_operation_profiler.cu
@@ -1193,11 +1193,11 @@ bool BlockwiseGemmOperationProfiler::verify_with_reference_(
   //
   // Verify results
   //
-  auto resultD = compare_tensors(
+  auto resultD = compare_tensor_batches(
     options,
     *gemm_workspace_.Computed,
     *gemm_workspace_.Reference,
-    gemm_workspace_.Computed->batch_stride()
+    problem_.batch_count
   );
   
   results_.back().verification_map[library::Provider::kReferenceHost] = resultD;
@@ -1549,4 +1549,3 @@ Status BlockwiseGemmOperationProfiler::profile_cutlass_(
 } // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
-

--- a/tools/profiler/src/cublas_helpers.cu
+++ b/tools/profiler/src/cublas_helpers.cu
@@ -506,6 +506,38 @@ void cublasLtGemmExDispatcher::initialize_cublaslt(){
   cublasLtMatrixLayoutCreate(&Cdesc, data_type_C, configuration.problem_size.m(), configuration.problem_size.n(), configuration.ldc);
   cublasLtMatrixLayoutCreate(&Ddesc, data_type_C, configuration.problem_size.m(), configuration.problem_size.n(), configuration.ldd);
 
+  if (configuration.mode == library::GemmUniversalMode::kBatched) {
+    int32_t batch_count = configuration.batch_count;
+
+    auto set_batch_layout = [this, batch_count](
+      cublasLtMatrixLayout_t layout,
+      int64_t batch_stride) {
+
+      if (status == Status::kSuccess) {
+        status = get_cutlass_status(
+          cublasLtMatrixLayoutSetAttribute(
+            layout,
+            CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+            &batch_count,
+            sizeof(batch_count)));
+      }
+
+      if (status == Status::kSuccess) {
+        status = get_cutlass_status(
+          cublasLtMatrixLayoutSetAttribute(
+            layout,
+            CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET,
+            &batch_stride,
+            sizeof(batch_stride)));
+      }
+    };
+
+    set_batch_layout(Adesc, arguments.batch_stride_A);
+    set_batch_layout(Bdesc, arguments.batch_stride_B);
+    set_batch_layout(Cdesc, arguments.batch_stride_C);
+    set_batch_layout(Ddesc, arguments.batch_stride_D);
+  }
+
 }
 
 bool cublasLtGemmExDispatcher::get_cublaslt_algo(cublasLtHandle_t handle,

--- a/tools/profiler/src/gemm_operation_profiler.cu
+++ b/tools/profiler/src/gemm_operation_profiler.cu
@@ -1342,12 +1342,12 @@ bool GemmOperationProfiler::verify_with_cublas_(
 
     gemm_op.initialize_cublaslt();
 
-    if(!gemm_op.get_cublaslt_algo(handle, AlgorithmMode::kDefault)){
+    if (gemm_op.status != Status::kSuccess) {
+      results_.back().verification_map[library::Provider::kCUBLAS] = Disposition::kNotRun;
       return true;
     }
 
-    if (gemm_op.status != Status::kSuccess) {
-      results_.back().verification_map[library::Provider::kCUBLAS] = Disposition::kNotRun;
+    if (!gemm_op.get_cublaslt_algo(handle, AlgorithmMode::kDefault)) {
       return true;
     }
 
@@ -1366,11 +1366,11 @@ bool GemmOperationProfiler::verify_with_cublas_(
     // Verify results
     //
 
-    results_.back().verification_map[library::Provider::kCUBLAS] = compare_tensors(
+    results_.back().verification_map[library::Provider::kCUBLAS] = compare_tensor_batches(
       options,
       *gemm_workspace_.Computed,
       *gemm_workspace_.Reference,
-      gemm_workspace_.Computed->batch_stride()
+      problem_.batch_count
     );
 
     // Save workspace if incorrect
@@ -1416,8 +1416,10 @@ bool GemmOperationProfiler::verify_with_reference_(
   //
   for (auto provider : options.verification.providers) {
 
-    // Skip providers that are not enabled
-    if (!options.verification.provider_enabled(provider)) {
+    // This path only dispatches reference operations. Other providers have
+    // dedicated verification paths.
+    if (provider != library::Provider::kReferenceHost &&
+        provider != library::Provider::kReferenceDevice) {
       continue;
     }
 
@@ -1539,11 +1541,11 @@ bool GemmOperationProfiler::verify_with_reference_(
       // Verify results
       //
 
-      results_.back().verification_map[provider] = compare_tensors(
+      results_.back().verification_map[provider] = compare_tensor_batches(
         options,
         *gemm_workspace_[i].Computed,
         *gemm_workspace_[i].Reference,
-        gemm_workspace_[i].Computed->batch_stride()
+        problem_.batch_count
       );
 
       // Save workspace if incorrect

--- a/tools/profiler/src/operation_profiler.cu
+++ b/tools/profiler/src/operation_profiler.cu
@@ -625,6 +625,43 @@ void OperationProfiler::sleep(int sleep_duration) {
   }
 }
 
+namespace {
+
+Disposition compare_tensor_data(
+  Options const &options,
+  library::NumericTypeID type,
+  void const *experimental,
+  void const *reference,
+  int64_t count) {
+
+  bool passed = false;
+
+  if (options.verification.epsilon == 0) {
+
+    // bit-level equality
+    passed = DeviceAllocation::block_compare_equal(
+      type,
+      experimental,
+      reference,
+      count);
+  }
+  else {
+
+    // relative error function
+    passed = DeviceAllocation::block_compare_relatively_equal(
+      type,
+      experimental,
+      reference,
+      count,
+      options.verification.epsilon,
+      options.verification.nonzero_floor);
+  }
+
+  return passed ? Disposition::kPassed : Disposition::kIncorrect;
+}
+
+} // namespace
+
 
 /// Compares tensors for equality
 Disposition OperationProfiler::compare_tensors(
@@ -637,34 +674,48 @@ Disposition OperationProfiler::compare_tensors(
     return Disposition::kIncorrect;
   }
 
-  bool passed = false;
-
   if (count == 0) {
     count = reference.capacity();
   }
 
-  if (options.verification.epsilon == 0) {
+  return compare_tensor_data(
+    options,
+    experimental.type(),
+    experimental.data(),
+    reference.data(),
+    count);
+}
 
-    // bit-level equality
-    passed = DeviceAllocation::block_compare_equal(
-      experimental.type(),
-      experimental.data(),
-      reference.data(),
-      count);
+/// Compares consecutive tensor batches for equality
+Disposition OperationProfiler::compare_tensor_batches(
+  Options const &options,
+  DeviceAllocation &experimental,
+  DeviceAllocation &reference,
+  int logical_batch_count) {
+
+  if (experimental.type() != reference.type() ||
+      experimental.batch_stride() != reference.batch_stride() ||
+      experimental.batch_stride() <= 0 ||
+      logical_batch_count <= 0 ||
+      logical_batch_count > experimental.batch_count() ||
+      logical_batch_count > reference.batch_count()) {
+    return Disposition::kIncorrect;
   }
-  else {
 
-    // relative error function
-    passed = DeviceAllocation::block_compare_relatively_equal(
+  for (int batch_idx = 0; batch_idx < logical_batch_count; ++batch_idx) {
+    Disposition disposition = compare_tensor_data(
+      options,
       experimental.type(),
-      experimental.data(),
-      reference.data(),
-      count,
-      options.verification.epsilon,
-      options.verification.nonzero_floor);
+      experimental.batch_data(batch_idx),
+      reference.batch_data(batch_idx),
+      experimental.batch_stride());
+
+    if (disposition != Disposition::kPassed) {
+      return disposition;
+    }
   }
 
-  return passed ? Disposition::kPassed : Disposition::kIncorrect;
+  return Disposition::kPassed;
 }
 
 /// Saves the workspace


### PR DESCRIPTION
## Summary

- Compare each logical GEMM batch independently through `batch_data()` and `batch_stride()`, while preserving the existing bitwise-exact and epsilon-based relative comparison semantics.
- Apply batched comparison to standard GEMM host, device, and cuBLAS verification; block-scaled GEMM D and SFD outputs; and blockwise GEMM D output.
- Set `CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT` and `CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET` on the cuBLASLt A/B/C/D layouts for batched GEMM.
- Limit the generic reference loop to host and device reference providers so dedicated provider results remain intact.

## Validation

- Completed full profiler builds on an RTX 4090 with CUDA 11.8 using both `CUTLASS_ENABLE_CUBLAS=OFF` and `CUTLASS_ENABLE_CUBLAS=ON`.
- Ran 38 total host-reference matrix cases across the baseline and fixed profilers at `beta=0`, using `batch_count` values 1, 2, 3, 7, and 16. Clean cases passed. On the baseline, batch-0 faults were detected while nonzero-batch faults reproduced the false pass. With the fix, every injected fault was detected.
- Ran 19 cuBLAS matrix cases with the fixed profiler at `beta=0` across the same batch counts and fault positions. Clean cases passed, and all batch-0 and nonzero-batch faults were detected.
- The full builds compiled the block-scaled and blockwise paths; those paths were not run on this GPU.

Fixes #3511.
