### PR TITLE
Fix cute.composition rejecting dynamic-shaped RHS modes with a ScaledBasis stride

### DIFF
--- a/cutlass_compiler/cutegen/include/cutegen/layout.hpp
+++ b/cutlass_compiler/cutegen/include/cutegen/layout.hpp
@@ -1674,7 +1674,8 @@ layout_t<TDynTraits> composition_impl(const cute_shape_t<TDynTraits>&  lhs_shape
     // Special case for a RHS ScaledBasis stride
     if(holds_scaled_basis(rhs_stride))
     {
-        if(!holds_int(rhs_shape)) return cg_error_t{};
+        // rhs_shape may be dynamic: it's forwarded as-is to composition_impl below,
+        // whose remaining cases already tolerate a dynamic shape.
         using sb_t                 = typename find_scaled_basis_in_rec_var<stride_t>::value;
         const auto& sb             = std::get<sb_t>(rhs_stride);
         const auto& v              = sb.modes();

--- a/cutlass_compiler/cutegen/test/cg_composition_test.cpp
+++ b/cutlass_compiler/cutegen/test/cg_composition_test.cpp
@@ -415,6 +415,28 @@ TEST(CompositionTest, Basic)
         EXPECT_EQ(r, layout(shape(dyn_t{}), stride(dyn_t{})));
     }
     // -------------------------------
+    // RHS ScaledBasis stride + dynamic shape (github.com/NVIDIA/cutlass/issues/3470)
+    // -------------------------------
+    {
+        // scaled_basis(mode, value)
+        auto a = layout(shape(4, 4), stride(4, 1));
+        auto b = layout(shape(dyn_t{}, 4), stride(cg::scaled_basis(1, 1), cg::scaled_basis(0, 1)));
+        auto r = test_composition(a, b);
+        // (4,4):(4,1) o (?,4):(1@1,1@0)  =>  (?,4):(1,4)
+        EXPECT_EQ(r, layout(shape(dyn_t{}, 4), stride(1, 4)));
+    }
+    {
+        // Exact repro from the issue: (4096,8192):(1,4096) o (32,?,8,128):(E(0),8*E(1),E(1),32*E(0))
+        auto a = layout(shape(4096, 8192), stride(1, 4096));
+        auto b = layout(shape(32, dyn_t{}, 8, 128),
+                        stride(cg::scaled_basis(0, 1),
+                                cg::scaled_basis(1, 8),
+                                cg::scaled_basis(1, 1),
+                                cg::scaled_basis(0, 32)));
+        auto r = test_composition(a, b);
+        EXPECT_TRUE(cg::is_valid(r));
+    }
+    // -------------------------------
     // cosize(b) > size(a) and divisibility
     // -------------------------------
     {


### PR DESCRIPTION
## Summary
cute.composition raised an MLIRError when the RHS layout had a ScaledBasis stride (cute.E(...)) on a mode with a dynamic shape.

The check causing this required the mode's shape to be a static int, but that shape is never read in the ScaledBasis branch before the check. It is forwarded unchanged into a recursive composition_impl call, and every branch that call can land in already tolerates a dynamic shape: one copies the shape into the result without inspecting it, the other gates its static divisibility checks behind holds_int() and skips them when an operand is dynamic. Removing the check lets composition compute the result the same way it already does in every other dynamic-shape case.

Fixes #3470.

## Test plan
- Added two cases to CompositionTest.Basic in cg_composition_test.cpp, one minimal ScaledBasis plus dynamic shape case, one matching the layouts from the issue.
- Ran the full cutegen unit suite (24 binaries, about 200 tests) against the patch. All pass.