### PR TITLE
[CuTeDSL] Fix blockwise GEMM opt-level version gate

### DIFF
--- a/examples/python/CuTeDSL/cute/blackwell/kernel/blockwise_gemm/blockwise_gemm.py
+++ b/examples/python/CuTeDSL/cute/blackwell/kernel/blockwise_gemm/blockwise_gemm.py
@@ -2716,7 +2716,14 @@ def run(
         sfb_tensor,
         max_active_clusters,
         current_stream,
-        options=f"--opt-level=2" if cutlass.__version__[0:3]=="4.6" else "",
+        options=(
+            "--opt-level=2"
+            if (
+                cutlass.target_version(exact_version="12.9")
+                or cutlass.target_version(min_version="13.1")
+            )
+            else ""
+        ),
     )
 
     # Execution


### PR DESCRIPTION
Summary:
- enable the existing opt-level=2 performance workaround for CUDA 12.9 and CUDA 13.1 or newer
- use `cutlass.target_version` so the gate follows the compiler backend version

The old exact package-version gate skipped the workaround for current builds and caused a blockwise GEMM performance regression.

Validation:
- CUDA 12.9 on B200: 1125.541 us to 929.870 us, 17.385 percent faster
- CUDA 13.4 on B200: 1048.910 us to 816.247 us, 22.181 percent faster
- the backend-version gate evaluates true in both tested environments
- reference checks passed for both runs
- formatting and git diff checks passed