### PR TITLE
Fix dropped K tail in blockscaled GEMV

### DIFF
--- a/examples/91_fp4_gemv/CMakeLists.txt
+++ b/examples/91_fp4_gemv/CMakeLists.txt
@@ -28,9 +28,28 @@
 
 if (NOT MSVC)
 
+# Cover exact, partial-stage, and stage-boundary K tails.
+set(TEST_K_288  --m=256 --k=288  --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_1024 --m=256 --k=1024 --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_1056 --m=256 --k=1056 --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_1152 --m=256 --k=1152 --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_1280 --m=256 --k=1280 --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_1312 --m=256 --k=1312 --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_2048 --m=256 --k=2048 --batch=1 --epilogue_st=1.0 --profiling=false)
+set(TEST_K_2176 --m=256 --k=2176 --batch=1 --epilogue_st=1.0 --profiling=false)
+
 cutlass_example_add_executable(
   91_fp4_gemv
   91_fp4_gemv.cu
+  TEST_COMMAND_OPTIONS
+  TEST_K_288
+  TEST_K_1024
+  TEST_K_1056
+  TEST_K_1152
+  TEST_K_1280
+  TEST_K_1312
+  TEST_K_2048
+  TEST_K_2176
 )
 
 endif()

--- a/include/cutlass/gemm/kernel/gemv_blockscaled.h
+++ b/include/cutlass/gemm/kernel/gemv_blockscaled.h
@@ -319,7 +319,7 @@ public:
         const int tileA_k_local = kThreadsPerRow * kElementsPerAccess;
         const int total_tiles   = gemm_k / tileA_k_local;
 
-        int unroll_col_k = 0; // total K elements consumed so far by this thread
+        int unroll_col_k = 0; // next K offset issued to gmem prefetch, not the K accumulated so far
         const int thread_id = threadIdx.y * kThreadsPerRow + threadIdx.x;
         const bool is_even_thread = (threadIdx.x % 2 == 0);
         const bool load_b = (threadIdx.y == 0);
@@ -485,8 +485,9 @@ public:
           __syncthreads();
 
           // Tail elements that don't fill a full tile
-          if (unroll_col_k + idx_col_k * kPackedElementsA < gemm_k) {
-            accum += process_tail_elements(unroll_col_k, idx_col_k, gemm_k,
+          const int tail_col_k = tile_idx * tileA_k_local;
+          if (tail_col_k + idx_col_k * kPackedElementsA < gemm_k) {
+            accum += process_tail_elements(tail_col_k, idx_col_k, gemm_k,
                                            ptr_A, ptr_B,
                                            ptr_SF_A, ptr_SF_B,
                                            A_converter, B_converter,


### PR DESCRIPTION
Addresses #3536.

## Problem

`gemv_blockscaled.h` gates the K tail on `unroll_col_k`, which is the gmem prefetch
issue cursor rather than the K range that has been accumulated. The prologue primes
one buffer and every mainloop iteration issues one more ahead of consumption, so at
loop exit `unroll_col_k` leads the accumulated range by `kStageCount * tileA_k_local`.

When `floor(gemm_k / tileA_k_local)` is a multiple of `kStageCount` and `gemm_k` is
not tile aligned, the guard is false for every thread, `process_tail_elements()` never
runs, and up to a tile of K is dropped from the dot product.

## Fix

`tile_idx` advances by `kStageCount` per iteration and the FMA sequence within an
iteration is unconditional, so `tile_idx * tileA_k_local` at loop exit is the K range
that was accumulated. It is used as the tail origin for both the guard and
`process_tail_elements()`. `ptr_A` and `ptr_B` are not advanced by the mainloop, so
absolute-K addressing inside the tail is unaffected.

## Tests

ctest cases registered on example 91, all with
`--m=256 --batch=1 --epilogue_st=1.0 --profiling=false`:

| K | floor(K/256) | before | after |
|---|---|---|---|
| 288 | 1 | pass | pass |
| 1024 | 4 | pass | pass |
| 1056 | 4 | **fail** | pass |
| 1152 | 4 | **fail** | pass |
| 1280 | 5 | pass | pass |
| 1312 | 5 | pass | pass |
| 2048 | 8 | pass | pass |
| 2176 | 8 | **fail** | pass |

288, 1280 and 1312 are controls: they would fail if `total_tiles * tileA_k_local` were
used as the tail origin, which double counts what the mainloop already consumed.

Wider sweep, 21 values of K from 32 to 2304 across batch {1, 2, 3}, same build with
only the kernel header swapped: 29/63 pass before, 38/63 after. The nine that change
are K = 1056, 1152 and 2176 at each batch count. No regressions.

Built and run on sm_120a (RTX 5070 Ti Laptop), CUDA 13.0.88.

## Targeted revalidation (2026-09-08)

Re-ran the published head `92d769b3d9ab9c611d8f3b7e7300e488a58ba5ac` on the same RTX 5070 Ti Laptop / SM120a / CUDA 13.0.88 environment:

- `ctest --test-dir build-3536-v3 -R ctest_examples_91_fp4_gemv --output-on-failure`: **8/8 passed**.
- Additional `(K, batch)` checks `(1056, 2)`, `(1152, 3)`, `(2176, 3)`, using the same verification options above: **3/3 passed**.

The independent partial-stage limitation described below remains outside this PR. AI assistance was used for the targeted revalidation and this report.

## Not covered here

#3536 also notes loads issued past the current K range. Because the per-iteration FMA
sequence is unconditional, the mainloop always runs a whole multiple of `kStageCount`
tiles and keeps accumulating past `gemm_k` whenever
`floor(gemm_k / tileA_k_local) % kStageCount != 0`. At `batch=1` those configurations
happen to verify; at `batch > 1` they do not:

```
./91_fp4_gemv --m=256 --k=1280 --batch=2 --epilogue_st=1.0 --profiling=false
```

Filed separately as #3568. Fixing it needs per-stage load/FMA predication plus a
matching change to the partial-stage accumulation, which is a much larger change than
this one, so it is left out here. I can follow up with it if that is useful.

Thanks to @VaggelisGian for the report and root-cause analysis.
