### PR TITLE
[Core] Fix PredicateVector zero detection

### DIFF
--- a/include/cutlass/predicate_vector.h
+++ b/include/cutlass/predicate_vector.h
@@ -166,7 +166,7 @@ struct PredicateVector {
   }
 
   /// Returns word mask.
-  CUTLASS_HOST_DEVICE static constexpr bool computeWordMask() {
+  CUTLASS_HOST_DEVICE static constexpr Storage computeWordMask() {
     Storage mask(0);
     CUTLASS_PRAGMA_UNROLL
     for (size_t byte = 0; byte < sizeof(Storage); ++byte) {
@@ -176,10 +176,11 @@ struct PredicateVector {
   }
 
   /// Returns mask of last word.
-  CUTLASS_HOST_DEVICE static constexpr bool computeLastWordMask() {
+  CUTLASS_HOST_DEVICE static constexpr Storage computeLastWordMask() {
     Storage mask(0);
+    constexpr int byte_count = (kBytes - 1) % int(sizeof(Storage)) + 1;
     CUTLASS_PRAGMA_UNROLL
-    for (int byte = 0; byte < kBytes % sizeof(Storage); ++byte) {
+    for (int byte = 0; byte < byte_count; ++byte) {
       mask |= (kByteMask << (byte * 8));
     }
     return mask;

--- a/test/unit/core/predicate_vector.cu
+++ b/test/unit/core/predicate_vector.cu
@@ -75,6 +75,24 @@ __global__ void load_predicates(unsigned *output, unsigned const *input) {
     output[word_idx] = result;
   }
 }
+
+template <int Predicates>
+void test_is_zero() {
+  cutlass::PredicateVector<Predicates> predicates(true);
+  EXPECT_FALSE(predicates.is_zero());
+
+  for (int i = 0; i < Predicates; ++i) {
+    predicates.set(i, false);
+  }
+  EXPECT_TRUE(predicates.is_zero()) << "Predicates: " << Predicates;
+
+  for (int i = 0; i < Predicates; ++i) {
+    predicates.set(i);
+    EXPECT_FALSE(predicates.is_zero()) << "Predicates: " << Predicates << ", index: " << i;
+    predicates.set(i, false);
+    EXPECT_TRUE(predicates.is_zero()) << "Predicates: " << Predicates << ", index: " << i;
+  }
+}
 }
 
 TEST(PredicateVector, Basic) {
@@ -123,6 +141,13 @@ TEST(PredicateVector, Basic) {
         << std::dec;
     }
   }
+}
+
+TEST(PredicateVector, IsZero) {
+  test::test_is_zero<4>();
+  test::test_is_zero<16>();
+  test::test_is_zero<20>();
+  test::test_is_zero<32>();
 }
 
 TEST(PredicateVector, Count) {


### PR DESCRIPTION
## Summary

- keep complete predicate masks instead of narrowing them to `bool`
- include every byte when the last storage word is exactly full
- cover single-word, partial-word, full-word, and padding-bit cases

## Testing

- compiled `test/unit/core/predicate_vector.cu` with NVCC 11.2
- ran `PredicateVector.*` on an RTX 3090: 3 tests passed
- verified the standalone reproduction fails before the change and passes after it
- `git diff --check`

The machine has CUDA 11.2, so the unrelated `complex.cu` part of the aggregate core target cannot build against CUTLASS 4.8. The affected test source compiled and ran successfully.

## Contribution disclosure

AI assistance was used for repository research, implementation, independent review, and running the checks above.

Fixes #3512
