### PR TITLE
Fix skipped workspace initialization for parallel split-K in GemmUniversalBase

### DIFF
--- a/include/cutlass/gemm/device/gemm_universal_base.h
+++ b/include/cutlass/gemm/device/gemm_universal_base.h
@@ -413,11 +413,7 @@ public:
     }
 
     // Assign and prepare workspace memory
-    if (args.mode == GemmUniversalMode::kGemm) {
-      return params_.init_workspace(workspace, stream);
-    }
-
-    return Status::kSuccess;
+    return params_.init_workspace(workspace, stream);
   }
 
 

--- a/include/cutlass/gemm/kernel/params_universal_base.h
+++ b/include/cutlass/gemm/kernel/params_universal_base.h
@@ -174,8 +174,10 @@ struct UniversalParamsBase
     cudaStream_t stream = nullptr)
   {
     semaphore = static_cast<int *>(workspace);
-    // Zero-initialize entire workspace
-    if (semaphore)
+    // Zero-initialize the workspace only for serial split-K semaphores
+    // (mode kGemm); other modes fully overwrite their workspace before
+    // reading it.
+    if (semaphore && mode == GemmUniversalMode::kGemm)
     {
       size_t workspace_bytes = get_workspace_size();
 


### PR DESCRIPTION
## **Problem**

Fixes #3538.

Since 3.2, GemmUniversalBase::initialize() only calls Params::init_workspace() for kGemm, but GemmWithKReduction::Params::init_workspace() performs the parallel split-K pointer setup only for kGemmSplitKParallel. That makes the setup unreachable: partials are written through the user's ptr_D, causing OOB writes when grid.k > 1, while the reduction reads workspace that was never written.

The gate only appeared in the 3.2 squash commit; v2.11 and v3.1 called `init_workspace()` in every mode. Every kernel that customizes `init_workspace()` checks the mode inside its own implementation, so the unconditional call is the contract those implementations were written against.

## **Fix**

Restore the unconditional init_workspace() call and move the mode check to ParamsBase's workspace memset. Only serial split-K needs that memset to zero its semaphore; parallel split-K fully overwrites its workspace before reduction.

This restores the required parallel setup while still skipping the pointless whole-buffer memset for parallel split-K, since it fully overwrites its workspace before reduction.

## **Testing**

Example 23 (ampere_gemm_operand_reduction_fusion), SM86, CUDA 12.8, m=1024 n=1024 k=8192:

Before: plain and serial split-K pass; 8-slice parallel split-K miscompares, with compute-sanitizer reporting invalid 16-byte writes past D.

After: all three pass; compute-sanitizer reports 0 errors.

Serial split-K also exercises the re-gated semaphore memset and remains unchanged.

------

AI assistance was used during investigation and drafting. The proposed logic, code changes, and reported test results were reviewed and verified by the author.