### PR TITLE
Fix ArraySubbyte logical back and iterator bounds

### DIFF
--- a/include/cutlass/array_subbyte.h
+++ b/include/cutlass/array_subbyte.h
@@ -312,7 +312,7 @@ struct Array<T, N, false> {
     const_iterator(Storage const *ptr, int idx = 0): ptr_(ptr), idx_(idx) { }
 
     CUTLASS_HOST_DEVICE
-    iterator &operator++() {
+    const_iterator &operator++() {
       ++idx_;
       if (idx_ == kElementsPerStoredItem) {
         ++ptr_;
@@ -322,7 +322,7 @@ struct Array<T, N, false> {
     }
 
     CUTLASS_HOST_DEVICE
-    iterator &operator--() {
+    const_iterator &operator--() {
       if (!idx_) {
         --ptr_;
         idx_ = kElementsPerStoredItem - 1;
@@ -334,8 +334,8 @@ struct Array<T, N, false> {
     }
 
     CUTLASS_HOST_DEVICE
-    iterator operator++(int) {
-      iterator ret(*this);
+    const_iterator operator++(int) {
+      const_iterator ret(*this);
       ++idx_;
       if (idx_ == kElementsPerStoredItem) {
         ++ptr_;
@@ -345,8 +345,8 @@ struct Array<T, N, false> {
     }
 
     CUTLASS_HOST_DEVICE
-    iterator operator--(int) {
-      iterator ret(*this);
+    const_iterator operator--(int) {
+      const_iterator ret(*this);
       if (!idx_) {
         --ptr_;
         idx_ = kElementsPerStoredItem - 1;
@@ -363,12 +363,12 @@ struct Array<T, N, false> {
     }
 
     CUTLASS_HOST_DEVICE
-    bool operator==(iterator const &other) const {
+    bool operator==(const_iterator const &other) const {
       return ptr_ == other.ptr_ && idx_ == other.idx_;
     }
 
     CUTLASS_HOST_DEVICE
-    bool operator!=(iterator const &other) const {
+    bool operator!=(const_iterator const &other) const {
       return !(*this == other);
     }
   };
@@ -449,12 +449,12 @@ struct Array<T, N, false> {
 
   CUTLASS_HOST_DEVICE
   reference back() {
-    return reference(storage + kStorageElements - 1, kElementsPerStoredItem - 1);
+    return at(N - 1);
   }
 
   CUTLASS_HOST_DEVICE
   const_reference back() const {
-    return const_reference(storage + kStorageElements - 1, kElementsPerStoredItem - 1);
+    return at(N - 1);
   }
 
   CUTLASS_HOST_DEVICE
@@ -513,18 +513,28 @@ struct Array<T, N, false> {
   }
 
   CUTLASS_HOST_DEVICE
+  const_iterator begin() const {
+    return cbegin();
+  }
+
+  CUTLASS_HOST_DEVICE
   const_iterator cbegin() const {
     return const_iterator(storage);
   }
 
   CUTLASS_HOST_DEVICE
   iterator end() {
-    return iterator(storage + kStorageElements);
+    return iterator(storage + N / kElementsPerStoredItem, N % kElementsPerStoredItem);
+  }
+
+  CUTLASS_HOST_DEVICE
+  const_iterator end() const {
+    return cend();
   }
 
   CUTLASS_HOST_DEVICE
   const_iterator cend() const {
-    return const_iterator(storage + kStorageElements);
+    return const_iterator(storage + N / kElementsPerStoredItem, N % kElementsPerStoredItem);
   }
 
   CUTLASS_HOST_DEVICE

--- a/test/unit/core/array.cu
+++ b/test/unit/core/array.cu
@@ -258,4 +258,54 @@ TEST(Array, Bin1x128) {
   TestArray<cutlass::bin1_t, 128>().run();
 }
 
+TEST(Array, SubbyteBackUsesLogicalLastElement) {
+  cutlass::Array<cutlass::int4b_t, 5> array;
+  array.clear();
+
+  for (int i = 0; i < int(array.size()); ++i) {
+    array[i] = cutlass::int4b_t(i + 1);
+  }
+
+  EXPECT_EQ(int(array.back()), int(array[4]));
+
+  cutlass::Array<cutlass::int4b_t, 5> const &const_array = array;
+  EXPECT_EQ(int(const_array.back()), int(const_array[4]));
+}
+
+TEST(Array, SubbyteIteratorsUseLogicalElementRange) {
+  cutlass::Array<cutlass::int4b_t, 5> array;
+  array.clear();
+
+  int count = 0;
+  for (auto mutable_it = array.begin(); mutable_it != array.end(); ++mutable_it) {
+    *mutable_it = cutlass::int4b_t(++count);
+  }
+  EXPECT_EQ(count, 5);
+
+  cutlass::Array<cutlass::int4b_t, 5> const &const_array = array;
+  auto it = const_array.cbegin();
+  auto first = it++;
+  EXPECT_EQ(int(*first), 1);
+  EXPECT_EQ(int(*it), 2);
+
+  ++it;
+  EXPECT_EQ(int(*it), 3);
+  --it;
+  EXPECT_EQ(int(*it), 2);
+
+  auto second = it--;
+  EXPECT_EQ(int(*second), 2);
+  EXPECT_TRUE(it == const_array.cbegin());
+  EXPECT_TRUE(it != const_array.cend());
+
+  count = 0;
+  int sum = 0;
+  for (auto value : const_array) {
+    ++count;
+    sum += int(value);
+  }
+  EXPECT_EQ(count, 5);
+  EXPECT_EQ(sum, 15);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- make `ArraySubbyte::back()` address logical element `N - 1` instead of the final physical storage position
- make `end()` and `cend()` stop after `N` elements so iteration does not expose padding
- fix the `const_iterator` self types and add the missing const `begin()` and `end()` overloads

## Testing

- reproduced the `back()` mismatch on `main`: the standalone check compiled and returned failure
- confirmed the new unit source fails to compile on `main` in the broken const iterator methods
- built `test/unit/core/array.cu` with CUDA 11.2 and GCC 10.2.1 for `sm_70` on `lsi`
- ran `Array.Subbyte*`: 2 tests passed
- ran `git diff --check`

The unfiltered test binary reaches an existing device assertion in `Array.Int4x32` because threads 8 through 31 construct out-of-range signed int4 values. The two targeted regression tests pass independently.

## Contribution disclosure

AI assistance was used for repository research, implementation, independent review, and running the checks above. I reproduced the failures, reviewed every changed line, and take responsibility for the submission.

Fixes #3515
