### PR TITLE
Synchronize GQA reduction scratch before reuse

### DIFF
--- a/examples/93_blackwell_low_latency_gqa/CMakeLists.txt
+++ b/examples/93_blackwell_low_latency_gqa/CMakeLists.txt
@@ -36,4 +36,9 @@ cutlass_example_add_executable(
   tgv_gqa_paged.cuh
 )
 
+cutlass_example_add_executable(
+  93_blackwell_low_latency_gqa_cta_reduce
+  test_cta_reduce.cu
+)
+
 endif()

--- a/examples/93_blackwell_low_latency_gqa/test_cta_reduce.cu
+++ b/examples/93_blackwell_low_latency_gqa/test_cta_reduce.cu
@@ -1,0 +1,97 @@
+/***************************************************************************************************
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "cutlass/util/device_memory.h"
+#include "tgv_gqa.cuh"
+
+namespace {
+
+constexpr int Iterations = 64;
+constexpr int Threads = 128;
+constexpr int Values = 8;
+
+__global__ void repeated_max(float* results) {
+  using namespace cute;
+  __shared__ float scratch[4 * Values];
+  auto smem = make_tensor(make_smem_ptr(scratch),
+                         make_layout(make_shape(Int<4>{}, Int<Values>{})));
+  auto values = make_tensor<float>(make_shape(Int<Values>{}));
+  auto reduced = make_tensor<float>(make_shape(Int<Values>{}));
+  cutlass::arch::NamedBarrier barrier(
+      Threads, cutlass::arch::ReservedNamedBarriers::EpilogueBarrier);
+  for (int iteration = 0; iteration < Iterations; ++iteration) {
+    for (int i = 0; i < Values; ++i) {
+      values(i) = float(iteration * Threads + threadIdx.x + i);
+    }
+    TGV::gqa::cta_reduce<TGV::gqa::ReduceOp::Max, 4>(
+        values, reduced, threadIdx.x / 32, smem, barrier);
+    for (int i = 0; i < Values; ++i) {
+      results[(iteration * Threads + threadIdx.x) * Values + i] = reduced(i);
+    }
+  }
+}
+
+void check(cudaError_t status) {
+  if (status != cudaSuccess) {
+    std::fprintf(stderr, "CUDA error: %s\n", cudaGetErrorString(status));
+    std::exit(2);
+  }
+}
+
+} // namespace
+
+int main() {
+  std::vector<float> results(Iterations * Threads * Values);
+  cutlass::device_memory::allocation<float> device_results(results.size());
+  check(cudaMemset(device_results.get(), 0xff, results.size() * sizeof(float)));
+  repeated_max<<<1, Threads>>>(device_results.get());
+  check(cudaGetLastError());
+  check(cudaDeviceSynchronize());
+  device_results.copy_to_host(results.data());
+  for (int iteration = 0; iteration < Iterations; ++iteration) {
+    for (int thread = 0; thread < Threads; ++thread) {
+      for (int i = 0; i < Values; ++i) {
+        float expected = float(iteration * Threads + Threads - 1 + i);
+        float actual = results[(iteration * Threads + thread) * Values + i];
+        if (actual != expected) {
+          std::fprintf(stderr, "iteration=%d thread=%d value=%d actual=%g expected=%g\n",
+                       iteration, thread, i, actual, expected);
+          return 1;
+        }
+      }
+    }
+  }
+  std::puts("Repeated CTA maximum reduction passed");
+  return 0;
+}

--- a/examples/93_blackwell_low_latency_gqa/tgv_gqa.cuh
+++ b/examples/93_blackwell_low_latency_gqa/tgv_gqa.cuh
@@ -462,6 +462,8 @@ cta_reduce(
     acc = __shfl_sync(0xffffffff, acc, 0, 32);
     out(i) = acc;
   }
+  // Complete all scratch reads before another reduction reuses the storage.
+  warp_reduce_barrier.arrive_and_wait();
 }
 
 // this function acts on the transposed tensor of the above cta_reduce function


### PR DESCRIPTION
Fixes #3597.

Complete all `cta_reduce` scratch reads before the next reduction reuses the storage. The existing barrier orders publication before reads; a second arrival on that same 128-thread barrier orders reads before reuse.

## Tests

Build `93_blackwell_low_latency_gqa_cta_reduce` with `CUTLASS_NVCC_ARCHS=100a`, then run:

```sh
compute-sanitizer --tool racecheck --error-exitcode 3 ./build/examples/93_blackwell_low_latency_gqa/93_blackwell_low_latency_gqa_cta_reduce
```

On B200/CUDA 13.1.1, the repeated-reduction test passes numerically with zero racecheck hazards. Restoring the original header produces wrong values and eight hazards. [CMake build](https://github.com/1sgtpepper/cutlass/actions/runs/34266492380).

This fixes scratch reuse independently of the mailbox initialization race in #3601. With both fixes, the contiguous and paged example checks pass. Another 16 contiguous regression cases pass under racecheck and memcheck.
