### PR TITLE
Fix handling of JAX tensor types without TVM FFI and leading dim deduction for all-1-size tensors

### DIFF
--- a/python/CuTeDSL/cutlass/cute/runtime.py
+++ b/python/CuTeDSL/cutlass/cute/runtime.py
@@ -235,6 +235,12 @@ class _Tensor(Tensor):
         :rtype: _Tensor
         """
         self.load_dltensor()
+        if leading_dim is None and self.shape and all(s <= 1 for s in self.shape):
+            leading_dim = len(self.shape) - 1
+            for dim in reversed(range(len(self.shape))):
+                if self.stride[dim] == 1:
+                    leading_dim = dim
+                    break
         self._dltensor_wrapper.mark_layout_dynamic(leading_dim)
         return self
 

--- a/python/CuTeDSL/cutlass/cute/runtime.py
+++ b/python/CuTeDSL/cutlass/cute/runtime.py
@@ -937,11 +937,23 @@ class TensorAdapter:
 
 
 # -------------------------------------------------------------------------
-# Register TensorAdapter for numpy/torch tensors lazily by type name, so
-# importing this module never pays for importing numpy or torch itself.
+# Register TensorAdapter for numpy/torch/jax tensors lazily by type name, so
+# importing this module never pays for importing numpy, torch, or jax itself.
 # -------------------------------------------------------------------------
 
 JitArgAdapterRegistry.register_jit_arg_adapter("numpy.ndarray", lazy=True)(
     TensorAdapter
 )
 JitArgAdapterRegistry.register_jit_arg_adapter("torch.Tensor", lazy=True)(TensorAdapter)
+
+# Register JAX array implementation classes
+for qualname in (
+    "jaxlib._jax.ArrayImpl",
+    "jax.jaxlib._jax.ArrayImpl",
+    "jaxlib.xla_extension.ArrayImpl",
+    "jax._src.array.ArrayImpl",
+):
+    JitArgAdapterRegistry.register_jit_arg_adapter(qualname, lazy=True)(
+        TensorAdapter
+    )
+


### PR DESCRIPTION
Fix leading dimension deduction for tensors with dimensions <= 1
When leading_dim is None in _Tensor.mark_layout_dynamic(), the
underlying C++ DLPack wrapper attempts to deduce the leading dimension
by finding the stride-1 dimension. For tensors where all dimensions in
shape are <= 1 (e.g., unit or 1D single-element tensors like shape (1,)),
the deduction fails or becomes ambiguous.

While numpy.ndarray and torch.Tensor are lazily registered with
TensorAdapter in JitArgAdapterRegistry, JAX array types were missing.
Consequently, passing JAX arrays into CuTeDSL JIT functions failed
when looking up the argument adapter.