### PR TITLE
[CuTeDSL] Support dynamic shapes in right_inverse

### DIFF
--- a/cutlass_compiler/cute_ir/include/cute_ir/Dialect/Cute/IR/CuteOps.td
+++ b/cutlass_compiler/cute_ir/include/cute_ir/Dialect/Cute/IR/CuteOps.td
@@ -3331,24 +3331,28 @@ def Cute_RightInverseOp : Cute_Op<"right_inverse", [
     DeclareOpInterfaceMethods<InferTypeOpInterface>
 ]> {
   let cuteSpecGroup = "LayoutAlgebra";
-  let summary = "Right inverse of a static layout";
+  let summary = "Right inverse of a layout";
   let description = [{
-    Computes the right inverse of a fully-static layout. The right
-    inverse ``R`` satisfies ``layout ∘ R = identity`` on the codomain of
-    ``layout``, making it useful for deriving inverse index mappings.
+    Computes the right inverse of a layout. The right inverse ``R`` satisfies
+    ``layout(R(i)) = i`` for every ``i`` in the domain of ``R``, making it
+    useful for deriving inverse index mappings.
 
     **Preconditions**
 
     - ``$input`` is ``!cute.layout``.
-    - ``$input`` is fully static (no ``?`` dynamic extents or strides).
-    - ``$input``'s strides are either all plain integer or all
-      scaled-basis (``@``); mixing the two within a single layout is
-      rejected.
+    - A dynamic shape is supported only with fully static plain-integer
+      strides. Static-shape inputs retain the supported integer,
+      non-ratio scaled-basis, and dynamic-stride behavior.
+    - Mixing plain-integer and scaled-basis strides is rejected unless every
+      plain-integer leaf is the static value zero, matching the existing
+      static-shape contract.
 
     **Postconditions**
 
-    - Result is ``!cute.layout`` and equals the right inverse ``R`` such
-      that ``$input ∘ R`` is the identity on ``$input``'s codomain.
+    - Result is ``!cute.layout`` and equals a right inverse ``R`` such that
+      ``$input ∘ R = make_layout(shape(R))``. For a dynamic shape, continuity
+      that cannot be proven statically conservatively limits ``R`` to the
+      maximal provable prefix.
 
     Worked example — column-major ``L = (2,3):(1,2)``
 
@@ -3453,23 +3457,22 @@ def Cute_RightInverseOp : Cute_Op<"right_inverse", [
     // Scaled-basis strides → flattened to plain scalar strides
     %r = cute.right_inverse(%src)
            : (!cute.layout<"(4,3):(1@0,1@1)">) -> !cute.layout<"(4,3):(1,4)">
+
+    // Dynamic shape → the maximal inverse prefix whose stride continuity is
+    // statically provable. Dynamic coalescing is a separate operation.
+    %r = cute.right_inverse(%src)
+           : (!cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)">
     ```
 
     **Errors**
 
-    - dynamic shape (right inverse not computable at compile time)
+    - dynamic shape combined with dynamic or scaled-basis strides
 
       ```mlir
-      %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(1,4)">) -> ...
+      %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(?,4)">) -> ...
       ```
 
-    - dynamic stride
-
-      ```mlir
-      %r = cute.right_inverse(%src) : (!cute.layout<"(4,3):(?,4)">) -> ...
-      ```
-
-    - mix of plain-integer and scaled-basis strides
+    - mix of nonzero plain-integer and scaled-basis strides
 
       ```mlir
       %r = cute.right_inverse(%src) : (!cute.layout<"(4,3):(1@0,4)">) -> ...
@@ -3484,7 +3487,7 @@ def Cute_RightInverseOp : Cute_Op<"right_inverse", [
   }];
 
   let arguments = (ins
-    Cute_Arg<Cute_LayoutType, "static input layout">:$input
+    Cute_Arg<Cute_LayoutType, "input layout">:$input
   );
   let results = (outs
     Cute_Arg<Cute_LayoutType, "right inverse layout">:$result

--- a/cutlass_compiler/cute_ir/lib/Conversion/CuteToBase/ExpandOps.cpp
+++ b/cutlass_compiler/cute_ir/lib/Conversion/CuteToBase/ExpandOps.cpp
@@ -1100,21 +1100,16 @@ struct DiceOpConversion final : public OpConversionPattern<DiceOp> {
   }
 };
 
-// right_inverse and left_inverse reject dynamic input via
-// inferReturnTypes (run by the InferTypeOpInterface trait
-// verifier), so the result is always static and the static-fold
-// shortcut at the top always fires. The dynamic path is therefore
-// unreachable in practice; kept as a defensive
-// notifyMatchFailure. The two ops have identical lowering logic —
-// InverseOpConversion<OpTy> captures the shared body, and the two
-// concrete types alias the template below.
+// right_inverse folds static results directly. Dynamic right_inverse results
+// are rebuilt from runtime-bound cutegen values. left_inverse remains
+// static-only.
 
 template <typename OpTy>
 struct InverseOpConversion final : public OpConversionPattern<OpTy> {
   using OpConversionPattern<OpTy>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(OpTy op, typename OpTy::Adaptor /*adaptor*/,
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
     auto resTy = llvm::cast<LayoutType>(op.getResult().getType());
@@ -1122,11 +1117,17 @@ struct InverseOpConversion final : public OpConversionPattern<OpTy> {
       rewriter.replaceOp(op, StaticOp::create(b, resTy));
       return success();
     }
-    return rewriter.notifyMatchFailure(
-        op, llvm::formatv("{0} requires fully-static input — "
-                          "inferReturnTypes should have rejected a "
-                          "dynamic operand before this pattern fires",
-                          OpTy::getOperationName()));
+    if constexpr (std::is_same_v<OpTy, RightInverseOp>) {
+      cg::dynamic_listener listener(b);
+      auto src = buildCutegenFromCuteValue<LayoutType>(
+          b, adaptor.getInput(), &listener);
+      auto res = cg::right_inverse(src);
+      rewriter.replaceOp(op, buildLayout(b, res));
+      return success();
+    } else {
+      return rewriter.notifyMatchFailure(
+          op, "left_inverse requires a fully-static input");
+    }
   }
 };
 

--- a/cutlass_compiler/cute_ir/lib/Dialect/IR/CuteOps.cpp
+++ b/cutlass_compiler/cute_ir/lib/Dialect/IR/CuteOps.cpp
@@ -1378,31 +1378,39 @@ DiceOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
 // Shared inferReturnTypes body for cute.right_inverse and
 // cute.left_inverse. The two ops differ in:
 //   - the cutegen function called (cgFn),
-//   - the diagnostic noun ("right" / "left"), and
-//   - the stride pre-condition: right_inverse accepts dynamic
-//     stride leaves (cutegen/layout.hpp, dyn_t allowed in the
-//     stride leaf-type predicate), while left_inverse requires the
-//     stride to be fully static (cutegen/layout.hpp).
-// Both overloads require a static shape.
+//   - the diagnostic noun ("right" / "left"),
+//   - the shape pre-condition, and
+//   - the stride pre-condition: right_inverse accepts dynamic stride leaves
+//     for static-shape inputs and fully static integer strides for dynamic
+//     shapes, while left_inverse requires the stride to be fully static
+//     (cutegen/layout.hpp).
 //
 
-// requireStaticStride toggles the stride check. cgFn is passed as
-// a callable so cutegen's template TDynTraits parameter is deduced
-// from cg::layout at the call site.
+// requireStaticShape and requireStaticStride toggle the corresponding
+// pre-condition checks. cgFn is passed as a callable so cutegen's template
+// TDynTraits parameter is deduced from cg::layout at the call site.
 template <typename Fn>
 static LogicalResult
 inferInverseReturnTypes(MLIRContext *context, std::optional<Location> location,
                         LayoutType inputTy, StringRef kindName,
-                        bool requireStaticStride, Fn &&cgFn,
+                        bool requireStaticShape, bool requireStaticStride,
+                        Fn &&cgFn,
                         SmallVectorImpl<Type> &inferredReturnTypes) {
   const auto &ref = inputTy.getRef();
-  if (!cg::is_static(ref.shape())) {
+  if (requireStaticShape && !cg::is_static(ref.shape())) {
     return emitOptionalError(location,
                              "expects a static-shape input layout, "
                              "but got ",
                              inputTy);
   }
-  // left inverse requires static stride
+  if (!requireStaticShape && !cg::is_static(ref.shape()) &&
+      !cg::is_integral_only(ref.stride())) {
+    return emitOptionalError(
+        location,
+        "expects a dynamic-shape input layout to have fully static integer "
+        "strides, but got ",
+        inputTy);
+  }
   if (requireStaticStride && !cg::is_static(ref.stride())) {
     return emitOptionalError(location,
                              "expects a static-stride input layout for ",
@@ -1433,7 +1441,8 @@ LogicalResult RightInverseOp::inferReturnTypes(
                              adaptor.getInput().getType());
   }
   return inferInverseReturnTypes(
-      context, location, inputTy, "right", /*requireStaticStride=*/false,
+      context, location, inputTy, "right", /*requireStaticShape=*/false,
+      /*requireStaticStride=*/false,
       [](const cg::layout &l) { return cg::right_inverse(l); },
       inferredReturnTypes);
 }
@@ -1454,7 +1463,8 @@ LogicalResult LeftInverseOp::inferReturnTypes(
                              adaptor.getInput().getType());
   }
   return inferInverseReturnTypes(
-      context, location, inputTy, "left", /*requireStaticStride=*/true,
+      context, location, inputTy, "left", /*requireStaticShape=*/true,
+      /*requireStaticStride=*/true,
       [](const cg::layout &l) { return cg::left_inverse(l); },
       inferredReturnTypes);
 }

--- a/cutlass_compiler/cute_ir/test/Conversion/CuteExpandOps/LayoutAlgebra/left_inverse.mlir
+++ b/cutlass_compiler/cute_ir/test/Conversion/CuteExpandOps/LayoutAlgebra/left_inverse.mlir
@@ -29,8 +29,9 @@
 // RUN: cute-opt -cute-expand-ops --split-input-file %s | FileCheck %s
 
 // Tests `cute-expand-ops` lowering for `cute.left_inverse`. Like
-// `right_inverse`, the op requires a fully-static input — the result is
-// always static and the static-fold shortcut always fires.
+// The op requires a fully-static input — the result is always static and the
+// static-fold shortcut always fires. `right_inverse` additionally supports
+// the bounded dynamic-shape path covered by its own test.
 
 // -----
 

--- a/cutlass_compiler/cute_ir/test/Conversion/CuteExpandOps/LayoutAlgebra/left_inverse.mlir
+++ b/cutlass_compiler/cute_ir/test/Conversion/CuteExpandOps/LayoutAlgebra/left_inverse.mlir
@@ -28,7 +28,7 @@
 
 // RUN: cute-opt -cute-expand-ops --split-input-file %s | FileCheck %s
 
-// Tests `cute-expand-ops` lowering for `cute.left_inverse`. Like
+// Tests `cute-expand-ops` lowering for `cute.left_inverse`.
 // The op requires a fully-static input — the result is always static and the
 // static-fold shortcut always fires. `right_inverse` additionally supports
 // the bounded dynamic-shape path covered by its own test.

--- a/cutlass_compiler/cute_ir/test/Conversion/CuteExpandOps/LayoutAlgebra/right_inverse.mlir
+++ b/cutlass_compiler/cute_ir/test/Conversion/CuteExpandOps/LayoutAlgebra/right_inverse.mlir
@@ -28,9 +28,8 @@
 
 // RUN: cute-opt -cute-expand-ops --split-input-file %s | FileCheck %s
 
-// Tests `cute-expand-ops` lowering for `cute.right_inverse`. The op
-// requires a fully-static input layout (verifier-enforced), so the
-// result is always static and the static-fold shortcut always fires.
+// Tests `cute-expand-ops` lowering for `cute.right_inverse`. Static results
+// fold directly; dynamic-shape results are rebuilt from runtime scalars.
 
 // -----
 
@@ -54,4 +53,36 @@ func.func @expand_static_permutation(%src: !cute.layout<"(4,3):(3,1)">)
   %r = cute.right_inverse(%src)
          : (!cute.layout<"(4,3):(3,1)">) -> !cute.layout<"(3,4):(4,1)">
   return %r : !cute.layout<"(3,4):(4,1)">
+}
+
+// -----
+
+// Dynamic shape with static integer strides.
+// CHECK-LABEL: func.func @expand_dynamic_shape
+// CHECK-NOT:   cute.right_inverse
+// CHECK:       %[[DYN:.+]] = cute.get_scalars<{only_dynamic}>
+// CHECK:       %[[SHAPE:.+]] = cute.make_shape(%[[DYN]]) : (i32) -> !cute.shape<"(16,?)">
+// CHECK:       %[[STRIDE:.+]] = cute.make_stride() : () -> !cute.stride<"(1,16)">
+// CHECK:       cute.make_layout(%[[SHAPE]], %[[STRIDE]])
+func.func @expand_dynamic_shape(%src: !cute.layout<"(16,?):(1,16)">)
+    -> !cute.layout<"(16,?):(1,16)"> {
+  %r = cute.right_inverse(%src)
+         : (!cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)">
+  return %r : !cute.layout<"(16,?):(1,16)">
+}
+
+// -----
+
+// Dynamic derived stride from the preserved runtime extent.
+// CHECK-LABEL: func.func @expand_dynamic_derived_stride
+// CHECK-NOT:   cute.right_inverse
+// CHECK:       %[[DYN:.+]] = cute.get_scalars<{only_dynamic}>
+// CHECK:       %[[SHAPE:.+]] = cute.make_shape() : () -> !cute.shape<"4">
+// CHECK:       %[[STRIDE:.+]] = cute.make_stride(%[[DYN]]) : (i32) -> !cute.stride<"?">
+// CHECK:       cute.make_layout(%[[SHAPE]], %[[STRIDE]]) : (!cute.shape<"4">, !cute.stride<"?">) -> !cute.layout<"4:?">
+func.func @expand_dynamic_derived_stride(%src: !cute.layout<"(?,4):(0,1)">)
+    -> !cute.layout<"4:?"> {
+  %r = cute.right_inverse(%src)
+         : (!cute.layout<"(?,4):(0,1)">) -> !cute.layout<"4:?">
+  return %r : !cute.layout<"4:?">
 }

--- a/cutlass_compiler/cute_ir/test/Conversion/CuteToBase/pipeline_full.mlir
+++ b/cutlass_compiler/cute_ir/test/Conversion/CuteToBase/pipeline_full.mlir
@@ -212,6 +212,47 @@ func.func @layout_algebra_composition(%a: !cute.layout<"(4,8):(1,4)">,
 
 // -----
 
+// LayoutAlgebra — dynamic right_inverse keeps the runtime extent through the
+// complete expansion and base-lowering pipeline.
+// CHECK-LABEL: func.func @layout_algebra_right_inverse_dynamic_shape
+// CHECK-SAME:    (%[[SRC:.+]]: !llvm.struct<(i32, struct<()>)>) -> i32
+// CHECK-NOT:     cute.
+// CHECK:         %[[N:.+]] = llvm.extractvalue %[[SRC]][0]
+// CHECK:         %[[WITH_N:.+]] = llvm.insertvalue %[[N]], %{{.+}}[0]
+// CHECK:         %[[OUT:.+]] = llvm.insertvalue %{{.+}}, %[[WITH_N]][1]
+// CHECK:         %[[RESULT_N:.+]] = llvm.extractvalue %[[OUT]][0]
+// CHECK:         return %[[RESULT_N]] : i32
+func.func @layout_algebra_right_inverse_dynamic_shape(
+    %src: !cute.layout<"(16,?):(1,16)">) -> i32 {
+  %r = cute.right_inverse(%src)
+         : (!cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)">
+  %n = cute.get_scalars<{only_dynamic}> (%r)
+         : !cute.layout<"(16,?):(1,16)">
+  return %n : i32
+}
+
+// -----
+
+// LayoutAlgebra — a runtime shape extent becomes the inverse's runtime stride
+// after a static zero-stride mode is skipped.
+// CHECK-LABEL: func.func @layout_algebra_right_inverse_zero_stride
+// CHECK-SAME:    (%[[SRC:.+]]: !llvm.struct<(i32, struct<()>)>) -> i32
+// CHECK-NOT:     cute.
+// CHECK:         %[[N:.+]] = llvm.extractvalue %[[SRC]][0]
+// CHECK:         %[[BASE:.+]] = llvm.insertvalue %{{.+}}, %{{.+}}[0]
+// CHECK:         %[[WITH_N:.+]] = llvm.insertvalue %[[N]], %[[BASE]][1]
+// CHECK:         %[[RESULT_N:.+]] = llvm.extractvalue %[[WITH_N]][1]
+// CHECK:         return %[[RESULT_N]] : i32
+func.func @layout_algebra_right_inverse_zero_stride(
+    %src: !cute.layout<"(?,4):(0,1)">) -> i32 {
+  %r = cute.right_inverse(%src)
+         : (!cute.layout<"(?,4):(0,1)">) -> !cute.layout<"4:?">
+  %n = cute.get_scalars<{only_dynamic}> (%r) : !cute.layout<"4:?">
+  return %n : i32
+}
+
+// -----
+
 // Arithmetic — tuple_sub on dynamic operands, then print.
 // CHECK-LABEL: func.func @arith_tuple_sub_print
 // CHECK-NOT:     cute.

--- a/cutlass_compiler/cute_ir/test/Conversion/CuteToBase/pipeline_full.mlir
+++ b/cutlass_compiler/cute_ir/test/Conversion/CuteToBase/pipeline_full.mlir
@@ -233,22 +233,48 @@ func.func @layout_algebra_right_inverse_dynamic_shape(
 
 // -----
 
-// LayoutAlgebra — a runtime shape extent becomes the inverse's runtime stride
-// after a static zero-stride mode is skipped.
-// CHECK-LABEL: func.func @layout_algebra_right_inverse_zero_stride
+// LayoutAlgebra — a dynamic middle extent contributes to the runtime prefix
+// product used as the second retained inverse mode's stride.
+// CHECK-LABEL: func.func @layout_algebra_right_inverse_dynamic_stride_product
 // CHECK-SAME:    (%[[SRC:.+]]: !llvm.struct<(i32, struct<()>)>) -> i32
 // CHECK-NOT:     cute.
 // CHECK:         %[[N:.+]] = llvm.extractvalue %[[SRC]][0]
-// CHECK:         %[[BASE:.+]] = llvm.insertvalue %{{.+}}, %{{.+}}[0]
-// CHECK:         %[[WITH_N:.+]] = llvm.insertvalue %[[N]], %[[BASE]][1]
-// CHECK:         %[[RESULT_N:.+]] = llvm.extractvalue %[[WITH_N]][1]
-// CHECK:         return %[[RESULT_N]] : i32
-func.func @layout_algebra_right_inverse_zero_stride(
-    %src: !cute.layout<"(?,4):(0,1)">) -> i32 {
+// CHECK:         %[[FOUR:.+]] = arith.constant 4 : i32
+// CHECK:         %[[STRIDE:.+]] = arith.muli %[[N]], %[[FOUR]]
+// CHECK:         %[[WITH_STRIDE:.+]] = llvm.insertvalue %[[STRIDE]], %{{.+}}[1]
+// CHECK:         %[[RESULT_STRIDE:.+]] = llvm.extractvalue %[[WITH_STRIDE]][1]
+// CHECK:         return %[[RESULT_STRIDE]] : i32
+func.func @layout_algebra_right_inverse_dynamic_stride_product(
+    %src: !cute.layout<"(4,?,2):(1,16,4)">) -> i32 {
   %r = cute.right_inverse(%src)
-         : (!cute.layout<"(?,4):(0,1)">) -> !cute.layout<"4:?">
-  %n = cute.get_scalars<{only_dynamic}> (%r) : !cute.layout<"4:?">
-  return %n : i32
+         : (!cute.layout<"(4,?,2):(1,16,4)">) -> !cute.layout<"(4,2):(1,?)">
+  %stride = cute.get_scalars<{only_dynamic}> (%r)
+              : !cute.layout<"(4,2):(1,?)">
+  return %stride : i32
+}
+
+// -----
+
+// LayoutAlgebra — after a static zero-stride mode is skipped, the second
+// runtime extent becomes the inverse shape while the first becomes its stride.
+// CHECK-LABEL: func.func @layout_algebra_right_inverse_zero_stride_order
+// CHECK-SAME:    (%[[SRC:.+]]: !llvm.struct<(struct<(i32, i32)>, struct<()>)>)
+// CHECK-SAME:    -> (i32, i32)
+// CHECK-NOT:     cute.
+// CHECK:         %[[EXTENT0:.+]] = llvm.extractvalue %[[SRC]][0, 0]
+// CHECK:         %[[EXTENT1:.+]] = llvm.extractvalue %[[SRC]][0, 1]
+// CHECK:         %[[WITH_SHAPE:.+]] = llvm.insertvalue %[[EXTENT1]], %{{.+}}[0]
+// CHECK:         %[[WITH_STRIDE:.+]] = llvm.insertvalue %[[EXTENT0]], %[[WITH_SHAPE]][1]
+// CHECK:         %[[RESULT_SHAPE:.+]] = llvm.extractvalue %[[WITH_STRIDE]][0]
+// CHECK:         %[[RESULT_STRIDE:.+]] = llvm.extractvalue %[[WITH_STRIDE]][1]
+// CHECK:         return %[[RESULT_SHAPE]], %[[RESULT_STRIDE]] : i32, i32
+func.func @layout_algebra_right_inverse_zero_stride_order(
+    %src: !cute.layout<"(?,?):(0,1)">) -> (i32, i32) {
+  %r = cute.right_inverse(%src)
+         : (!cute.layout<"(?,?):(0,1)">) -> !cute.layout<"?:?">
+  %shape, %stride = cute.get_scalars<{only_dynamic}> (%r)
+                       : !cute.layout<"?:?">
+  return %shape, %stride : i32, i32
 }
 
 // -----

--- a/cutlass_compiler/cute_ir/test/Dialect/Cute/LayoutAlgebra/right_inverse.mlir
+++ b/cutlass_compiler/cute_ir/test/Dialect/Cute/LayoutAlgebra/right_inverse.mlir
@@ -61,6 +61,42 @@ func.func @row_major(
 
 // -----
 
+// Dynamic shape with a statically provable first continuity step.
+// CHECK-LABEL: func.func @dynamic_shape_continuous
+// CHECK-SAME:  (%[[SRC:.+]]: !cute.layout<"(16,?):(1,16)">)
+func.func @dynamic_shape_continuous(
+    %src: !cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)"> {
+  // CHECK: %[[R:.+]] = cute.right_inverse(%[[SRC]]) : (!cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)">
+  %r = cute.right_inverse(%src) : (!cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)">
+  return %r : !cute.layout<"(16,?):(1,16)">
+}
+
+// -----
+
+// Unknown equality truncates the inverse rather than being treated as equal.
+// CHECK-LABEL: func.func @dynamic_shape_truncated
+// CHECK-SAME:  (%[[SRC:.+]]: !cute.layout<"(?,4):(1,16)">)
+func.func @dynamic_shape_truncated(
+    %src: !cute.layout<"(?,4):(1,16)">) -> !cute.layout<"?:1"> {
+  // CHECK: %[[R:.+]] = cute.right_inverse(%[[SRC]]) : (!cute.layout<"(?,4):(1,16)">) -> !cute.layout<"?:1">
+  %r = cute.right_inverse(%src) : (!cute.layout<"(?,4):(1,16)">) -> !cute.layout<"?:1">
+  return %r : !cute.layout<"?:1">
+}
+
+// -----
+
+// A zero-stride mode is skipped; the remaining derived stride is dynamic.
+// CHECK-LABEL: func.func @dynamic_shape_derived_stride
+// CHECK-SAME:  (%[[SRC:.+]]: !cute.layout<"(?,4):(0,1)">)
+func.func @dynamic_shape_derived_stride(
+    %src: !cute.layout<"(?,4):(0,1)">) -> !cute.layout<"4:?"> {
+  // CHECK: %[[R:.+]] = cute.right_inverse(%[[SRC]]) : (!cute.layout<"(?,4):(0,1)">) -> !cute.layout<"4:?">
+  %r = cute.right_inverse(%src) : (!cute.layout<"(?,4):(0,1)">) -> !cute.layout<"4:?">
+  return %r : !cute.layout<"4:?">
+}
+
+// -----
+
 // Identity layout is self-inverse.
 // CHECK-LABEL: func.func @scalar_identity
 // CHECK-SAME:  (%[[SRC:.+]]: !cute.layout<"8:1">)

--- a/cutlass_compiler/cute_ir/test/Dialect/Cute/LayoutAlgebra/right_inverse_errors.mlir
+++ b/cutlass_compiler/cute_ir/test/Dialect/Cute/LayoutAlgebra/right_inverse_errors.mlir
@@ -44,12 +44,23 @@ func.func @bad_operand_composed_layout(
 
 // -----
 
-// Dynamic shape: pre-check rejects before computing the inverse.
-func.func @dynamic_shape(
-    %src: !cute.layout<"(?,3):(1,4)">) {
-  // expected-error@+2 {{expects a static-shape input layout, but got '!cute.layout<"(?,3):(1,4)">'}}
+// Dynamic shape combined with dynamic stride remains unsupported.
+func.func @dynamic_shape_dynamic_stride(
+    %src: !cute.layout<"(?,3):(?,4)">) {
+  // expected-error@+2 {{expects a dynamic-shape input layout to have fully static integer strides, but got '!cute.layout<"(?,3):(?,4)">'}}
   // expected-error@+1 {{'cute.right_inverse' op failed to infer returned types}}
-  %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(1,4)">) -> !cute.layout<"12:1">
+  %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(?,4)">) -> !cute.layout<"12:1">
+  return
+}
+
+// -----
+
+// Dynamic shape combined with scaled-basis stride remains unsupported.
+func.func @dynamic_shape_scaled_basis_stride(
+    %src: !cute.layout<"(?,3):(1@0,1@1)">) {
+  // expected-error@+2 {{expects a dynamic-shape input layout to have fully static integer strides, but got '!cute.layout<"(?,3):(1@0,1@1)">'}}
+  // expected-error@+1 {{'cute.right_inverse' op failed to infer returned types}}
+  %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(1@0,1@1)">) -> !cute.layout<"12:1">
   return
 }
 

--- a/cutlass_compiler/cutegen/include/cutegen/layout.hpp
+++ b/cutlass_compiler/cutegen/include/cutegen/layout.hpp
@@ -828,7 +828,9 @@ auto composition(const layout_t<TDynTraits>& lhs, const cute_tile_t<TDynTraits>&
  * with this function returning `1:0` for layouts with modes of shape extent greater than 1 and 0
  * stride extent. `1:0` trivially satisfies the above conditions.
  *
- * @pre `layout` is static (cf. CuTe-C++)
+ * @pre `layout` has a static shape, or has a dynamic shape with fully static
+ *      plain-integer strides. Static-shape layouts may use the supported
+ *      integer or non-ratio scaled-basis stride forms.
  */
 template <class TDynTraits>
 layout_t<TDynTraits> right_inverse(const layout_t<TDynTraits>& layout);
@@ -3769,16 +3771,17 @@ layout_t<TDynTraits> right_inverse(const layout_t<TDynTraits>& layout)
                std::holds_alternative<ratio>(std::get<sb_t>(l).value());
     };
 
-    // Shape and stride must be static valid (no cg_error_t or dynamic values).
-    // The stride must only have scaled basis and static integer values.
+    // The shape may be dynamic only for the bounded plain-integer-stride
+    // path. Dynamic shape combined with dynamic or scaled-basis strides is
+    // not safe to infer here.
     if(!is_valid(layout.shape()) ||
-       !is_static(layout.shape()) ||
+       (!is_static(layout.shape()) && !is_integral_only(layout.stride())) ||
        !is_valid(layout.stride()) ||
        !has_only_leaves_of_type<int_t, dyn_t, sb_t>(layout.stride()) ||
        any_leaf_is(layout.stride(), is_sb_with_ratio_value))
     {
 #if defined(__cpp_exceptions) && !defined(CUTEGEN_DISALLOW_EXCEPTIONS)
-        throw std::runtime_error("right inverse input layout must be valid with static shapes and only integer or non-ratio scaled basis strides");
+        throw std::runtime_error("right inverse input layout must be valid with a static shape, or a dynamic shape with fully static integer strides, and only integer or non-ratio scaled basis strides");
 #else
         return cg_error_t{};
 #endif
@@ -3872,9 +3875,10 @@ layout_t<TDynTraits> right_inverse(const layout_t<TDynTraits>& layout)
         {
             continue;
         }
-        if(holds_int(curr_d) &&
-           holds_int(d) &&
-           (curr_d.as_int() != d.as_int()))
+        // Only retain a mode when continuity is provably equal. In
+        // particular, an undecidable dynamic equality must truncate the
+        // inverse rather than being treated as equal.
+        if(!eq_op_can_fold(curr_d, d).value_or(false))
         {
             continue;
         }

--- a/cutlass_compiler/cutegen/test/cg_right_inverse_test.cpp
+++ b/cutlass_compiler/cutegen/test/cg_right_inverse_test.cpp
@@ -73,6 +73,14 @@ void test_right_inverse(const Layout& layout, const Layout& exp)
         }
     }
 }
+
+template <class Layout>
+void test_dynamic_shape_right_inverse(const Layout& layout, const Layout& exp)
+{
+    // Do not use test_right_inverse here: its finite-domain checks require a
+    // static result size and are not meaningful for a runtime extent.
+    EXPECT_EQ(cg::right_inverse(layout), exp) << " for layout " << layout;
+}
 } // namespace
 
 ////////////////////////////////////////////////////////////////////////
@@ -194,6 +202,34 @@ TEST(RightInverseTest, Basic)
         auto test     = cg::layout(cg::shape(1), cg::stride(cg::dynamic_t{}));
         auto expected = cg::layout(cg::shape(1), cg::stride(0));
         test_right_inverse(test, expected);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// RightInverseTest.DynamicShape
+TEST(RightInverseTest, DynamicShape)
+{
+    using dyn_t = cg::dynamic_t;
+
+    { // (16,N):(1,16) => (16,N):(1,16)
+        auto test     = cg::layout(cg::shape(16, dyn_t{}), cg::stride(1, 16));
+        auto expected = cg::layout(cg::shape(16, dyn_t{}), cg::stride(1, 16));
+        test_dynamic_shape_right_inverse(test, expected);
+    }
+    { // (N,4):(1,16) => N:1; unknown N != 16 must truncate.
+        auto test     = cg::layout(cg::shape(dyn_t{}, 4), cg::stride(1, 16));
+        auto expected = cg::layout(cg::shape(dyn_t{}), cg::stride(1));
+        test_dynamic_shape_right_inverse(test, expected);
+    }
+    { // (4,N):(1,16) => 4:1
+        auto test     = cg::layout(cg::shape(4, dyn_t{}), cg::stride(1, 16));
+        auto expected = cg::layout(cg::shape(4), cg::stride(1));
+        test_dynamic_shape_right_inverse(test, expected);
+    }
+    { // (N,4):(0,1) => 4:N
+        auto test     = cg::layout(cg::shape(dyn_t{}, 4), cg::stride(0, 1));
+        auto expected = cg::layout(cg::shape(4), cg::stride(dyn_t{}));
+        test_dynamic_shape_right_inverse(test, expected);
     }
 }
 

--- a/media/docs/cutlass_compiler/cute_dialect.rst
+++ b/media/docs/cutlass_compiler/cute_dialect.rst
@@ -4062,7 +4062,7 @@ all components:
 ``cute.right_inverse``
 ^^^^^^^^^^^^^^^^^^^^^^
 
-*Right inverse of a static layout*
+*Right inverse of a layout*
 
 **Assembly format**
 
@@ -4072,7 +4072,7 @@ all components:
 
 **Operands**
 
-- ``$input``: static input layout
+- ``$input``: input layout
 
 **Results**
 
@@ -4086,22 +4086,26 @@ Description
 """""""""""
 
 
-Computes the right inverse of a fully-static layout. The right
-inverse ``R`` satisfies ``layout ∘ R = identity`` on the codomain of
-``layout``, making it useful for deriving inverse index mappings.
+Computes the right inverse of a layout. The right inverse ``R`` satisfies
+``layout(R(i)) = i`` for every ``i`` in the domain of ``R``, making it
+useful for deriving inverse index mappings.
 
 **Preconditions**
 
 - ``$input`` is ``!cute.layout``.
-- ``$input`` is fully static (no ``?`` dynamic extents or strides).
-- ``$input``'s strides are either all plain integer or all
-  scaled-basis (``@``); mixing the two within a single layout is
-  rejected.
+- A dynamic shape is supported only with fully static plain-integer
+  strides. Static-shape inputs retain the supported integer,
+  non-ratio scaled-basis, and dynamic-stride behavior.
+- Mixing plain-integer and scaled-basis strides is rejected unless every
+  plain-integer leaf is the static value zero, matching the existing
+  static-shape contract.
 
 **Postconditions**
 
-- Result is ``!cute.layout`` and equals the right inverse ``R`` such
-  that ``$input ∘ R`` is the identity on ``$input``'s codomain.
+- Result is ``!cute.layout`` and equals a right inverse ``R`` such that
+  ``$input ∘ R = make_layout(shape(R))``. For a dynamic shape,
+  continuity that cannot be proven statically conservatively limits ``R``
+  to the maximal provable prefix.
 
 Worked example — column-major ``L = (2,3):(1,2)``
 
@@ -4213,24 +4217,22 @@ for the same reason.
    %r = cute.right_inverse(%src)
           : (!cute.layout<"(4,3):(1@0,1@1)">) -> !cute.layout<"(4,3):(1,4)">
 
+   // Dynamic shape → the maximal inverse prefix whose stride continuity is
+   // statically provable. Dynamic coalescing is a separate operation.
+   %r = cute.right_inverse(%src)
+          : (!cute.layout<"(16,?):(1,16)">) -> !cute.layout<"(16,?):(1,16)">
+
 
 **Errors**
 
-- dynamic shape (right inverse not computable at compile time)
+- dynamic shape combined with dynamic or scaled-basis strides
 
   .. code-block::
 
-     %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(1,4)">) -> ...
+     %r = cute.right_inverse(%src) : (!cute.layout<"(?,3):(?,4)">) -> ...
 
 
-- dynamic stride
-
-  .. code-block::
-
-     %r = cute.right_inverse(%src) : (!cute.layout<"(4,3):(?,4)">) -> ...
-
-
-- mix of plain-integer and scaled-basis strides
+- mix of nonzero plain-integer and scaled-basis strides
 
   .. code-block::
 
@@ -7777,6 +7779,5 @@ Lowers ``cute.static``, ``cute.get_scalars``, the 7 constructor ops
 (``make_*``), and ``cute.print`` — ``cute.print`` emits ``gpu.printf``
 inside a GPU module/launch and falls back to ``llvm.call @printf``
 (with a generated ``llvm.mlir.global`` format string) on the host.
-
 
 


### PR DESCRIPTION
## Summary

- allow `right_inverse` to accept dynamic shapes when every stride is a fully static integer
- retain only the maximal inverse prefix whose stride continuity is statically provable, and carry dynamic shape values through CuTe expansion and base lowering
- preserve the existing static-shape behavior, including dynamic strides and supported scaled-basis forms
- add verifier, expansion, full-pipeline, and cutegen regression coverage for continuous, truncated, and zero-stride cases

For `(16, N):(1, 16)`, this returns the functionally equivalent uncoalesced `(16, N):(1, 16)` layout demonstrated by PyCuTe in the issue discussion. Producing the canonical `16*N:1` representation depends on dynamic coalescing, which is tracked separately in #3469. Consequently, callers that require a coalesced rank-1 inverse, including the `blackwell_helpers.py` TMA-shape path, still depend on #3469.

## Testing

- `cmake --build build-cutlass-compiler --target check-cute -j 8` (236/236 passed)
- `cmake --build build-cutlass-compiler --target check-cutegen-unittests -j 8` (220/220 passed across 25 test binaries)
- focused post-review MLIR suite (5/5 passed)
- `ctest --test-dir build-cutlass-compiler -R 'cg_right_inverse_test' --output-on-failure` (1/1 passed)
- `git diff --check`

The compiler and tests were built CPU-only against the LLVM revision pinned by `cutlass_compiler/LLVM_COMMIT`.

## Contribution disclosure

AI assistance was used for repository research, implementation, independent review, and running the checks above.

Fixes #3471
