### PR TITLE
Fix B-scale reuse across SM90 blockwise FP8 M waves

### DIFF
--- a/include/cutlass/gemm/collective/sm90_mma_tma_gmma_ss_warpspecialized_fp8_blockwise_scaling.hpp
+++ b/include/cutlass/gemm/collective/sm90_mma_tma_gmma_ss_warpspecialized_fp8_blockwise_scaling.hpp
@@ -940,6 +940,10 @@ struct CollectiveMma<
           }
         }
         if constexpr (ScaleMsPerWave == 1 && ScaleNsPerTile  > 1) {
+          // M waves alias B's registers; restore B before combining the next A scale.
+          if (m_split != 0) {
+            copy(tCsSFB(_,_,_,make_coord(_0{}, read_stage)), tCrSFB);
+          }
           ElementBlockScale scale_a = tCrSFA_local(_0{});
           CUTLASS_PRAGMA_UNROLL
           for (int i = 0; i < size(filter_zeros(tCrSFB_local)); i++) {
@@ -1030,6 +1034,10 @@ struct CollectiveMma<
           }
         }
         if constexpr (ScaleMsPerWave == 1 && ScaleNsPerTile  > 1) {
+          // M waves alias B's registers; restore B before combining the next A scale.
+          if (m_split != 0) {
+            copy(tCsSFB(_,_,_,make_coord(_0{}, read_stage)), tCrSFB);
+          }
           ElementBlockScale scale_a = tCrSFA_local(_0{});
           CUTLASS_PRAGMA_UNROLL
           for (int i = 0; i < size(filter_zeros(tCrSFB_local)); i++) {

--- a/test/unit/gemm/device/sm90_gemm_f8_f8_f8_tensor_op_f32_blockwise.cu
+++ b/test/unit/gemm/device/sm90_gemm_f8_f8_f8_tensor_op_f32_blockwise.cu
@@ -292,4 +292,15 @@ TEST(SM90_Device_Gemm_e4m3t_e4m3n_e4m3t_tensorop_f32_align16_blockwise, 128x128x
 
 }
 
+TEST(SM90_Device_Gemm_e4m3t_e4m3n_e4m3t_tensorop_f32_align16_blockwise, 256x128x128_1x1x1_128x64x128_scale) {
+  bool passed = groupwise_test<cute::GMMA::Major::MN, cute::GMMA::Major::MN>(
+      Int<128>{}, Int<64>{}, Int<128>{},
+      cutlass::layout::RowMajor{}, cutlass::layout::ColumnMajor{},
+      cutlass::layout::RowMajor{},
+      Shape<_256,_128,_128>{},
+      Shape<_1,_1,_1>{});
+
+  EXPECT_TRUE(passed);
+}
+
 #endif // #if defined(CUTLASS_ARCH_MMA_SM90_SUPPORTED)

--- a/test/unit/gemm/device/sm90_gemm_f8_f8_f8_tensor_op_f32_blockwise.cu
+++ b/test/unit/gemm/device/sm90_gemm_f8_f8_f8_tensor_op_f32_blockwise.cu
@@ -292,7 +292,8 @@ TEST(SM90_Device_Gemm_e4m3t_e4m3n_e4m3t_tensorop_f32_align16_blockwise, 128x128x
 
 }
 
-TEST(SM90_Device_Gemm_e4m3t_e4m3n_e4m3t_tensorop_f32_align16_blockwise, 256x128x128_1x1x1_128x64x128_scale) {
+TEST(SM90_Device_Gemm_e4m3t_e4m3n_e4m3t_tensorop_f32_align16_blockwise,
+     256x128x128_1x1x1_128x64x128_scale) {
   bool passed = groupwise_test<cute::GMMA::Major::MN, cute::GMMA::Major::MN>(
       Int<128>{}, Int<64>{}, Int<128>{},
       cutlass::layout::RowMajor{}, cutlass::layout::ColumnMajor{},


### PR DESCRIPTION
Fixes #3596.

Reload B's original scales before combining them with a later M wave's A scale in the SM90 cooperative blockwise FP8 mainloop and drain. The preceding wave modifies the same B-scale registers, so reusing them applies its A scale again. The reload uses the existing register tensor while the shared stage is still owned.

## Tests

On H100 with CUDA 13.1.1:

- `fp8_scale_wave --all`: all ten pass; reverting restores the same six failures. Fixed matrix passes memcheck.
- Added `*256x128x128_1x1x1_128x64x128_scale` case in `cutlass_test_unit_gemm_device_tensorop_sm90_blockwise`: fails before the fix, passes after it, fails after reversion.
- [CUDA compilation and CuTe layout checks](https://github.com/1sgtpepper/cutlass/actions/runs/34094777129) pass.

Four short CUDA-graph benchmarks cover drain, multiple K tiles, one M wave and one B scale. Median differences are below 0.2%, with overlapping sample ranges; these measurements cover only those four workloads.
