### PR TITLE
Fix non-fused dual GEMM verification

### DIFF
--- a/examples/45_dual_gemm/dual_gemm_run.h
+++ b/examples/45_dual_gemm/dual_gemm_run.h
@@ -437,8 +437,8 @@ struct NonFusedDualGemmRun
     CHECK_GT(cutlass::reference::host::TensorNorm(reference_D1.host_view()), 0);
 
     bool passed0 = cutlass::reference::host::TensorEquals(
-      reference_D1.host_view(), 
-      tensor_D1.host_view());
+      reference_D0.host_view(),
+      tensor_D0.host_view());
     CHECK_TRUE(passed0);
 
     bool passed1 = cutlass::reference::host::TensorEquals(
@@ -460,6 +460,7 @@ struct NonFusedDualGemmRun
         << "\nC0 =\n" << tensor_C0.host_view()
         << "\nBias0:\n" << tensor_Bias0.host_view() << "\n"
         << "\nD0 =\n" << tensor_D0.host_view()
+        << "\nReference D0 =\n" << reference_D0.host_view()
         << "\nB1 =\n" << tensor_B1.host_view()
         << "\nC1 =\n" << tensor_C1.host_view()
         << "\nBias1:\n" << tensor_Bias1.host_view() << "\n"


### PR DESCRIPTION
## Summary

The non-fused dual GEMM example compared D1 twice, so a bad D0 result could still report success. This changes the first comparison to D0 and includes Reference D0 in the failure dump.

## Testing

- Built `45_dual_gemm` with CUDA 12.4.1 for SM86
- Ran it on an RTX 3090; the non-fused, fused, batched, and broadcast cases passed

Fixes #3523

This change was prepared with AI assistance and verified by the author.