### PR TITLE
Fix Constexpr method receivers in dynamic control-flow regions

### DIFF
--- a/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
+++ b/python/CuTeDSL/cutlass/base_dsl/ast_preprocessor.py
@@ -50,6 +50,7 @@ from itertools import chain
 
 from .common import *
 from .diagnostics import DiagId
+from .runtime.jit_arg_adapters import is_arg_annotation_constexpr
 from .utils.logger import log
 
 
@@ -333,6 +334,7 @@ class SessionData:
     region_stack: list[Region] = field(default_factory=list)
     generator_targets: list[str] = field(default_factory=list)
     lambda_args: list[str] = field(default_factory=list)
+    constexpr_param_names: set[str] = field(default_factory=set)
 
     @contextlib.contextmanager
     def _set_attr(self, attr: str, value: str) -> Generator[None, None, None]:
@@ -647,6 +649,15 @@ class DSLPreprocessor(ast.NodeTransformer):
             function_pointer, self._default_arg_source_names(func_def)
         )
 
+        sig = inspect.signature(function_pointer, eval_str=True)
+        self.session_data.constexpr_param_names = {
+            name
+            for index, (name, param) in enumerate(sig.parameters.items())
+            if is_arg_annotation_constexpr(
+                param.annotation, name, index, function_pointer
+            )
+        }
+
         # Step 2. Transform the function
         transformed_tree = self.visit(tree)
 
@@ -872,6 +883,7 @@ class DSLPreprocessor(ast.NodeTransformer):
         write_args = OrderedSet()
         invoked_args = OrderedSet()
         called_functions = OrderedSet()
+        constexpr_param_names = self.session_data.constexpr_param_names
 
         class RegionAnalyzer(ast.NodeVisitor):
             force_store = False
@@ -926,7 +938,11 @@ class DSLPreprocessor(ast.NodeTransformer):
 
                 # Classes are mutable by default. Mark them as write. If they are
                 # dataclass(frozen=True), treat them as read in runtime.
-                if base_name is not None and base_name not in ("self",):
+                if (
+                    base_name is not None
+                    and base_name not in ("self",)
+                    and base_name not in constexpr_param_names
+                ):
                     invoked_args.add(base_name)
 
                 self.generic_visit(node)

--- a/test/python/CuTeDSL/test_constexpr_receiver_in_if.py
+++ b/test/python/CuTeDSL/test_constexpr_receiver_in_if.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# Use of this software is governed by the terms and conditions of the
+# NVIDIA End User License Agreement (EULA), available at:
+# https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/license.html
+#
+# Any use, reproduction, disclosure, or distribution of this software
+# and related documentation outside the scope permitted by the EULA
+# is strictly prohibited.
+
+"""Regression coverage for a Constexpr method receiver in staged control flow."""
+
+import unittest
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32
+from cutlass.cute.runtime import make_fake_tensor
+
+
+class _ConstexprReceiver:
+    """Plain Python meta object: deliberately not MLIR-decomposable."""
+
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    @cute.jit
+    def store(self, output: cute.Tensor) -> None:
+        output[0] = Float32(self.value)
+
+
+@cute.kernel
+def _kernel_with_constexpr_receiver(
+    receiver: cutlass.Constexpr[_ConstexprReceiver], output: cute.Tensor
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    if tidx == Int32(0):
+        receiver.store(output)
+
+
+@cute.jit
+def _compile_constexpr_receiver(
+    receiver: cutlass.Constexpr[_ConstexprReceiver], output: cute.Tensor
+):
+    _kernel_with_constexpr_receiver(receiver, output).launch(
+        grid=(1, 1, 1), block=(32, 1, 1)
+    )
+
+
+class TestConstexprReceiverInIf(unittest.TestCase):
+    def test_plain_python_receiver_is_not_lowered_as_if_result(self):
+        output = make_fake_tensor(Float32, (1,), stride=(1,), assumed_align=4)
+        cute.compile(_compile_constexpr_receiver, _ConstexprReceiver(3.0), output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3632

## Motivation

I encountered this while implementing FlashAttention. The implementation naturally groups the load and MMA paths into JIT methods on a compile-time configuration object, and selects between them using the runtime warp index. A reduced version looks like this:

```python
class FlashAttention:
    @cute.jit
    def load(self, tensor, pipeline):
        ...

    @cute.jit
    def mma(self, tensor, pipeline):
        ...


@cute.jit
def fa4_device_body(
    fa: cutlass.Constexpr[FlashAttention],
    tensor: cute.Tensor,
    storage,
):
    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())

    pipeline = make_pipeline(
        storage=storage,
        num_stages=fa.num_stages,
    )

    if warp_idx < 4:
        cute.arch.setmaxregister_decrease(fa.num_producer_regs)
        fa.load(tensor, pipeline)
    else:
        cute.arch.setmaxregister_increase(fa.num_mma_regs)
        fa.mma(tensor, pipeline)
```

Here, `self` in `FlashAttention.load()` and `FlashAttention.mma()` is a compile-time method receiver. The `fa` parameter in `fa4_device_body()` refers to the same kind of compile-time object, made explicit by its `Constexpr` annotation.

Writing the device body as an actual instance method makes this code compile, but only because the compiler has a special case that excludes a receiver whose name is literally `self`. Passing the same object as a named `Constexpr[FlashAttention]` parameter should have equivalent staging semantics, but currently does not.

## Problem

CuTe DSL treats `Constexpr[T]` parameters as compile-time Python meta values. They do not have an MLIR representation and must not become arguments or results of runtime control-flow regions.

However, when a method is called through a `Constexpr` receiver inside a dynamic `if`, the receiver is incorrectly captured as a region argument:

```python
class Receiver:
    @cute.jit
    def store(self, output):
        ...


@cute.kernel
def kernel(receiver: cutlass.Constexpr[Receiver], output: cute.Tensor):
    tidx, _, _ = cute.arch.thread_idx()

    if tidx == Int32(0):
        receiver.store(output)
```

The region analyzer currently treats the base object of every method call as a mutable runtime value, except when its name is literally `self`.

Consequently, `receiver` is added to the values carried through the dynamic `if`. Lowering then attempts to flatten the plain Python `Receiver` instance into MLIR values and fails with:

```text
error[TYPE_DYNAMIC_EXPR_UNSUPPORTED]:
A value carried through this `if` is a plain Python value (Meta value)
(a `Receiver`) that cannot be turned into a Runtime value (Staged value)
```

This means `self.method()` works because of the existing `self` special case, while an explicitly annotated `receiver: Constexpr[Receiver]` does not, despite having the same staging semantics.

## Root cause

`Constexpr` is a property of the original function parameter binding. The AST preprocessor removes parameter annotations while transforming the function, so the later control-flow region analysis no longer knows which names refer to `Constexpr` parameters.

`RegionAnalyzer.visit_Call()` therefore sees only a method call on a Python object and adds its receiver to `invoked_args`.

## Fix

This change:

1. Inspects the original function signature before AST transformation.
2. Uses the existing `is_arg_annotation_constexpr()` helper to record `Constexpr` parameter names in the preprocessing session.
3. Excludes those names from method receivers carried through runtime control-flow regions.

Normal runtime receivers and decomposable DSL values continue to use the existing region argument handling.

## Regression test

A regression test uses a deliberately non-MLIR-decomposable Python class as a `Constexpr` receiver and calls one of its JIT methods inside a dynamic `if`.

The test calls `cute.compile()`, so it verifies the complete lowering path that previously failed.

## Validation

Both sides of the comparison used the same `nvidia-cutlass-dsl 4.8.0.dev0` native runtime components and the same test.

### Before this change

Base commit: `59e3a333` (`v4.8.0dev-6`)

```text
FAILED test_constexpr_receiver_in_if.py
error[TYPE_DYNAMIC_EXPR_UNSUPPORTED]
1 failed
```

The failure occurs because `_ConstexprReceiver` is included in the values passed through the dynamic `if`.

### After this change

Commit: `740f0a6c` (`v4.8.0dev-7`)

```text
1 passed
```

The new regression test together with the existing structured control-flow tests also passes:

```text
7 passed, 6 warnings in 0.88s
```

The warnings are existing `SmemAllocator` deprecation warnings and are unrelated to this change.