### PR TITLE
[CuTeDSL] Preserve deterministic link library ordering

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/dsl.py
+++ b/python/CuTeDSL/cutlass/base_dsl/dsl.py
@@ -2124,8 +2124,8 @@ class BaseDSL(metaclass=DSLSingletonMeta):
                 continue
             if gpu_module is not None:
                 link_libraries = self.compile_options.options[LinkLibraries].value
-                sources = set(
-                    x.value for x in gpu_module.attributes.get("link-libraries", set())
+                sources = dict.fromkeys(
+                    x.value for x in gpu_module.attributes.get("link-libraries", ())
                 )
                 link_libraries = (
                     link_libraries

--- a/test/python/CuTeDSL/test_link_libraries_order.py
+++ b/test/python/CuTeDSL/test_link_libraries_order.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from cutlass.base_dsl import dsl as dsl_module
+from cutlass.base_dsl.compiler import LinkLibraries
+
+
+class _ReverseSet(set):
+    def __iter__(self):
+        return iter(sorted(super().__iter__(), reverse=True))
+
+
+class TestLinkLibrariesOrder(unittest.TestCase):
+    def test_preserves_attribute_order_and_deduplicates(self):
+        paths = ["device.bc", "math.bc", "user.bc", "math.bc"]
+        gpu_module = SimpleNamespace(
+            name="gpu.module",
+            attributes={
+                "link-libraries": [SimpleNamespace(value=path) for path in paths]
+            },
+        )
+        module = SimpleNamespace(body=SimpleNamespace(operations=[gpu_module]))
+        compile_options = SimpleNamespace(
+            options={LinkLibraries: LinkLibraries("existing.bc")}
+        )
+        owner = SimpleNamespace(compile_options=compile_options)
+
+        # Make the old set-based path fail deterministically, independent of
+        # the interpreter's hash seed. The fixed path does not use this name.
+        with mock.patch.object(dsl_module, "set", _ReverseSet, create=True):
+            dsl_module.BaseDSL._merge_gpu_link_libraries(owner, module)
+
+        self.assertEqual(
+            compile_options.options[LinkLibraries].value,
+            "existing.bc,device.bc,math.bc,user.bc",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/CuTeDSL/test_link_libraries_order.py
+++ b/test/python/CuTeDSL/test_link_libraries_order.py
@@ -24,7 +24,7 @@ class _ReverseSet(set):
 
 class TestLinkLibrariesOrder(unittest.TestCase):
     def test_preserves_attribute_order_and_deduplicates(self):
-        paths = ["device.bc", "math.bc", "user.bc", "math.bc"]
+        paths = ["user.bc", "device.bc", "math.bc", "device.bc"]
         gpu_module = SimpleNamespace(
             name="gpu.module",
             attributes={
@@ -44,7 +44,7 @@ class TestLinkLibrariesOrder(unittest.TestCase):
 
         self.assertEqual(
             compile_options.options[LinkLibraries].value,
-            "existing.bc,device.bc,math.bc,user.bc",
+            "existing.bc,user.bc,device.bc,math.bc",
         )
 
 


### PR DESCRIPTION
## Summary

- keep the canonical order already stored in each GPU module's `link-libraries` attribute
- retain deduplication without relying on Python set iteration
- add a CPU-only regression test that preserves existing options and detects the old unordered path

## Testing

- `python test/python/CuTeDSL/test_link_libraries_order.py -v`
- `ruff check test/python/CuTeDSL/test_link_libraries_order.py`
- `ruff format --check test/python/CuTeDSL/test_link_libraries_order.py`
- `python3.12 -m py_compile python/CuTeDSL/cutlass/base_dsl/dsl.py test/python/CuTeDSL/test_link_libraries_order.py`
- `git diff --check`

## Contribution disclosure

AI assistance was used for repository research, implementation, independent review, and running the checks above.

Fixes #3564
