### PR TITLE
Size SM100/SM103 array GEMM tensormap workspace from the device SM count

### DIFF
--- a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized.hpp
@@ -339,24 +339,40 @@ public:
   //
 
   // Convert to underlying arguments.
+  // The mainloop and epilogue keep one set of TMA descriptors per SM in the workspace and index it
+  // on the device by SM id (%smid for ptr-array kernels, linear CTA id for grouped kernels), so the
+  // workspace has to be sized from the SM count the kernel will actually observe. Fill in the device
+  // SM count when the user did not supply one, and never size a ptr-array kernel's workspace below
+  // the device SM count, since %smid does not honor a smaller user-supplied value.
+  static KernelHardwareInfo
+  get_workspace_hw_info(KernelHardwareInfo const& user_hw_info) {
+    KernelHardwareInfo hw_info = user_hw_info;
+    if (hw_info.sm_count <= 0) {
+      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
+          "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+      hw_info.sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+    }
+    if constexpr (!IsGroupedGemmKernel) {
+      int device_sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+      if (hw_info.sm_count != device_sm_count) {
+        CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
+            "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).\n"
+            "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+        hw_info.sm_count = device_sm_count;
+      }
+    }
+    return hw_info;
+  }
+
   static
   Params
   to_underlying_arguments(Arguments const& args, void* workspace) {
     constexpr uint32_t NumEpilogueSubTiles = 1;
     CUTLASS_TRACE_HOST("to_underlying_arguments():");
     ProblemShape problem_shapes = args.problem_shape;
-    // Get SM count if needed, otherwise use user supplied SM count
-    int sm_count = args.hw_info.sm_count;
-    if (IsGroupedGemmKernel && sm_count <= 0) {
-      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
-          "  For optimal performance, populate the arguments KernelHardwareInfo struct with the SM count.");
-      sm_count = KernelHardwareInfo::query_device_multiprocessor_count(args.hw_info.device_id);
-    }
-    else if (!IsGroupedGemmKernel && sm_count != 0) {
-      CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
-          "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).");
-    }
-    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+    // Every workspace query below must use the same SM count that the kernel sees on the device.
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << hw_info.sm_count);
 
     // Calculate workspace pointers
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
@@ -364,39 +380,39 @@ public:
 
     // Epilogue
     void* epilogue_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     void* mainloop_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     // Tile scheduler
     void* scheduler_workspace = workspace_ptr + workspace_offset;
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, problem_shapes.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, problem_shapes.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     TileSchedulerParams scheduler;
     if constexpr (IsGroupedGemmKernel) {
       scheduler = TileScheduler::to_underlying_arguments(
       problem_shapes, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-      args.hw_info, args.scheduler, scheduler_workspace);
+      hw_info, args.scheduler, scheduler_workspace);
     }
     else {
       scheduler = TileScheduler::to_underlying_arguments(
       problem_shapes.get_host_problem_shape(), TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-      args.hw_info, args.scheduler, scheduler_workspace
+      hw_info, args.scheduler, scheduler_workspace
       );
     }
 
     return {
       args.mode,
       problem_shapes,
-      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, hw_info),
       CollectiveEpilogue::to_underlying_arguments(problem_shapes, args.epilogue, epilogue_workspace),
       scheduler,
-      args.hw_info
+      hw_info
     };
   }
 
@@ -454,20 +470,21 @@ public:
 
   static size_t
   get_workspace_size(Arguments const& args) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     constexpr uint32_t NumEpilogueSubTiles = 1;
     size_t workspace_size = 0;
 
     // Epilogue
-    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     // Mainloop
-    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     // Tile scheduler
     workspace_size += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     return workspace_size;
@@ -476,6 +493,7 @@ public:
   static cutlass::Status
   initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
     CudaHostAdapter* cuda_adapter = nullptr) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     constexpr uint32_t NumEpilogueSubTiles = 1;
     Status status = Status::kSuccess;
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
@@ -483,7 +501,7 @@ public:
 
     // Epilogue
     status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -491,7 +509,7 @@ public:
 
     // Mainloop
     status = CollectiveMainloop::initialize_workspace(args.problem_shape, args.mainloop, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -499,9 +517,9 @@ public:
 
     // Tile scheduler
     status = TileScheduler::template initialize_workspace<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;

--- a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_input_transform.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_input_transform.hpp
@@ -269,49 +269,59 @@ public:
   //
 
   // Convert to underlying arguments. In this case, a simple copy for the aliased type.
+  // The mainloop and epilogue keep one set of TMA descriptors per SM in the workspace and index it
+  // on the device by %smid, so the workspace has to be sized from the device SM count regardless of
+  // the value the user supplied: a smaller user-supplied count would place descriptors of the
+  // higher-numbered SMs outside the allocation.
+  static KernelHardwareInfo
+  get_workspace_hw_info(KernelHardwareInfo const& user_hw_info) {
+    KernelHardwareInfo hw_info = user_hw_info;
+    int device_sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+    if (hw_info.sm_count != device_sm_count) {
+      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include the device SM count.\n"
+          "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+      hw_info.sm_count = device_sm_count;
+    }
+    return hw_info;
+  }
+
   static Params
   to_underlying_arguments(Arguments const& args, void* workspace) {
     static constexpr uint32_t NumEpilogueSubTiles = 1;
     CUTLASS_TRACE_HOST("to_underlying_arguments():");
     ProblemShape problem_shapes = args.problem_shape;
-    // Get SM count if needed, otherwise use user supplied SM count
-    int sm_count = args.hw_info.sm_count;
-    if (sm_count <= 0) {
-      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
-          "  For optimal performance, populate the arguments KernelHardwareInfo struct with the SM count.");
-      sm_count = KernelHardwareInfo::query_device_multiprocessor_count(args.hw_info.device_id);
-    }
-
-    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+    // Every workspace query below must use the same SM count that the kernel sees on the device.
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << hw_info.sm_count);
     // Calculate workspace pointers
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
     size_t workspace_offset = 0;
 
     // Epilogue
     void* epilogue_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     void* mainloop_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     // Tile scheduler
     void* scheduler_workspace = workspace_ptr + workspace_offset;
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, problem_shapes.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, problem_shapes.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     return {
       args.mode,
       problem_shapes,
-      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, hw_info),
       CollectiveEpilogue::to_underlying_arguments(problem_shapes, args.epilogue, epilogue_workspace),
       TileScheduler::to_underlying_arguments(
         problem_shapes.get_host_problem_shape(), TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-        args.hw_info, args.scheduler, scheduler_workspace
+        hw_info, args.scheduler, scheduler_workspace
       )
-      ,args.hw_info
+      ,hw_info
     };
   }
 
@@ -338,20 +348,21 @@ public:
 
   static size_t
   get_workspace_size(Arguments const& args) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     static constexpr uint32_t NumEpilogueSubTiles = 1;
     size_t workspace_size = 0;
 
     // Epilogue
-    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     // Mainloop
-    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     // Tile scheduler
     workspace_size += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     return workspace_size;
@@ -360,6 +371,7 @@ public:
   static cutlass::Status
   initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
     CudaHostAdapter* cuda_adapter = nullptr) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     Status status = Status::kSuccess;
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
     size_t workspace_offset = 0;
@@ -367,7 +379,7 @@ public:
 
     // Epilogue
     status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -375,7 +387,7 @@ public:
 
     // Mainloop
     status = CollectiveMainloop::initialize_workspace(args.problem_shape, args.mainloop, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -383,9 +395,9 @@ public:
 
     // Tile scheduler
     status = TileScheduler::template initialize_workspace<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;

--- a/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_mma_transform.hpp
+++ b/include/cutlass/gemm/kernel/sm100_gemm_array_tma_warpspecialized_mma_transform.hpp
@@ -280,24 +280,40 @@ public:
   //
 
   // Convert to underlying arguments.
+  // The mainloop and epilogue keep one set of TMA descriptors per SM in the workspace and index it
+  // on the device by SM id (%smid for ptr-array kernels, linear CTA id for grouped kernels), so the
+  // workspace has to be sized from the SM count the kernel will actually observe. Fill in the device
+  // SM count when the user did not supply one, and never size a ptr-array kernel's workspace below
+  // the device SM count, since %smid does not honor a smaller user-supplied value.
+  static KernelHardwareInfo
+  get_workspace_hw_info(KernelHardwareInfo const& user_hw_info) {
+    KernelHardwareInfo hw_info = user_hw_info;
+    if (hw_info.sm_count <= 0) {
+      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
+          "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+      hw_info.sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+    }
+    if constexpr (!IsGroupedGemmKernel) {
+      int device_sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+      if (hw_info.sm_count != device_sm_count) {
+        CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
+            "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).\n"
+            "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+        hw_info.sm_count = device_sm_count;
+      }
+    }
+    return hw_info;
+  }
+
   static
   Params
   to_underlying_arguments(Arguments const& args, void* workspace) {
     constexpr uint32_t NumEpilogueSubTiles = 1;
     CUTLASS_TRACE_HOST("to_underlying_arguments():");
     ProblemShape problem_shapes = args.problem_shape;
-    // Get SM count if needed, otherwise use user supplied SM count
-    int sm_count = args.hw_info.sm_count;
-    if (IsGroupedGemmKernel && sm_count <= 0) {
-      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
-          "  For optimal performance, populate the arguments KernelHardwareInfo struct with the SM count.");
-      sm_count = KernelHardwareInfo::query_device_multiprocessor_count(args.hw_info.device_id);
-    }
-    else if (!IsGroupedGemmKernel && sm_count != 0) {
-      CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
-          "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).");
-    }
-    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+    // Every workspace query below must use the same SM count that the kernel sees on the device.
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << hw_info.sm_count);
 
     // Calculate workspace pointers
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
@@ -305,39 +321,39 @@ public:
 
     // Epilogue
     void* epilogue_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
 
     void* mainloop_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
 
     // Tile scheduler
     void* scheduler_workspace = workspace_ptr + workspace_offset;
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, problem_shapes.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, problem_shapes.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
 
     TileSchedulerParams scheduler;
     if constexpr (IsGroupedGemmKernel) {
       scheduler = TileScheduler::to_underlying_arguments(
       problem_shapes, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-      args.hw_info, args.scheduler, scheduler_workspace);
+      hw_info, args.scheduler, scheduler_workspace);
     }
     else {
       scheduler = TileScheduler::to_underlying_arguments(
       problem_shapes.get_host_problem_shape(), TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-      args.hw_info, args.scheduler, scheduler_workspace
+      hw_info, args.scheduler, scheduler_workspace
       );
     }
 
     return {
       args.mode,
       problem_shapes,
-      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, hw_info),
       CollectiveEpilogue::to_underlying_arguments(problem_shapes, args.epilogue, epilogue_workspace),
       scheduler,
-      args.hw_info
+      hw_info
     };
   }
 
@@ -395,20 +411,21 @@ public:
 
   static size_t
   get_workspace_size(Arguments const& args) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     constexpr uint32_t NumEpilogueSubTiles = 1;
     size_t workspace_size = 0;
 
     // Epilogue
-    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
 
     // Mainloop
-    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
 
     // Tile scheduler
     workspace_size += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
 
     return workspace_size;
@@ -417,6 +434,7 @@ public:
   static cutlass::Status
   initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
     CudaHostAdapter* cuda_adapter = nullptr) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     constexpr uint32_t NumEpilogueSubTiles = 1;
     Status status = Status::kSuccess;
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
@@ -424,7 +442,7 @@ public:
 
     // Epilogue
     status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -432,7 +450,7 @@ public:
 
     // Mainloop
     status = CollectiveMainloop::initialize_workspace(args.problem_shape, args.mainloop, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -440,9 +458,9 @@ public:
 
     // Tile scheduler
     status = TileScheduler::template initialize_workspace<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;

--- a/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
+++ b/include/cutlass/gemm/kernel/sm103_blockscaled_gemm_array_tma_warpspecialized.hpp
@@ -279,24 +279,40 @@ public:
   //
 
   // Convert to underlying arguments.
+  // The mainloop and epilogue keep one set of TMA descriptors per SM in the workspace and index it
+  // on the device by SM id (%smid for ptr-array kernels, linear CTA id for grouped kernels), so the
+  // workspace has to be sized from the SM count the kernel will actually observe. Fill in the device
+  // SM count when the user did not supply one, and never size a ptr-array kernel's workspace below
+  // the device SM count, since %smid does not honor a smaller user-supplied value.
+  static KernelHardwareInfo
+  get_workspace_hw_info(KernelHardwareInfo const& user_hw_info) {
+    KernelHardwareInfo hw_info = user_hw_info;
+    if (hw_info.sm_count <= 0) {
+      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
+          "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+      hw_info.sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+    }
+    if constexpr (!IsGroupedGemmKernel) {
+      int device_sm_count = KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+      if (hw_info.sm_count != device_sm_count) {
+        CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
+            "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).\n"
+            "  Sizing the per-SM tensormap workspace from the device SM count instead.");
+        hw_info.sm_count = device_sm_count;
+      }
+    }
+    return hw_info;
+  }
+
   static
   Params
   to_underlying_arguments(Arguments const& args, void* workspace) {
     constexpr uint32_t NumEpilogueSubTiles = 1;
     CUTLASS_TRACE_HOST("to_underlying_arguments():");
     ProblemShape problem_shapes = args.problem_shape;
-    // Get SM count if needed, otherwise use user supplied SM count
-    int sm_count = args.hw_info.sm_count;
-    if (IsGroupedGemmKernel && sm_count <= 0) {
-      CUTLASS_TRACE_HOST("  WARNING: Arguments do not include a valid SM count.\n"
-          "  For optimal performance, populate the arguments KernelHardwareInfo struct with the SM count.");
-      sm_count = KernelHardwareInfo::query_device_multiprocessor_count(args.hw_info.device_id);
-    }
-    else if (!IsGroupedGemmKernel && sm_count != 0) {
-      CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
-          "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).");
-    }
-    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+    // Every workspace query below must use the same SM count that the kernel sees on the device.
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << hw_info.sm_count);
 
     // Calculate workspace pointers
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
@@ -304,39 +320,39 @@ public:
 
     // Epilogue
     void* epilogue_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(problem_shapes, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     void* mainloop_workspace = workspace_ptr + workspace_offset;
-    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(problem_shapes, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     // Tile scheduler
     void* scheduler_workspace = workspace_ptr + workspace_offset;
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, problem_shapes.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, problem_shapes.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
 
     TileSchedulerParams scheduler;
     if constexpr (IsGroupedGemmKernel) {
       scheduler = TileScheduler::to_underlying_arguments(
       problem_shapes, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-      args.hw_info, args.scheduler, scheduler_workspace);
+      hw_info, args.scheduler, scheduler_workspace);
     }
     else {
       scheduler = TileScheduler::to_underlying_arguments(
       problem_shapes.get_host_problem_shape(), TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
-      args.hw_info, args.scheduler, scheduler_workspace
+      hw_info, args.scheduler, scheduler_workspace
       );
     }
 
     return {
       args.mode,
       problem_shapes,
-      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveMainloop::to_underlying_arguments(problem_shapes, args.mainloop, mainloop_workspace, hw_info),
       CollectiveEpilogue::to_underlying_arguments(problem_shapes, args.epilogue, epilogue_workspace),
       scheduler,
-      args.hw_info
+      hw_info
     };
   }
 
@@ -402,20 +418,21 @@ public:
 
   static size_t
   get_workspace_size(Arguments const& args) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     constexpr uint32_t NumEpilogueSubTiles = 1;
     size_t workspace_size = 0;
 
     // Epilogue
-    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     // Mainloop
-    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_size += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     // Tile scheduler
     workspace_size += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_size = round_nearest(workspace_size, MinTensorMapWorkspaceAlignment);
 
     return workspace_size;
@@ -424,6 +441,7 @@ public:
   static cutlass::Status
   initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
     CudaHostAdapter* cuda_adapter = nullptr) {
+    KernelHardwareInfo hw_info = get_workspace_hw_info(args.hw_info);
     constexpr uint32_t NumEpilogueSubTiles = 1;
     Status status = Status::kSuccess;
     uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
@@ -431,7 +449,7 @@ public:
 
     // Epilogue
     status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, args.hw_info.sm_count);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -439,7 +457,7 @@ public:
 
     // Mainloop
     status = CollectiveMainloop::initialize_workspace(args.problem_shape, args.mainloop, workspace_ptr + workspace_offset, stream, cuda_adapter);
-    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, args.hw_info.sm_count);
+    workspace_offset += CollectiveMainloop::get_workspace_size(args.problem_shape, args.mainloop, hw_info.sm_count);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;
@@ -447,9 +465,9 @@ public:
 
     // Tile scheduler
     status = TileScheduler::template initialize_workspace<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
     workspace_offset += TileScheduler::template get_workspace_size<typename ProblemShape::UnderlyingProblemShape, ElementAccumulator>(
-      args.scheduler, args.problem_shape.get_host_problem_shape(0), args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+      args.scheduler, args.problem_shape.get_host_problem_shape(0), hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
     workspace_offset = round_nearest(workspace_offset, MinTensorMapWorkspaceAlignment);
     if (status != Status::kSuccess) {
       return status;


### PR DESCRIPTION
Fixes #3585.

## Summary

The Blackwell ptr-array and grouped GEMM kernels (`sm100_gemm_array_tma_warpspecialized.hpp` and its input-transform, mma-transform and SM103 block-scaled siblings) keep one set of TMA descriptors per SM in the global workspace and index it on the device by SM id (`%smid` for ptr-array kernels, linear CTA id for grouped kernels). The workspace was sized from the raw `args.hw_info.sm_count` in `get_workspace_size()`, `initialize_workspace()` and `to_underlying_arguments()`, and the raw `hw_info` was stored in `Params`. `to_underlying_arguments()` did query the device SM count when the field was left at its default of `0`, but the result was only used in a trace message.

Consequences with a default `KernelHardwareInfo`:

- ptr-array (`kArray`) kernels: the launch grid is the full tile grid and does not depend on `sm_count`, so the kernel runs with a zero-byte tensormap workspace. Each CTA writes its 128-byte descriptors to `tensormaps[%smid * N]` through a null or undersized pointer, and the A and B slots alias because the B offset is `sm_count * N = 0`. This is an illegal-address fault, or silent corruption of adjacent device memory when a fusion workspace exists. A user-supplied `sm_count` smaller than the device SM count has the same effect for every SM whose `%smid` is at or beyond that count, and nothing rejects that configuration. The existing trace text for these kernels told users not to set the field.
- grouped kernels: the raw `hw_info` stored in `Params` collapses the launch grid to zero, so `run()` fails even though `can_implement()` accepted the arguments, and the device query in `to_underlying_arguments()` is dead code.

The SM90 array kernels (`sm90_gemm_array_tma_warpspecialized_cooperative.hpp`, `_pingpong.hpp`) already query the device SM count and size the workspace from it, so a default `KernelHardwareInfo` is safe on Hopper and unsafe on Blackwell.

## Changes

- Add a `get_workspace_hw_info()` helper to the four kernels. It fills in the device SM count when `sm_count <= 0`, and for kernels that index the workspace by `%smid` (the non-grouped SM100 path and the input-transform kernel) it never sizes the workspace below the device SM count, since `%smid` does not honor a smaller user-supplied value.
- Use the resulting `hw_info` consistently in `get_workspace_size()`, `initialize_workspace()` and `to_underlying_arguments()`, pass it to the mainloop and tile scheduler, and store it in `Params` so that the device-side descriptor stride matches the host-side sizing.
- Reword the trace messages that described the field as a performance hint.

Behaviour for callers that already set `hw_info.sm_count` to the device SM count (all in-tree tests, examples and the profiler) is unchanged: the helper returns the same value and the same workspace size.

## Testing

- The four headers parse cleanly with GCC 15 in a host-only build (`-fsyntax-only`) via `cutlass/gemm/kernel/gemm_universal.hpp`.
- I do not have Blackwell hardware, so I could not run the SM100/SM103 unit tests; the change is a host-side sizing fix and the device code is untouched. The existing `sm100_*ptr_array*` and `sm100_*group*` device tests in `test/unit/gemm/device` exercise the modified functions with `sm_count` set, and running one of them with a default `KernelHardwareInfo` would exercise the fixed path.
