### PR TITLE
Fix SFB shared memory layout major selection

### DIFF
--- a/include/cutlass/detail/blockwise_scale_layout.hpp
+++ b/include/cutlass/detail/blockwise_scale_layout.hpp
@@ -107,7 +107,7 @@ struct Sm1xxBlockwiseScaleConfig {
   smem_atom_layoutSFB(CtaShape_MNK cta_shape_mnk) {
     static_assert(cute::is_static_v<CtaShape_MNK>, "Expect static CTA shape");
     auto strides = [&]() CUTLASS_LAMBDA_FUNC_INLINE {
-      if constexpr (majorSFA == UMMA::Major::MN) {
+      if constexpr (majorSFB == UMMA::Major::MN) {
         return make_stride(make_stride(_0{}, _1{}), make_stride(_0{}, Int<cute::ceil_div(size<1>(CtaShape_MNK{}), SFVecSizeN)>{}));
       }
       else {

--- a/test/unit/cute/core/CMakeLists.txt
+++ b/test/unit/cute/core/CMakeLists.txt
@@ -31,6 +31,7 @@ cutlass_test_unit_add_executable(
   WITHOUT_CUDA
   array_subbyte.cpp
   bitfield.cpp
+  blockwise_scale_layout.cpp
   coalesce.cpp
   compact_xmajor.cpp
   compare.cpp

--- a/test/unit/cute/core/blockwise_scale_layout.cpp
+++ b/test/unit/cute/core/blockwise_scale_layout.cpp
@@ -1,0 +1,50 @@
+/***************************************************************************************************
+ * Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "cutlass/detail/blockwise_scale_layout.hpp"
+
+TEST(CuTe_core, BlockwiseScaleLayoutSFBUsesOwnMajor) {
+  using namespace cute;
+
+  using KMajorSfa = cutlass::detail::Sm1xxBlockwiseScaleConfig<
+      64, 128, 128, UMMA::Major::K, UMMA::Major::MN>;
+  auto sfb_mn = KMajorSfa::smem_atom_layoutSFB(Shape<_128, _256, _512>{});
+  EXPECT_EQ(int(stride<0, 1>(sfb_mn)), 1);
+  EXPECT_EQ(int(stride<1, 1>(sfb_mn)), 2);
+
+  using MnMajorSfa = cutlass::detail::Sm1xxBlockwiseScaleConfig<
+      64, 128, 128, UMMA::Major::MN, UMMA::Major::K>;
+  auto sfb_k = MnMajorSfa::smem_atom_layoutSFB(Shape<_128, _256, _512>{});
+  EXPECT_EQ(int(stride<0, 1>(sfb_k)), 4);
+  EXPECT_EQ(int(stride<1, 1>(sfb_k)), 1);
+}

--- a/test/unit/cute/core/blockwise_scale_layout.cpp
+++ b/test/unit/cute/core/blockwise_scale_layout.cpp
@@ -29,22 +29,34 @@
  *
  **************************************************************************************************/
 
-#include <gtest/gtest.h>
+#include "cutlass_unit_test.h"
 
 #include "cutlass/detail/blockwise_scale_layout.hpp"
 
-TEST(CuTe_core, BlockwiseScaleLayoutSFBUsesOwnMajor) {
+template <cute::UMMA::Major MajorSFA, cute::UMMA::Major MajorSFB>
+constexpr bool
+sfb_smem_strides_match_global_layout()
+{
   using namespace cute;
+  using Config = cutlass::detail::Sm1xxBlockwiseScaleConfig<
+      64, 128, 128, MajorSFA, MajorSFB>;
+  // A CTA-sized problem makes the global SFB tile directly comparable to its
+  // shared-memory atom.
+  constexpr auto cta_shape = Shape<_128, _256, _512>{};
+  constexpr auto smem_layout = Config::smem_atom_layoutSFB(cta_shape);
+  constexpr auto global_layout = Config::tile_atom_to_shape_SFB(cta_shape);
+  return stride<0, 1>(smem_layout) == stride<0, 1>(global_layout) &&
+         stride<1, 1>(smem_layout) == stride<1, 1>(global_layout);
+}
 
-  using KMajorSfa = cutlass::detail::Sm1xxBlockwiseScaleConfig<
-      64, 128, 128, UMMA::Major::K, UMMA::Major::MN>;
-  auto sfb_mn = KMajorSfa::smem_atom_layoutSFB(Shape<_128, _256, _512>{});
-  EXPECT_EQ(int(stride<0, 1>(sfb_mn)), 1);
-  EXPECT_EQ(int(stride<1, 1>(sfb_mn)), 2);
-
-  using MnMajorSfa = cutlass::detail::Sm1xxBlockwiseScaleConfig<
-      64, 128, 128, UMMA::Major::MN, UMMA::Major::K>;
-  auto sfb_k = MnMajorSfa::smem_atom_layoutSFB(Shape<_128, _256, _512>{});
-  EXPECT_EQ(int(stride<0, 1>(sfb_k)), 4);
-  EXPECT_EQ(int(stride<1, 1>(sfb_k)), 1);
+TEST(CuTe_core, BlockwiseScaleLayoutSFBUsesOwnMajor)
+{
+  static_assert(sfb_smem_strides_match_global_layout<cute::UMMA::Major::MN,
+                                                      cute::UMMA::Major::MN>());
+  static_assert(sfb_smem_strides_match_global_layout<cute::UMMA::Major::K,
+                                                      cute::UMMA::Major::MN>());
+  static_assert(sfb_smem_strides_match_global_layout<cute::UMMA::Major::MN,
+                                                      cute::UMMA::Major::K>());
+  static_assert(sfb_smem_strides_match_global_layout<cute::UMMA::Major::K,
+                                                      cute::UMMA::Major::K>());
 }


### PR DESCRIPTION
`smem_atom_layoutSFB` currently selects its strides from `majorSFA`, so both mixed-major configurations get the opposite SFB ordering. This changes the predicate to `majorSFB`.

The host regression covers all four `(majorSFA, majorSFB)` combinations and compares the SFB shared-memory atom directly with `tile_atom_to_shape_SFB`. That gives a compile/pass check for `(K, MN)` and catches the otherwise masked `(MN, K)` mismatch at compile time.

Testing:

- compiled and ran `CuTe_core.BlockwiseScaleLayoutSFBUsesOwnMajor` with GCC 10.2.1
- confirmed the same test fails to compile on current `main` at exactly the two mixed-major assertions
- confirmed all four combinations compile with this change

Fixes #3535
