### PR TITLE
examples/64: relax exact CC 8.9 gate to inclusive check

### DIFF
--- a/examples/64_ada_fp8_gemm_grouped/ada_fp8_gemm_grouped.cu
+++ b/examples/64_ada_fp8_gemm_grouped/ada_fp8_gemm_grouped.cu
@@ -1104,8 +1104,8 @@ int main(int argc, char const **args) {
     return 0;
   }
 
-  if (!(properties.major == 8 && properties.minor == 9)) {
-    std::cerr << "CUTLASS's Ada FP8 Gemm Grouped example requires a device of compute capability 89.\n" << std::endl;
+  if (properties.major < 8 || (properties.major == 8 && properties.minor < 9)) {
+    std::cerr << "CUTLASS's Ada FP8 Gemm Grouped example requires a device of compute capability 89 or higher.\n" << std::endl;
     return 0;
   }
   //


### PR DESCRIPTION
Fixes #3524

Example 64 gated on compute capability exactly 8.9, rejecting newer
architectures despite the kernels compiling and running correctly. This
uses the inclusive form already present in example 58
(`major < 8 || (major == 8 && minor < 9)`), and updates the error
message to match.

Verified on sm_120a, CUDA 13.0, CUTLASS 4.8.0:

    cmake .. -DCUTLASS_NVCC_ARCHS=120a
    make 64_ada_fp8_gemm_grouped

    Grouped GEMM (CUTLASS) with mode kDeviceOnly:
        9300 total threadblock tiles.
        Grouped Runtime: 6.32188 ms
        Grouped  GFLOPs: 54070.7
    Passed