### PR TITLE
[Examples] Fix wgrad workspace dump tensor and swapped grid/block in FMHA reference

### DIFF
--- a/examples/30_wgrad_split_k/30_wgrad_split_k.cu
+++ b/examples/30_wgrad_split_k/30_wgrad_split_k.cu
@@ -618,7 +618,7 @@ Result profile_convolution(Options const &options) {
       output_workspace << "Reference = \n" << tensor_ref_d.host_view() << "\n\n";
     }
 
-    output_workspace << "Computed = \n" << tensor_c.host_view() << std::endl;
+    output_workspace << "Computed = \n" << tensor_d.host_view() << std::endl;
 
     std::cout << "Results written to '" << ss.str() << "'." << std::endl;
   }

--- a/examples/77_blackwell_fmha/reference/reference_abs_error.hpp
+++ b/examples/77_blackwell_fmha/reference/reference_abs_error.hpp
@@ -160,7 +160,7 @@ void reference_abs_diff(
 
   dim3 block(256, 1, 1);
   dim3 grid(1024, 1, 1);
-  reference_abs_diff_kernel<<<block, grid>>>(
+  reference_abs_diff_kernel<<<grid, block>>>(
       data.get(), data_ref.get(), data.size(),
       result.get(), result.get() + 1, kPrintDiff);
 
@@ -256,7 +256,7 @@ void reference_rel_diff(
 
   dim3 block(256, 1, 1);
   dim3 grid(1024, 1, 1);
-  reference_rel_diff_kernel<<<block, grid>>>(
+  reference_rel_diff_kernel<<<grid, block>>>(
       data.get(), data_ref.get(), data.size(),
       result.get(), result.get() + 1, kPrintDiff);
 

--- a/examples/88_hopper_fmha/reference/reference_abs_error.hpp
+++ b/examples/88_hopper_fmha/reference/reference_abs_error.hpp
@@ -103,7 +103,7 @@ void reference_abs_diff(
 
   dim3 block(256, 1, 1);
   dim3 grid(1024, 1, 1);
-  reference_abs_diff_kernel<<<block, grid>>>(
+  reference_abs_diff_kernel<<<grid, block>>>(
       data.get(), data_ref.get(), data.size(),
       result.get(), result.get() + 1, kPrintDiff);
 


### PR DESCRIPTION
Fixes #3525 — two independent, unrelated example defects.

## 1. `examples/30_wgrad_split_k`: the workspace dump prints the wrong tensor

`30_wgrad_split_k.cu:621` labels `tensor_c` as `Computed`:

```cpp
output_workspace << "Computed = \n" << tensor_c.host_view() << std::endl;
```

`tensor_c` is the zero-filled C/bias input (`TensorFill` at :435). The kernel output is `tensor_d` — it is what the reference check compares (`TensorEquals(tensor_d, tensor_ref_d)` at :586) and it is the counterpart of the `Reference = tensor_ref_d` line printed a few lines above. So `--save-workspace` handed anyone debugging a dump of zeros labelled as the computed result.

## 2. `examples/{77_blackwell,88_hopper}_fmha`: transposed launch arguments

Three call sites in the reference diff-checkers (`77_blackwell_fmha/reference/reference_abs_error.hpp:163,259` and `88_hopper_fmha/reference/reference_abs_error.hpp:106`):

```cpp
dim3 block(256, 1, 1);
dim3 grid(1024, 1, 1);
reference_abs_diff_kernel<<<block, grid>>>(...);
```

The arguments are transposed, so the kernel runs **256 blocks of 1024 threads** instead of the intended **1024 blocks of 256 threads**.

Results are unaffected: the scan is a grid-stride loop, and the block-level state is two `__shared__` scalars rather than a `blockDim`-sized array. But it is not free either. The reduction that follows is serialized over `blockDim.x` with a `__syncthreads()` on every iteration:

```cpp
for (int i = 0; i < blockDim.x; i++) {
  if (i == threadIdx.x) { /* fold thread partials into shared */ }
  __syncthreads();
}
```

Quadrupling `blockDim.x` therefore quadruples both the number of barriers per block and the number of threads per barrier.

### Measurement

A faithful standalone copy of `reference_abs_diff_kernel`, both launch configurations, 200 iterations per point, H200 (sm_90, 132 SMs), CUDA 12.8, `-O3 -arch=sm_90a`:

| elements | as written (256 blk × 1024 thr) | fixed (1024 blk × 256 thr) | speedup |
|---:|---:|---:|---:|
| 4096 | 0.140 ms | 0.034 ms | **4.16×** |
| 65536 | 0.139 ms | 0.034 ms | **4.15×** |
| 1048576 | 0.140 ms | 0.035 ms | **4.04×** |
| 16777216 | 0.178 ms | 0.072 ms | **2.49×** |

The ratio tracks the 4× `blockDim` change until the memory-bound scan begins to dominate at 16M elements.

Both headers are commonly copied as the starting point for a new reference check, so the transposed launch propagates beyond these two examples.

## Notes

Four tokens changed across three files; no API, kernel or reference-semantics change. I did not build the FMHA examples locally — the change is confined to the launch arguments and the dumped tensor, and CI compiles the examples.
