### PR TITLE
Copy the imaginary halves of the inputs in MmaPlanarComplex

### DIFF
--- a/include/cutlass/gemm/warp/mma_planar_complex.h
+++ b/include/cutlass/gemm/warp/mma_planar_complex.h
@@ -135,10 +135,10 @@ public:
     frag_A.real = A_in.real;
 
     if (kTransformA == ComplexTransform::kConjugate) {
-      frag_A.imag = neg_A(frag_A.imag);
+      frag_A.imag = neg_A(A_in.imag);
     }
     else {
-      frag_A.imag = frag_A.imag;
+      frag_A.imag = A_in.imag;
     }
 
     FragmentB frag_B;
@@ -146,10 +146,10 @@ public:
 
     if (kTransformB == ComplexTransform::kConjugate) {
       negate<typename FragmentB::ArrayReal> neg;
-      frag_B.imag = neg(frag_B.imag);
+      frag_B.imag = neg(B_in.imag);
     }
     else {
-      frag_B.imag = frag_B.imag;
+      frag_B.imag = B_in.imag;
     }
 
     //


### PR DESCRIPTION
Was reading `mma_planar_complex.h` and stopped on `frag_A.imag = frag_A.imag;` in the non-conjugate branch. Grepping the rest of the file, `A_in.imag` and `B_in.imag` do not appear anywhere, so the imaginary halves of both input fragments never reach the local ones. `ArrayPlanarComplex` holds two plain `cutlass::Array` members and nothing clears them, so `frag_A.imag` is whatever was on the stack, and the conjugate branch negates that same uninitialized value rather than the input. Three of the four real-valued mmas below then consume it.

I have not run this on hardware and could not find a test that reaches this specialization, so it is worth a second opinion on whether it is still on a live path before this goes in.
